### PR TITLE
Include tests in final package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     license="MIT",
     keywords="survival analysis statistics data analysis",
     url="https://github.com/CamDavidsonPilon/lifelines",
-    packages=['lifelines'],
+    packages=['lifelines', 'lifelines.tests'],
     long_description=read('README.txt'),
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
It's nice to be able to run the tests, even as an end-user.  Tests were
not included earlier at least on Windows when installing from the wheel
packages.

This also greatly simplifies Windows testing capabilities. It will make
it possible to automate tests where the wheel packages are installed and
the tests executed.
