### PR TITLE
Fix missing bdist_wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 import os
 import sys
 
+# bdist_wheel requires setuptools
+import setuptools
+# use setup from numpy to build fortran codes
 from numpy.distutils.core import setup, Extension
 
 


### PR DESCRIPTION
Found this trick at https://github.com/numpy/numpy/blob/master/setup.py

Importing setuptools make numpy's version of setup find the
'bdist_wheel' command. It is now possible to deploy wheel files with

```
python setup.py bdist_wheel upload
```

Signed-off-by: Jonas Kalderstam jonas@kalderstam.se
