### PR TITLE
Adding smoothing penalizer to aalen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Changelogs
 
+#### 0.6.0
+
+- Added new penalization scheme to AalenAdditiveFitter. You can now add a smoothing penalizer
+that will try to keep subsequent values of a hazard curve close together. The penalizing coefficient
+is `smoothing_penalizer`. 
+- Changed `penalizer` keyword arg to `coef_penalizer` in AalenAdditiveFitter.
+- new `ridge_regression` function in `utils.py` to perform linear regression with l2 penalizer terms.
+- 
+
 #### 0.5.1
 
 - New API for `CoxPHFitter` and `AalenAdditiveFitter`: the default arguments for `event_col` and `duration_col`. `duration_col` is now mandatory, and `event_col` now accepts a column, or by default, `None`, which assumes all events are observed (non-censored).

--- a/lifelines/estimation.py
+++ b/lifelines/estimation.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 import numpy as np
-from numpy.linalg import LinAlgError, inv, solve, norm
+from numpy.linalg import solve, norm, inv, LinAlgError
 from numpy import dot, exp
 from numpy.random import beta
 from scipy.integrate import trapz
@@ -12,6 +12,7 @@ import pandas as pd
 from lifelines.plotting import plot_estimate, plot_regressions
 from lifelines.utils import survival_table_from_events, inv_normal_cdf, \
     epanechnikov_kernel, StatError, coalesce, normalize, significance_code
+from lifelines.utils import ridge_regression as lr
 from lifelines.progress_bar import progress_bar
 from lifelines.utils import concordance_index
 
@@ -416,11 +417,12 @@ class AalenAdditiveFitter(BaseFitter):
 
     """
 
-    def __init__(self, fit_intercept=True, alpha=0.95, penalizer=0.5):
+    def __init__(self, fit_intercept=True, alpha=0.95, coef_penalizer=0.5, smoothing_penalizer=0.):
         self.fit_intercept = fit_intercept
         self.alpha = alpha
-        self.penalizer = penalizer
-        assert penalizer >= 0, "penalizer must be >= 0."
+        self.coef_penalizer = coef_penalizer
+        self.smoothing_penalizer = smoothing_penalizer
+        assert coef_penalizer >= 0 or smoothing_penalizer >= 0, "penalizer must be >= 0."
 
     def fit(self, dataframe, duration_col, event_col=None,
             timeline=None, id_col=None, show_progress=True):
@@ -537,10 +539,8 @@ class AalenAdditiveFitter(BaseFitter):
         variance_ = pd.DataFrame(np.zeros((n_deaths, d)), columns=columns,
                                  index=from_tuples(non_censorsed_times)).swaplevel(1, 0)
 
-        # initializes the penalizer matrix
-        penalizer = self.penalizer * np.eye(d)
-
         # initialize loop variables.
+        previous_hazard = np.zeros((d,))
         progress = progress_bar(n_deaths)
         to_remove = []
         t = T.iloc[0]
@@ -562,17 +562,15 @@ class AalenAdditiveFitter(BaseFitter):
             relevant_individuals = (ids == id)
             assert relevant_individuals.sum() == 1.
 
-            # perform linear regression step. This is to be abstracted out. 
-            X = df.values
+            # perform linear regression step.
             try:
-                V = dot(inv(dot(X.T, X) + penalizer), X.T)
+                v, V = lr(df.values, relevant_individuals, c1=self.coef_penalizer, c2=self.smoothing_penalizer, offset=previous_hazard)
             except LinAlgError:
                 print("Linear regression error. Try increasing the penalizer term.")
 
-            v = dot(V, 1.0 * relevant_individuals)
-
             hazards_.ix[time, id] = v.T
             variance_.ix[time, id] = V[:, relevant_individuals][:, 0] ** 2
+            previous_hazard = v.T
 
             # update progress bar
             if show_progress:
@@ -643,9 +641,7 @@ class AalenAdditiveFitter(BaseFitter):
         variance_ = pd.DataFrame(np.zeros((len(non_censorsed_times), d)),
                                  columns=columns, index=from_tuples(non_censorsed_times))
 
-        # initializes the penalizer matrix
-        penalizer = self.penalizer * np.eye(d)
-
+        previous_hazard = np.zeros((d,))
         ids = wp.minor_axis.values
         progress = progress_bar(len(non_censorsed_times))
 
@@ -657,18 +653,15 @@ class AalenAdditiveFitter(BaseFitter):
             relevant_individuals = (ids == id)
             assert relevant_individuals.sum() == 1.
 
-            X = wp[time].values
-
             # perform linear regression step.
             try:
-                V = dot(inv(dot(X.T, X) + penalizer), X.T)
+                v, V = lr(wp[time].values, relevant_individuals, c1=self.coef_penalizer, c2=self.smoothing_penalizer, offset=previous_hazard)
             except LinAlgError:
                 print("Linear regression error. Try increasing the penalizer term.")
 
-            v = dot(V, 1.0 * relevant_individuals)
-
             hazards_.ix[id, time] = v.T
             variance_.ix[id, time] = V[:, relevant_individuals][:, 0] ** 2
+            previous_hazard = v.T
 
             # update progress bar
             if show_progress:
@@ -679,7 +672,7 @@ class AalenAdditiveFitter(BaseFitter):
             print()
 
         ordered_cols = df.columns  # to_panel() mixes up my columns
-        # not sure this is the correct thing to do.
+
         self.hazards_ = hazards_.groupby(level=1).sum()[ordered_cols]
         self.cumulative_hazards_ = self.hazards_.cumsum()[ordered_cols]
         self.variance_ = variance_.groupby(level=1).sum()[ordered_cols]
@@ -812,8 +805,8 @@ class CoxPHFitter(BaseFitter):
       alpha: the level in the confidence intervals.
       tie_method: specify how the fitter should deal with ties. Currently only
         'Efron' is available.
-      normalize: substract the mean and divide by standard deviation of each covariate 
-        in the input data before performing any fitting. 
+      normalize: substract the mean and divide by standard deviation of each covariate
+        in the input data before performing any fitting.
     """
 
     def __init__(self, alpha=0.95, tie_method='Efron', normalize=True):

--- a/lifelines/estimation.py
+++ b/lifelines/estimation.py
@@ -422,7 +422,7 @@ class AalenAdditiveFitter(BaseFitter):
         self.alpha = alpha
         self.coef_penalizer = coef_penalizer
         self.smoothing_penalizer = smoothing_penalizer
-        assert coef_penalizer >= 0 or smoothing_penalizer >= 0, "penalizer must be >= 0."
+        assert coef_penalizer >= 0 and smoothing_penalizer >= 0, "penalizer must be >= 0."
 
     def fit(self, dataframe, duration_col, event_col=None,
             timeline=None, id_col=None, show_progress=True):

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -263,11 +263,11 @@ class TestKaplanMeierFitter():
         kmf.fit(df.ix[ix]['time'], df.ix[ix]['event'], timeline=[9, 19, 32, 34])
 
         expected_lower_bound = np.array([0.2731, 0.1946, 0.1109, 0.0461])
-        npt.assert_array_almost_equal(kmf.confidence_interval_['KM-estimate_lower_0.95'].values,
+        npt.assert_array_almost_equal(kmf.confidence_interval_['KM_estimate_lower_0.95'].values,
                                       expected_lower_bound, decimal=3)
 
         expected_upper_bound = np.array([0.975, 0.904, 0.804, 0.676])
-        npt.assert_array_almost_equal(kmf.confidence_interval_['KM-estimate_upper_0.95'].values,
+        npt.assert_array_almost_equal(kmf.confidence_interval_['KM_estimate_upper_0.95'].values,
                                       expected_upper_bound, decimal=3)
 
 
@@ -729,6 +729,18 @@ Concordance = 0.642""".strip().split()
 
 
 class TestAalenAdditiveFitter():
+
+    def test_penalizer_reduces_norm_of_hazards(self):
+        from numpy.linalg import norm
+        rossi = load_rossi()
+
+        aaf_without_penalizer = AalenAdditiveFitter(coef_penalizer=0., smoothing_penalizer=0.)
+        assert aaf_without_penalizer.coef_penalizer == aaf_without_penalizer.smoothing_penalizer == 0.0
+        aaf_without_penalizer.fit(rossi, event_col='week', duration_col='arrest')
+
+        aaf_with_penalizer = AalenAdditiveFitter(coef_penalizer=10., smoothing_penalizer=10.)
+        aaf_with_penalizer.fit(rossi, event_col='week', duration_col='arrest')
+        assert norm(aaf_with_penalizer.cumulative_hazards_) <= norm(aaf_without_penalizer.cumulative_hazards_)
 
     def test_input_column_order_is_equal_to_output_hazards_order(self):
         rossi = load_rossi()

--- a/lifelines/tests/test_utils.py
+++ b/lifelines/tests/test_utils.py
@@ -5,6 +5,8 @@ import pytest
 
 from pandas.util.testing import assert_frame_equal
 import numpy.testing as npt
+from numpy.linalg import norm, lstsq
+from numpy.random import randn
 import pytest
 from ..utils import group_survival_table_from_events, survival_table_from_events, survival_events_from_table, \
     datetimes_to_durations, k_fold_cross_validation, normalize, unnormalize,\
@@ -13,11 +15,45 @@ from ..estimation import CoxPHFitter
 from ..datasets import (load_regression_dataset, load_larynx,
                         load_waltons, load_rossi)
 from .._utils.cindex import concordance_index as slow_cindex
+from lifelines import utils
 try:
     from .._utils._cindex import concordance_index as fast_cindex
 except ImportError:
     # If code has not been compiled.
     fast_cindex = None
+
+
+def test_ridge_regression_with_penalty_is_less_than_without_penalty():
+    X = randn(2, 2)
+    Y = randn(2)
+    assert norm(utils.ridge_regression(X, Y, c1=2.0)[0]) <= norm(utils.ridge_regression(X, Y)[0])
+    assert norm(utils.ridge_regression(X, Y, c1=1.0, c2=1.0)[0]) <= norm(utils.ridge_regression(X, Y)[0])
+
+
+def test_ridge_regression_with_extreme_c1_penalty_equals_close_to_zero_vector():
+    c1 = 10e8
+    c2 = 0.0
+    offset = np.ones(2)
+    X = randn(2, 2)
+    Y = randn(2)
+    assert norm(utils.ridge_regression(X, Y, c1, c2, offset)[0]) < 10e-4
+
+
+def test_ridge_regression_with_extreme_c2_penalty_equals_close_to_offset():
+    c1 = 0.0
+    c2 = 10e8
+    offset = np.ones(2)
+    X = randn(2, 2)
+    Y = randn(2)
+    assert norm(utils.ridge_regression(X, Y, c1`, c2, offset)[0] - offset) < 10e-4
+
+
+def test_lstsq_returns_similar_values_to_ridge_regression():
+    offset = np.ones(2)
+    X = randn(2, 2)
+    Y = randn(2)
+    expected = lstsq(X, Y)[0]
+    assert norm(utils.ridge_regression(X, Y)[0] - expected) < 10e-4
 
 
 def test_unnormalize():

--- a/lifelines/tests/test_utils.py
+++ b/lifelines/tests/test_utils.py
@@ -42,7 +42,7 @@ def test_ridge_regression_with_extreme_c2_penalty_equals_close_to_offset():
     offset = np.ones(2)
     X = randn(2, 2)
     Y = randn(2)
-    assert norm(utils.ridge_regression(X, Y, c1`, c2, offset)[0] - offset) < 10e-4
+    assert norm(utils.ridge_regression(X, Y, c1, c2, offset)[0] - offset) < 10e-4
 
 
 def test_lstsq_returns_similar_values_to_ridge_regression():

--- a/lifelines/tests/test_utils.py
+++ b/lifelines/tests/test_utils.py
@@ -81,7 +81,6 @@ def test_l2_log_loss_with_observed():
     assert utils.l2_log_loss(actual, predicted, E) == 0.0
     predicted = np.array([2,1,1])
     assert utils.l2_log_loss(actual, predicted, E) == 0.0
->>>>>>> 0bb26599ead2d00d01552ba3612f949dac433245
 
 
 def test_unnormalize():

--- a/lifelines/utils.py
+++ b/lifelines/utils.py
@@ -517,9 +517,11 @@ def median_survival_times(survival_functions):
 
 def ridge_regression(X, Y, c1=0.0, c2=0.0, offset=None):
     """
-    This solves the minimization problem:
+    Also known as Tikhonov regularization. This solves the minimization problem:
 
     min_{beta} ||(beta X - Y)||^2 + c1||beta||^2 + c2||beta - offset||^2
+
+    One can find more information here: http://en.wikipedia.org/wiki/Tikhonov_regularization
 
     Parameters:
         X: a (n,d) numpy array
@@ -540,7 +542,6 @@ def ridge_regression(X, Y, c1=0.0, c2=0.0, offset=None):
     if offset is None:
         offset = np.zeros((d,))
 
-    # based on http://en.wikipedia.org/wiki/Tikhonov_regularization
     V_1 = inv(np.dot(X.T, X) + penalizer_matrix)
     V_2 = (np.dot(X.T, Y) + c2 * offset)
     beta = np.dot(V_1, V_2)


### PR DESCRIPTION
This PR adds: 

- Added new penalization scheme to AalenAdditiveFitter. You can now add a smoothing penalizer
that will try to keep subsequent values of a hazard curve close together. The penalizing coefficient
is `smoothing_penalizer`. 
- Changed `penalizer` keyword arg to `coef_penalizer` in AalenAdditiveFitter.
- new `ridge_regression` function in `utils.py` to perform linear regression with l2 penalizer terms.