### PR TITLE
division by zero

### DIFF
--- a/lifelines/estimation.py
+++ b/lifelines/estimation.py
@@ -156,6 +156,8 @@ class KaplanMeierFitter(object):
   def _variance_f(self, N, d):
      if N==d==0:
         return 0
+     if N==d:
+        return 0
      return 1.*d/(N*(N-d))
 
 


### PR DESCRIPTION
changed the code for avoiding 'division by zero' error in KMF when using the Tutorial and Examples notebook.
