### PR TITLE
Make logrank test work with negative death times

### DIFF
--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -96,8 +96,8 @@ def pairwise_logrank_test(event_durations, groups, event_observed=None,
     if event_observed is None:
         event_observed = np.ones((event_durations.shape[0], 1))
 
-    n = max(event_durations.shape)
-    assert n == max(event_durations.shape) == max(event_observed.shape), "inputs must be of the same length."
+    n = np.max(event_durations.shape)
+    assert n == np.max(event_durations.shape) == np.max(event_observed.shape), "inputs must be of the same length."
     groups, event_durations, event_observed = map(lambda x: pd.Series(np.reshape(x, (n,))), [groups, event_durations, event_observed])
 
     unique_groups = np.unique(groups)
@@ -160,11 +160,11 @@ def multivariate_logrank_test(event_durations, groups, event_observed=None,
     if event_observed is None:
         event_observed = np.ones((event_durations.shape[0], 1))
 
-    n = max(event_durations.shape)
-    assert n == max(event_durations.shape) == max(event_observed.shape), "inputs must be of the same length."
+    n = np.max(event_durations.shape)
+    assert n == np.max(event_durations.shape) == np.max(event_observed.shape), "inputs must be of the same length."
     groups, event_durations, event_observed = map(lambda x: pd.Series(np.reshape(x, (n,))), [groups, event_durations, event_observed])
 
-    unique_groups, rm, obs, _ = group_survival_table_from_events(groups, event_durations, event_observed, np.zeros_like(event_durations), t_0)
+    unique_groups, rm, obs, _ = group_survival_table_from_events(groups, event_durations, event_observed, limit=t_0)
     n_groups = unique_groups.shape[0]
 
     # compute the factors needed
@@ -208,7 +208,7 @@ def chisq_test(U, degrees_freedom, alpha):
 
 
 def two_sided_z_test(Z, alpha):
-    p_value = 1 - max(stats.norm.cdf(Z), 1 - stats.norm.cdf(Z))
+    p_value = 1 - np.max(stats.norm.cdf(Z), 1 - stats.norm.cdf(Z))
     if p_value < 1 - alpha / 2.:
         return True, p_value
     else:

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -41,6 +41,24 @@ def test_integer_times_logrank_test():
     assert result
 
 
+def test_equal_intensity_with_negative_data():
+    data1 = np.random.normal(0, size=(2000, 1))
+    data1 -= data1.mean()
+    data1 /= data1.std()
+    data2 = np.random.normal(0, size=(2000, 1))
+    data2 -= data2.mean()
+    data2 /= data2.std()
+    summary, p_value, result = logrank_test(data1, data2)
+    assert result is None
+
+
+def test_unequal_intensity_with_negative_data():
+    data1 = np.random.normal(-5, size=(2000, 1))
+    data2 = np.random.normal(5, size=(2000, 1))
+    summary, p_value, result = logrank_test(data1, data2)
+    assert result
+
+
 def test_waltons_dataset():
     df = load_waltons()
     ix = df['group'] == 'miR-137'

--- a/lifelines/utils.py
+++ b/lifelines/utils.py
@@ -75,7 +75,7 @@ def coalesce(*args):
     return next(s for s in args if s is not None)
 
 
-def group_survival_table_from_events(groups, durations, event_observed, birth_times, limit=-1):
+def group_survival_table_from_events(groups, durations, event_observed, birth_times=None, limit=-1):
     """
     Joins multiple event series together into dataframes. A generalization of
     `survival_table_from_events` to data with groups. Previously called `group_event_series` pre 0.2.3.
@@ -127,8 +127,15 @@ def group_survival_table_from_events(groups, durations, event_observed, birth_ti
         ]
 
     """
-    n = max(groups.shape)
-    assert n == max(durations.shape) == max(event_observed.shape) == max(birth_times.shape), "inputs must be of the same length."
+    n = np.max(groups.shape)
+    assert n == np.max(durations.shape) == np.max(event_observed.shape), "inputs must be of the same length."
+    if birth_times is None:
+        # Create some birth times
+        birth_times = np.zeros(np.max(durations.shape))
+        birth_times[:] = np.min(durations)
+
+    assert n == np.max(birth_times.shape), "inputs must be of the same length."
+
     groups, durations, event_observed, birth_times = map(lambda x: pd.Series(np.reshape(x, (n,))), [groups, durations, event_observed, birth_times])
     unique_groups = groups.unique()
 
@@ -343,7 +350,7 @@ def k_fold_cross_validation(fitter, df, duration_col, event_col=None,
         refers to whether the 'death' events was observed: 1 if observed, 0 else (censored).
     duration_col: the column in dataframe that contains the subjects lifetimes.
     event_col: the column in dataframe that contains the subject's death observation. If left
-                as None, assumes all individuals are non-censored.   
+                as None, assumes all individuals are non-censored.
     k: the number of folds to perform. n/k data will be withheld for testing on.
     evaluation_measure: a function that accepts either (event_times, predicted_event_times),
                   or (event_times, predicted_event_times, event_observed) and returns a scalar value.


### PR DESCRIPTION
This change is in the spirit of earlier changes to allow normalized
times to be used without issues. Creates birth times as the minimum
death time instead of "zero".

Also changed a bunch of 'max' to 'np.max' to get moar speed.

Associated issue: #129