### PR TITLE
Allow multiple models in k_fold_cross_validation

### DIFF
--- a/lifelines/tests/test_utils.py
+++ b/lifelines/tests/test_utils.py
@@ -231,6 +231,18 @@ def test_cross_validator_returns_k_results():
     assert len(results) == 5
 
 
+def test_cross_validator_returns_fitters_k_results():
+    cf = CoxPHFitter()
+    fitters = [cf, cf]
+    results = utils.k_fold_cross_validation(fitters, load_regression_dataset(), duration_col='T', event_col='E', k=3)
+    assert len(results) == 2
+    assert len(results[0]) == len(results[1]) == 3
+
+    results = utils.k_fold_cross_validation(fitters, load_regression_dataset(), duration_col='T', event_col='E', k=5)
+    assert len(results) == 2
+    assert len(results[0]) == len(results[1]) == 5
+
+
 def test_cross_validator_with_predictor():
     cf = CoxPHFitter()
     results = utils.k_fold_cross_validation(cf, load_regression_dataset(),


### PR DESCRIPTION
Often cross_validation is used to compare different models. In such
cases it often desired that all models train on the same data to
make the comparison worthwile.

Scores can now also be anything return by the evaluation function.
One might for example want to compare more than one measure, in which
case a scalar is far too restricting. It is now even possible to just
have the evaulation method dump the validation output and perform
any numerical comparisons later.

Signed-off-by: Jonas Kalderstam <jonas@kalderstam.se>