### PR TITLE
Math was not entirely correct in C-index

### DIFF
--- a/lifelines/_utils/_cindex.f90
+++ b/lifelines/_utils/_cindex.f90
@@ -37,8 +37,11 @@ function concordance_index (event_times, predictions, event_observed, rows) resu
       event_b = event_observed(b)
 
       ! Check if it's a valid comparison
-      if (event_a == 1 .and. event_b == 1) then
-        ! Two events can always be compared
+      if (time_a == time_b) then
+        ! Ties are not informative
+        valid_pair = .false.
+      else if (event_a == 1 .and. event_b == 1) then
+        ! Two events which are not tied are informative
         valid_pair = .true.
       else if (event_a == 1 .and. time_a < time_b) then
         ! If b is censored, then a must have event first
@@ -47,7 +50,7 @@ function concordance_index (event_times, predictions, event_observed, rows) resu
         ! If a is censored, then b must have event first
         valid_pair = .true.
       else
-        ! Not valid to compare this pair
+        ! Not an informative pair
         valid_pair = .false.
       end if
 

--- a/lifelines/_utils/cindex.py
+++ b/lifelines/_utils/cindex.py
@@ -5,7 +5,10 @@ def concordance_index(event_times, predicted_event_times, event_observed):
     """
     def valid_comparison(time_a, time_b, event_a, event_b):
         """True if times can be compared."""
-        if event_a and event_b:
+        if time_a == time_b:
+            # Ties are not informative
+            return False
+        elif event_a and event_b:
             return True
         elif event_a and time_a < time_b:
             return True

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -479,7 +479,7 @@ prio  2.639e-01  1.302e+00 8.291e-02  3.182e+00 1.460e-03   1.013e-01   4.264e-0
 ---
 Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
 
-Concordance = 0.642""".strip().split()
+Concordance = 0.644""".strip().split()
             for i in [0, 1, 2, -2, -1]:
                 assert output[i] == expected[i]
         finally:


### PR DESCRIPTION
A pair which is tied (time_a == time_b) is not an informative pair and
should be ignored.