### PR TITLE
Using pandas reindex to make Additive estimates really fast

### DIFF
--- a/lifelines/estimation.py
+++ b/lifelines/estimation.py
@@ -81,7 +81,6 @@ class NelsonAalenFitter(object):
     def _variance_f_smooth(self, population, deaths):
         df = pd.DataFrame( {'N':population, 'd':deaths})
         return df.apply( lambda (N,d): np.sum([1./(N-i)**2 for i in range(int(d))]), axis=1 )
-        
 
     def _variance_f_discrete(self, population, deaths):
         return 1.*(population-deaths)*deaths/population**3
@@ -161,7 +160,6 @@ class KaplanMeierFitter(object):
 
 
 def _additive_estimate(events, timeline, _additive_f, _additive_var):
-
     N = events["removed"].sum()
 
     deaths = events['observed']

--- a/lifelines/tests/test_suite.py
+++ b/lifelines/tests/test_suite.py
@@ -212,10 +212,9 @@ class StatisticalTests(unittest.TestCase):
         if censor:
            ix = LIFETIMES == t
            c = sum(1-CENSORSHIP[ix])
-           n -=  c
            if n!=0:
               v *= ( 1-(self.lifetimes.get(t)-c)/n )
-           n -= self.lifetimes.get(t) - c
+           n -= self.lifetimes.get(t)
         else:
            v *= ( 1-self.lifetimes.get(t)/n )
            n -= self.lifetimes.get(t)
@@ -233,10 +232,9 @@ class StatisticalTests(unittest.TestCase):
         if censor:
            ix = LIFETIMES == t
            c = sum(1-CENSORSHIP[ix])
-           n -=  c
            if n!=0:
               v += ( (self.lifetimes.get(t)-c)/n )
-           n -= self.lifetimes.get(t) - c
+           n -= self.lifetimes.get(t)
         else:
            v += ( self.lifetimes.get(t)/n )
            n -= self.lifetimes.get(t)


### PR DESCRIPTION
Instead of using that nasty for loop, Pandas has a built in reindex that does the job for me. It may miss some edge cases though, so this needs to be tested. 

This also significantly cleans the code up.
- [x] compare speeds
- [ ] more tests
