### PR TITLE
Idea for a a plot improvement

### DIFF
--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -278,7 +278,8 @@ def plot_estimate(self, estimate):
           ci_show: show confidence intervals. Default: True
           ci_legend: if ci_force_lines is True, this is a boolean flag to add
                      the lines' labels to the legend. Default: False
-          size_show: show group sizes at time points. Default: False
+          at_risk_counts: show group sizes at time points. See function
+                          'add_at_risk_counts' for details. Default: False
           ix: specify a time-based subsection of the curves to plot, ex:
                    .plot(ix=slice(0.,10.))
               will plot the time values between t=0. and t=10.
@@ -294,7 +295,7 @@ def plot_estimate(self, estimate):
 
     def plot(ix=None, iloc=None, flat=False, show_censors=False,
              censor_styles=None, ci_legend=False, ci_force_lines=False,
-             ci_alpha=0.25, ci_show=True, size_show=False,
+             ci_alpha=0.25, ci_show=True, at_risk_counts=False,
              bandwidth=None, **kwargs):
 
         if censor_styles is None:
@@ -362,7 +363,7 @@ def plot_estimate(self, estimate):
                                    alpha=ci_alpha, color=kwargs['color'],
                                    linewidth=1.0)
 
-        if size_show:
+        if at_risk_counts:
             add_at_risk_counts(kwargs['ax'], self)
 
         return kwargs['ax']


### PR DESCRIPTION
I often see the sizes of the groups printed in survival curves. So I thought I'd have a go at implementing it.

Example script:

``` python
import matplotlib.pyplot as plt
import numpy as np
from lifelines.estimation import KaplanMeierFitter


t = np.random.exponential(size=50)
kmf = KaplanMeierFitter()
kmf.fit(t)
kmf.plot(size_show=True)
plt.show()
```

And result:
![1riskexample](https://cloud.githubusercontent.com/assets/223655/5486965/af748ac4-86ac-11e4-8436-72d68f58bda5.png)

Stuff to improve:
- [x] It is hard-coded for KaplanMeier at the moment, and should be changed or moved into KaplanMeier specifically, if approved.
- [x] Make this feature a separate function, to allow for several groups in one plot.
- [x] Take several groups into account with figure size adjustments
- [x] Add group labels
- [x] Add unit tests (test with labels, and without labels)
- [ ] Document the functionality
