### PR TITLE
Version 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changelogs
 
+#### 0.7.0
+- allow for multiple fitters to be passed into `k_fold_cross_validation`. 
+- statistical tests in `lifelines.statstics`. now return a `StatisticalResult` object with properties like `p_value`, `test_results`, and `summary`.  
+- fixed a bug in how log-rank statistical tests are performed. The covariance matrix was not being correctly calculated. This resulted in slightly different p-values. 
+- `WeibullFitter`, `ExponentialFitter`, `KaplanMeierFitter` and `BreslowFlemingHarringtonFitter` all have a `conditional_time_to_event_` property that measures  the median duration remaining until the death event, given survival up until time t.
+
 #### 0.6.1
 
 - addition of `median_` property to `WeibullFitter` and `ExponentialFitter`. 

--- a/lifelines/estimation.py
+++ b/lifelines/estimation.py
@@ -381,7 +381,7 @@ class NelsonAalenFitter(BaseFitter):
         hazard_name = "differenced-" + cumulative_hazard_name
         hazard_ = self.cumulative_hazard_.diff().fillna(self.cumulative_hazard_.iloc[0])
         C = (hazard_[cumulative_hazard_name] != 0.0).values
-        return pd.DataFrame(1. / (2 * bandwidth) * np.dot(epanechnikov_kernel(timeline[:, None], timeline[C][None, :], bandwidth), hazard_.values[C,:]),
+        return pd.DataFrame(1. / (2 * bandwidth) * np.dot(epanechnikov_kernel(timeline[:, None], timeline[C][None, :], bandwidth), hazard_.values[C, :]),
                             columns=[hazard_name], index=timeline)
 
     def smoothed_hazard_confidence_intervals_(self, bandwidth, hazard_=None):

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -193,13 +193,13 @@ class StatisticalResult(object):
         return "<lifelines.StatisticalResult: \n%s\n>" % self.__unicode__()
 
     def __unicode__(self):
-        HEADER = "   __ p-value ___|__ test statistic __|___ test result ____|__ is significant __"
+        HEADER = "   __ p-value ___|__ test statistic __|____ test result ____|__ is significant __"
         meta_data = self._pretty_print_meta_data(self._kwargs)
         s = ""
         s += "Results\n"
         s += meta_data + "\n"
         s += HEADER + "\n"
-        s += "         %.5f |              %.3f |%s|%s|" % (self.p_value, self.test_statistic,  '{: ^20}'.format(self.test_result), '{: ^20}'.format('True' if self.is_significant else 'False'))
+        s += '{:>16.5f} | {:>18.3f} |  {: ^19}| {: ^18}'.format(self.p_value, self.test_statistic, self.test_result, 'True' if self.is_significant else 'False')
         return s
 
     def _pretty_print_meta_data(self, dictionary):

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -19,11 +19,7 @@ def logrank_test(event_times_A, event_times_B, event_observed_A=None, event_obse
     H_0: both event series are from the same generating processes
     H_A: the event series are from different generating processes.
 
-    Pre lifelines 0.2.x: this returned a test statistic.
-    Post lifelines 0.2.x: this returns the results of the entire test.
-
-    See Survival and Event Analysis, page 108. This implicitly uses the log-rank weights. The R language
-    equivilant in the `survival` package would use conf.type='log-log'.
+    See Survival and Event Analysis, page 108. This implicitly uses the log-rank weights.
 
     Parameters:
       event_times_foo: a (nx1) array of event durations (birth to death,...) for the population.
@@ -32,10 +28,9 @@ def logrank_test(event_times_A, event_times_B, event_observed_A=None, event_obse
       alpha: the level of signifiance
       kwargs: add keywords and meta-data to the experiment summary
 
-    Returns
-      summary: a print-friendly string detailing the results of the test.
-      p: the p-value
-      test result: True if reject the null, (pendantically None if inconclusive)
+    Returns:
+      results: a StatisticalResult object with properties 'p_value', 'summary', 'test_statistic', 'test_results'
+
     """
 
     event_times_A, event_times_B = np.array(event_times_A), np.array(event_times_B)
@@ -126,10 +121,8 @@ def multivariate_logrank_test(event_durations, groups, event_observed=None,
       t_0: the final time to compare the series' up to. Defaults to all.
       kwargs: add keywords and meta-data to the experiment summary.
 
-    Returns:
-      summary: a print-friendly summary of the statistical test
-      p_value: the p-value
-      test_result: True if reject the null, (pendantically) None if we can't reject the null.
+    Returns
+      results: a StatisticalResult object with properties 'p_value', 'summary', 'test_statistic', 'test_results'
 
     """
     event_durations, groups = np.asarray(event_durations), np.asarray(groups)

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -179,7 +179,15 @@ class StatisticalResult(object):
             setattr(self, kw, value)
 
         self._kwargs = kwargs
-        self.summary = self.__unicode__()
+
+    def print_summary(self):
+       print(self.__unicode__())
+       return
+
+    @property
+    def summary(self):
+       cols = ['p-value', 'test_statistics', 'test_results']
+       return pd.DataFrame([[self.p_value, self.test_statistic, self.test_results]], columns=cols)
 
     def __repr__(self):
         return "<lifelines.StatisticalResult: \n%s\n>" % self.__unicode__()

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -173,8 +173,8 @@ class StatisticalResult(object):
     def __init__(self, test_result, p_value, test_statistic, **kwargs):
         self.p_value = p_value
         self.test_statistic = test_statistic
-        self.test_result = test_result
-        self.significant = test_result is True
+        self.test_result = "Reject Null" if test_result else "Cannot Reject Null"
+        self.is_significant = test_result is True
 
         for kw, value in kwargs.items():
             setattr(self, kw, value)
@@ -186,20 +186,20 @@ class StatisticalResult(object):
 
     @property
     def summary(self):
-        cols = ['p-value', 'test_statistic', 'test_result']
-        return pd.DataFrame([[self.p_value, self.test_statistic, self.test_result]], columns=cols)
+        cols = ['p-value', 'test_statistic', 'test_result', 'is_significant']
+        return pd.DataFrame([[self.p_value, self.test_statistic, self.test_result, self.is_significant]], columns=cols)
 
     def __repr__(self):
         return "<lifelines.StatisticalResult: \n%s\n>" % self.__unicode__()
 
     def __unicode__(self):
-        HEADER = "   __ p-value ___|__ test statistic __|__ test result __"
+        HEADER = "   __ p-value ___|__ test statistic __|___ test result ____|__ is significant __"
         meta_data = self._pretty_print_meta_data(self._kwargs)
         s = ""
         s += "Results\n"
         s += meta_data + "\n"
         s += HEADER + "\n"
-        s += "         %.5f |              %.3f |     %s   " % (self.p_value, self.test_statistic, self.test_result)
+        s += "         %.5f |              %.3f |%s|%s|" % (self.p_value, self.test_statistic,  '{: ^20}'.format(self.test_result), '{: ^20}'.format('True' if self.is_significant else 'False'))
         return s
 
     def _pretty_print_meta_data(self, dictionary):

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -204,7 +204,7 @@ class StatisticalResult(object):
     def _pretty_print_meta_data(self, dictionary):
         s = ""
         for k, v in dictionary.items():
-            s += "   " + unicode(k).replace('_', ' ') + ": " + unicode(v) + "\n"
+            s += "   " + str(k).replace('_', ' ') + ": " + str(v) + "\n"
         return s
 
 

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -29,7 +29,7 @@ def logrank_test(event_times_A, event_times_B, event_observed_A=None, event_obse
       kwargs: add keywords and meta-data to the experiment summary
 
     Returns:
-      results: a StatisticalResult object with properties 'p_value', 'summary', 'test_statistic', 'test_results'
+      results: a StatisticalResult object with properties 'p_value', 'summary', 'test_statistic', 'test_result'
 
     """
 
@@ -122,7 +122,7 @@ def multivariate_logrank_test(event_durations, groups, event_observed=None,
       kwargs: add keywords and meta-data to the experiment summary.
 
     Returns
-      results: a StatisticalResult object with properties 'p_value', 'summary', 'test_statistic', 'test_results'
+      results: a StatisticalResult object with properties 'p_value', 'summary', 'test_statistic', 'test_result'
 
     """
     event_durations, groups = np.asarray(event_durations), np.asarray(groups)
@@ -170,10 +170,11 @@ def multivariate_logrank_test(event_durations, groups, event_observed=None,
 
 class StatisticalResult(object):
 
-    def __init__(self, test_results, p_value, test_statistic, **kwargs):
+    def __init__(self, test_result, p_value, test_statistic, **kwargs):
         self.p_value = p_value
         self.test_statistic = test_statistic
-        self.test_results = test_results
+        self.test_result = test_result
+        self.significant = test_result is True
 
         for kw, value in kwargs.items():
             setattr(self, kw, value)
@@ -181,25 +182,24 @@ class StatisticalResult(object):
         self._kwargs = kwargs
 
     def print_summary(self):
-       print(self.__unicode__())
-       return
+        print(self.__unicode__())
 
     @property
     def summary(self):
-       cols = ['p-value', 'test_statistics', 'test_results']
-       return pd.DataFrame([[self.p_value, self.test_statistic, self.test_results]], columns=cols)
+        cols = ['p-value', 'test_statistic', 'test_result']
+        return pd.DataFrame([[self.p_value, self.test_statistic, self.test_result]], columns=cols)
 
     def __repr__(self):
         return "<lifelines.StatisticalResult: \n%s\n>" % self.__unicode__()
 
     def __unicode__(self):
-        HEADER = "   __ p-value ___|__ test statistic __|__ test results __"
+        HEADER = "   __ p-value ___|__ test statistic __|__ test result __"
         meta_data = self._pretty_print_meta_data(self._kwargs)
         s = ""
         s += "Results\n"
         s += meta_data + "\n"
         s += HEADER + "\n"
-        s += "         %.5f |              %.3f |     %s   " % (self.p_value, self.test_statistic, self.test_results)
+        s += "         %.5f |              %.3f |     %s   " % (self.p_value, self.test_statistic, self.test_result)
         return s
 
     def _pretty_print_meta_data(self, dictionary):
@@ -222,4 +222,4 @@ def two_sided_z_test(Z, alpha):
     if p_value < 1 - alpha / 2.:
         return True, p_value
     else:
-        return False, p_value
+        return None, p_value

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -233,7 +233,7 @@ class TestWeibullFitter():
 
     def test_exponential_data_produces_correct_inference_no_censorship(self):
         wf = WeibullFitter()
-        N = 10000
+        N = 40000
         T = 5 * np.random.exponential(1, size=N) ** 2
         wf.fit(T)
         assert abs(wf.rho_ - 0.5) < 0.01

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -242,7 +242,7 @@ class TestWeibullFitter():
 
     def test_exponential_data_produces_correct_inference_with_censorship(self):
         wf = WeibullFitter()
-        N = 10000
+        N = 40000
         factor = 5
         T = factor * np.random.exponential(1, size=N)
         T_ = factor * np.random.exponential(1, size=N)

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -83,6 +83,12 @@ def data_nus():
 
 class TestUnivariateFitters():
 
+    def test_univarite_fitters_with_survival_function_have_conditional_time_to(self, positive_sample_lifetimes, univariate_fitters):
+        for fitter in univariate_fitters:
+            f = fitter().fit(positive_sample_lifetimes[0])
+            if hasattr(f, 'survival_function_'):
+                assert all(f.conditional_time_to_event_.index == f.survival_function_.index)
+
     def test_univariate_fitters_allows_one_to_change_alpha_at_fit_time(self, positive_sample_lifetimes, univariate_fitters):
         alpha = 0.9
         alpha_fit = 0.95
@@ -232,7 +238,7 @@ class TestWeibullFitter():
         wf.fit(T)
         assert abs(wf.rho_ - 0.5) < 0.01
         assert abs(wf.lambda_ - 0.2) < 0.01
-        assert abs(wf.median_ - 5 * np.log(2) ** 2) < 0.01
+        assert abs(wf.median_ - 5 * np.log(2) ** 2) < 0.1  # worse convergence
 
     def test_exponential_data_produces_correct_inference_with_censorship(self):
         wf = WeibullFitter()
@@ -243,7 +249,7 @@ class TestWeibullFitter():
         wf.fit(np.minimum(T, T_), (T < T_))
         assert abs(wf.rho_ - 1.) < 0.05
         assert abs(wf.lambda_ - 1. / factor) < 0.05
-        assert abs(wf.median_ - 5 * np.log(2)) < 0.05
+        assert abs(wf.median_ - 5 * np.log(2)) < 0.1
 
     def test_convergence_completes_for_ever_increasing_data_sizes(self):
         wf = WeibullFitter()

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -1,18 +1,18 @@
 from __future__ import print_function
-
+import numpy as np
+import pandas as pd
 import numpy.testing as npt
 from pandas.util.testing import assert_frame_equal
 
-
-from ..statistics import *
+from .. import statistics as stats
 from ..datasets import load_waltons, load_g3
 
 
 def test_unequal_intensity_with_random_data():
     data1 = np.random.exponential(5, size=(2000, 1))
     data2 = np.random.exponential(1, size=(2000, 1))
-    summary, p_value, result = logrank_test(data1, data2)
-    assert result
+    test_result = stats.logrank_test(data1, data2)
+    assert test_result.test_results
 
 
 def test_logrank_test_output_against_R_1():
@@ -22,8 +22,8 @@ def test_logrank_test_output_against_R_1():
     d2, e2 = df.ix[~ix]['time'], df.ix[~ix]['event']
 
     expected = 0.0138
-    summary, p_value, result = logrank_test(d1, d2, event_observed_A=e1, event_observed_B=e2)
-    assert abs(p_value - expected) < 0.0001
+    result = stats.logrank_test(d1, d2, event_observed_A=e1, event_observed_B=e2)
+    assert abs(result.p_value - expected) < 0.0001
 
 
 def test_logrank_test_output_against_R_2():
@@ -34,10 +34,11 @@ def test_logrank_test_output_against_R_2():
     treatment_T = [6, 6, 6, 7, 10, 13, 16, 22, 23, 6, 9, 10, 11, 17, 19, 20, 25, 32, 32, 34, 25]
     treatment_E = [1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
-    summary, p_value, result = logrank_test(control_T, treatment_T, event_observed_A=control_E, event_observed_B=treatment_E)
+    result = stats.logrank_test(control_T, treatment_T, event_observed_A=control_E, event_observed_B=treatment_E)
     expected_p_value = 4.17e-05
 
-    assert abs(p_value - expected_p_value) < 0.0001
+    assert abs(result.p_value - expected_p_value) < 0.0001
+    assert abs(result.test_statistic - 16.8) < 0.1
 
 
 def test_unequal_intensity_event_observed():
@@ -45,15 +46,15 @@ def test_unequal_intensity_event_observed():
     data2 = np.random.exponential(1, size=(2000, 1))
     eventA = np.random.binomial(1, 0.5, size=(2000, 1))
     eventB = np.random.binomial(1, 0.5, size=(2000, 1))
-    summary, p_value, result = logrank_test(data1, data2, event_observed_A=eventA, event_observed_B=eventB)
-    assert result
+    result = stats.logrank_test(data1, data2, event_observed_A=eventA, event_observed_B=eventB)
+    assert result.test_results
 
 
 def test_integer_times_logrank_test():
     data1 = np.random.exponential(5, size=(2000, 1)).astype(int)
     data2 = np.random.exponential(1, size=(2000, 1)).astype(int)
-    summary, p_value, result = logrank_test(data1, data2)
-    assert result
+    result = stats.logrank_test(data1, data2)
+    assert result.test_results
 
 
 def test_equal_intensity_with_negative_data():
@@ -63,15 +64,15 @@ def test_equal_intensity_with_negative_data():
     data2 = np.random.normal(0, size=(2000, 1))
     data2 -= data2.mean()
     data2 /= data2.std()
-    summary, p_value, result = logrank_test(data1, data2)
-    assert result is None
+    result = stats.logrank_test(data1, data2)
+    assert result.test_results is None
 
 
 def test_unequal_intensity_with_negative_data():
     data1 = np.random.normal(-5, size=(2000, 1))
     data2 = np.random.normal(5, size=(2000, 1))
-    summary, p_value, result = logrank_test(data1, data2)
-    assert result
+    result = stats.logrank_test(data1, data2)
+    assert result.test_results
 
 
 def test_waltons_dataset():
@@ -79,58 +80,40 @@ def test_waltons_dataset():
     ix = df['group'] == 'miR-137'
     waltonT1 = df.ix[ix]['T']
     waltonT2 = df.ix[~ix]['T']
-    summary, p_value, result = logrank_test(waltonT1, waltonT2)
-    assert result
+    result = stats.logrank_test(waltonT1, waltonT2)
+    assert result.test_results
 
 
 def test_logrank_test_is_symmetric():
     data1 = np.random.exponential(5, size=(2000, 1)).astype(int)
     data2 = np.random.exponential(1, size=(2000, 1)).astype(int)
-    summary1, p_value1, result1 = logrank_test(data1, data2)
-    summary2, p_value2, result2 = logrank_test(data2, data1)
-    assert abs(p_value2 - p_value1) < 10e-8
-    assert result2 == result1
+    result1 = stats.logrank_test(data1, data2)
+    result2 = stats.logrank_test(data2, data1)
+    assert abs(result1.p_value - result2.p_value) < 10e-8
+    assert result2.test_results == result1.test_results
 
 
 def test_multivariate_unequal_intensities():
     T = np.random.exponential(10, size=300)
     g = np.random.binomial(2, 0.5, size=300)
     T[g == 1] = np.random.exponential(1, size=(g == 1).sum())
-    s, _, result = multivariate_logrank_test(T, g)
-    assert result
+    result = stats.multivariate_logrank_test(T, g)
+    assert result.test_results
 
 
 def test_pairwise_waltons_dataset_is_significantly_different():
     waltons_dataset = load_waltons()
-    _, _, R = pairwise_logrank_test(waltons_dataset['T'], waltons_dataset['group'])
-    assert R.values[0, 1]
+    R = stats.pairwise_logrank_test(waltons_dataset['T'], waltons_dataset['group'])
+    assert R.values[0, 1].test_results
 
 
 def test_pairwise_logrank_test_with_identical_data_returns_inconclusive():
     t = np.random.exponential(10, size=100)
     T = np.tile(t, 3)
     g = np.array([1, 2, 3]).repeat(100)
-    S, P, R = pairwise_logrank_test(T, g, alpha=0.99)
-    V = np.array([[np.nan, None, None], [None, np.nan, None], [None, None, np.nan]])
-    npt.assert_array_equal(R, V)
-
-
-def test_multivariate_inputs_return_identical_solutions():
-    T = np.array([1, 2, 3])
-    E = np.array([1, 1, 0], dtype=bool)
-    G = np.array([1, 2, 1])
-    m_a = multivariate_logrank_test(T, G, E, suppress_print=True)
-    p_a = pairwise_logrank_test(T, G, E, suppress_print=True)
-
-    T = pd.Series(T)
-    E = pd.Series(E)
-    G = pd.Series(G)
-    m_s = multivariate_logrank_test(T, G, E, suppress_print=True)
-    p_s = pairwise_logrank_test(T, G, E, suppress_print=True)
-    assert m_a == m_s
-    assert_frame_equal(p_a[0], p_s[0])
-    assert_frame_equal(p_a[1], p_s[1])
-    assert_frame_equal(p_a[2], p_s[2])
+    R = stats.pairwise_logrank_test(T, g, alpha=0.99).applymap(lambda r: r.test_results if r is not None else None)
+    V = np.array([[None, None, None], [None, None, None], [None, None, None]])
+    npt.assert_array_equal(R.values, V)
 
 
 def test_pairwise_allows_dataframes():
@@ -139,17 +122,17 @@ def test_pairwise_allows_dataframes():
     df["T"] = np.random.exponential(1, size=N)
     df["C"] = np.random.binomial(1, 0.6, size=N)
     df["group"] = np.random.binomial(2, 0.5, size=N)
-    pairwise_logrank_test(df['T'], df["group"], event_observed=df["C"])
+    stats.pairwise_logrank_test(df['T'], df["group"], event_observed=df["C"])
 
 
 def test_log_rank_returns_None_if_equal_arrays():
     T = np.random.exponential(5, size=200)
-    summary, p_value, result = logrank_test(T, T, alpha=0.95, suppress_print=True)
-    assert result is None
+    result = stats.logrank_test(T, T, alpha=0.95)
+    assert result.test_results is None
 
     C = np.random.binomial(2, 0.8, size=200)
-    summary, p_value, result = logrank_test(T, T, C, C, alpha=0.95, suppress_print=True)
-    assert result is None
+    result = stats.logrank_test(T, T, C, C, alpha=0.95)
+    assert result.test_results is None
 
 
 def test_multivariate_log_rank_is_identital_to_log_rank_for_n_equals_2():
@@ -158,11 +141,11 @@ def test_multivariate_log_rank_is_identital_to_log_rank_for_n_equals_2():
     T2 = np.random.exponential(5, size=N)
     C1 = np.random.binomial(2, 0.9, size=N)
     C2 = np.random.binomial(2, 0.9, size=N)
-    summary, p_value, result = logrank_test(T1, T2, C1, C2, alpha=0.95, suppress_print=True)
+    result = stats.logrank_test(T1, T2, C1, C2, alpha=0.95)
 
     T = np.r_[T1, T2]
     C = np.r_[C1, C2]
     G = np.array([1] * 200 + [2] * 200)
-    summary_m, p_value_m, result_m = multivariate_logrank_test(T, G, C, alpha=0.95, suppress_print=True)
-    assert p_value == p_value_m
-    assert result == result_m
+    result_m = stats.multivariate_logrank_test(T, G, C, alpha=0.95)
+    assert result.test_results == result_m.test_results
+    assert result.p_value == result_m.p_value

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -15,7 +15,7 @@ def test_unequal_intensity_with_random_data():
     assert result
 
 
-def test_logrank_test_output_against_R():
+def test_logrank_test_output_against_R_1():
     df = load_g3()
     ix = (df['group'] == 'RIT')
     d1, e1 = df.ix[ix]['time'], df.ix[ix]['event']
@@ -24,6 +24,20 @@ def test_logrank_test_output_against_R():
     expected = 0.0138
     summary, p_value, result = logrank_test(d1, d2, event_observed_A=e1, event_observed_B=e2)
     assert abs(p_value - expected) < 0.0001
+
+
+def test_logrank_test_output_against_R_2():
+    # from https://stat.ethz.ch/education/semesters/ss2011/seminar/contents/presentation_2.pdf
+    control_T = [1, 1, 2, 2, 3, 4, 4, 5, 5, 8, 8, 8, 8, 11, 11, 12, 12, 15, 17, 22, 23]
+    control_E = np.ones_like(control_T)
+
+    treatment_T = [6, 6, 6, 7, 10, 13, 16, 22, 23, 6, 9, 10, 11, 17, 19, 20, 25, 32, 32, 34, 25]
+    treatment_E = [1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+    summary, p_value, result = logrank_test(control_T, treatment_T, event_observed_A=control_E, event_observed_B=treatment_E)
+    expected_p_value = 4.17e-05
+
+    assert abs(p_value - expected_p_value) < 0.0001
 
 
 def test_unequal_intensity_event_observed():

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -11,7 +11,7 @@ def test_unequal_intensity_with_random_data():
     data1 = np.random.exponential(5, size=(2000, 1))
     data2 = np.random.exponential(1, size=(2000, 1))
     test_result = stats.logrank_test(data1, data2)
-    assert test_result.test_result
+    assert test_result.is_significant
 
 
 def test_logrank_test_output_against_R_1():
@@ -46,14 +46,14 @@ def test_unequal_intensity_event_observed():
     eventA = np.random.binomial(1, 0.5, size=(2000, 1))
     eventB = np.random.binomial(1, 0.5, size=(2000, 1))
     result = stats.logrank_test(data1, data2, event_observed_A=eventA, event_observed_B=eventB)
-    assert result.test_result
+    assert result.is_significant
 
 
 def test_integer_times_logrank_test():
     data1 = np.random.exponential(5, size=(2000, 1)).astype(int)
     data2 = np.random.exponential(1, size=(2000, 1)).astype(int)
     result = stats.logrank_test(data1, data2)
-    assert result.test_result
+    assert result.is_significant
 
 
 def test_equal_intensity_with_negative_data():
@@ -64,14 +64,14 @@ def test_equal_intensity_with_negative_data():
     data2 -= data2.mean()
     data2 /= data2.std()
     result = stats.logrank_test(data1, data2)
-    assert result.test_result is None
+    assert not result.is_significant
 
 
 def test_unequal_intensity_with_negative_data():
     data1 = np.random.normal(-5, size=(2000, 1))
     data2 = np.random.normal(5, size=(2000, 1))
     result = stats.logrank_test(data1, data2)
-    assert result.test_result
+    assert result.is_significant
 
 
 def test_waltons_dataset():
@@ -80,7 +80,7 @@ def test_waltons_dataset():
     waltonT1 = df.ix[ix]['T']
     waltonT2 = df.ix[~ix]['T']
     result = stats.logrank_test(waltonT1, waltonT2)
-    assert result.test_result
+    assert result.is_significant
 
 
 def test_logrank_test_is_symmetric():
@@ -89,7 +89,7 @@ def test_logrank_test_is_symmetric():
     result1 = stats.logrank_test(data1, data2)
     result2 = stats.logrank_test(data2, data1)
     assert abs(result1.p_value - result2.p_value) < 10e-8
-    assert result2.test_result == result1.test_result
+    assert result2.is_significant == result1.is_significant
 
 
 def test_multivariate_unequal_intensities():
@@ -97,21 +97,21 @@ def test_multivariate_unequal_intensities():
     g = np.random.binomial(2, 0.5, size=300)
     T[g == 1] = np.random.exponential(1, size=(g == 1).sum())
     result = stats.multivariate_logrank_test(T, g)
-    assert result.test_result
+    assert result.is_significant
 
 
 def test_pairwise_waltons_dataset_is_significantly_different():
     waltons_dataset = load_waltons()
     R = stats.pairwise_logrank_test(waltons_dataset['T'], waltons_dataset['group'])
-    assert R.values[0, 1].test_result
+    assert R.values[0, 1].is_significant
 
 
 def test_pairwise_logrank_test_with_identical_data_returns_inconclusive():
     t = np.random.exponential(10, size=100)
     T = np.tile(t, 3)
     g = np.array([1, 2, 3]).repeat(100)
-    R = stats.pairwise_logrank_test(T, g, alpha=0.99).applymap(lambda r: r.test_result if r is not None else None)
-    V = np.array([[None, None, None], [None, None, None], [None, None, None]])
+    R = stats.pairwise_logrank_test(T, g, alpha=0.99).applymap(lambda r: r.is_significant if r is not None else None)
+    V = np.array([[None, False, False], [False, None, False], [False, False, None]])
     npt.assert_array_equal(R.values, V)
 
 
@@ -127,11 +127,11 @@ def test_pairwise_allows_dataframes():
 def test_log_rank_returns_None_if_equal_arrays():
     T = np.random.exponential(5, size=200)
     result = stats.logrank_test(T, T, alpha=0.95)
-    assert result.test_result is None
+    assert not result.is_significant
 
     C = np.random.binomial(2, 0.8, size=200)
     result = stats.logrank_test(T, T, C, C, alpha=0.95)
-    assert result.test_result is None
+    assert not result.is_significant
 
 
 def test_multivariate_log_rank_is_identital_to_log_rank_for_n_equals_2():
@@ -146,20 +146,20 @@ def test_multivariate_log_rank_is_identital_to_log_rank_for_n_equals_2():
     C = np.r_[C1, C2]
     G = np.array([1] * 200 + [2] * 200)
     result_m = stats.multivariate_logrank_test(T, G, C, alpha=0.95)
-    assert result.test_result == result_m.test_result
+    assert result.is_significant == result_m.is_significant
     assert result.p_value == result_m.p_value
+
 
 def test_StatisticalResult_class():
     sr = stats.StatisticalResult(True, 0.04, 5.0)
-    assert sr.significant
+    assert sr.is_significant
+    assert sr.test_result == "Reject Null"
 
     sr = stats.StatisticalResult(None, 0.04, 5.0)
-    assert not sr.significant
+    assert not sr.is_significant
+    assert sr.test_result == "Cannot Reject Null"
 
     sr = stats.StatisticalResult(True, 0.05, 5.0, kw='some_value')
     assert hasattr(sr, 'kw')
     assert getattr(sr, 'kw') == 'some_value'
     assert 'some_value' in sr.__unicode__()
-
-
-

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import numpy as np
 import pandas as pd
 import numpy.testing as npt
-from pandas.util.testing import assert_frame_equal
 
 from .. import statistics as stats
 from ..datasets import load_waltons, load_g3
@@ -12,7 +11,7 @@ def test_unequal_intensity_with_random_data():
     data1 = np.random.exponential(5, size=(2000, 1))
     data2 = np.random.exponential(1, size=(2000, 1))
     test_result = stats.logrank_test(data1, data2)
-    assert test_result.test_results
+    assert test_result.test_result
 
 
 def test_logrank_test_output_against_R_1():
@@ -47,14 +46,14 @@ def test_unequal_intensity_event_observed():
     eventA = np.random.binomial(1, 0.5, size=(2000, 1))
     eventB = np.random.binomial(1, 0.5, size=(2000, 1))
     result = stats.logrank_test(data1, data2, event_observed_A=eventA, event_observed_B=eventB)
-    assert result.test_results
+    assert result.test_result
 
 
 def test_integer_times_logrank_test():
     data1 = np.random.exponential(5, size=(2000, 1)).astype(int)
     data2 = np.random.exponential(1, size=(2000, 1)).astype(int)
     result = stats.logrank_test(data1, data2)
-    assert result.test_results
+    assert result.test_result
 
 
 def test_equal_intensity_with_negative_data():
@@ -65,14 +64,14 @@ def test_equal_intensity_with_negative_data():
     data2 -= data2.mean()
     data2 /= data2.std()
     result = stats.logrank_test(data1, data2)
-    assert result.test_results is None
+    assert result.test_result is None
 
 
 def test_unequal_intensity_with_negative_data():
     data1 = np.random.normal(-5, size=(2000, 1))
     data2 = np.random.normal(5, size=(2000, 1))
     result = stats.logrank_test(data1, data2)
-    assert result.test_results
+    assert result.test_result
 
 
 def test_waltons_dataset():
@@ -81,7 +80,7 @@ def test_waltons_dataset():
     waltonT1 = df.ix[ix]['T']
     waltonT2 = df.ix[~ix]['T']
     result = stats.logrank_test(waltonT1, waltonT2)
-    assert result.test_results
+    assert result.test_result
 
 
 def test_logrank_test_is_symmetric():
@@ -90,7 +89,7 @@ def test_logrank_test_is_symmetric():
     result1 = stats.logrank_test(data1, data2)
     result2 = stats.logrank_test(data2, data1)
     assert abs(result1.p_value - result2.p_value) < 10e-8
-    assert result2.test_results == result1.test_results
+    assert result2.test_result == result1.test_result
 
 
 def test_multivariate_unequal_intensities():
@@ -98,20 +97,20 @@ def test_multivariate_unequal_intensities():
     g = np.random.binomial(2, 0.5, size=300)
     T[g == 1] = np.random.exponential(1, size=(g == 1).sum())
     result = stats.multivariate_logrank_test(T, g)
-    assert result.test_results
+    assert result.test_result
 
 
 def test_pairwise_waltons_dataset_is_significantly_different():
     waltons_dataset = load_waltons()
     R = stats.pairwise_logrank_test(waltons_dataset['T'], waltons_dataset['group'])
-    assert R.values[0, 1].test_results
+    assert R.values[0, 1].test_result
 
 
 def test_pairwise_logrank_test_with_identical_data_returns_inconclusive():
     t = np.random.exponential(10, size=100)
     T = np.tile(t, 3)
     g = np.array([1, 2, 3]).repeat(100)
-    R = stats.pairwise_logrank_test(T, g, alpha=0.99).applymap(lambda r: r.test_results if r is not None else None)
+    R = stats.pairwise_logrank_test(T, g, alpha=0.99).applymap(lambda r: r.test_result if r is not None else None)
     V = np.array([[None, None, None], [None, None, None], [None, None, None]])
     npt.assert_array_equal(R.values, V)
 
@@ -128,11 +127,11 @@ def test_pairwise_allows_dataframes():
 def test_log_rank_returns_None_if_equal_arrays():
     T = np.random.exponential(5, size=200)
     result = stats.logrank_test(T, T, alpha=0.95)
-    assert result.test_results is None
+    assert result.test_result is None
 
     C = np.random.binomial(2, 0.8, size=200)
     result = stats.logrank_test(T, T, C, C, alpha=0.95)
-    assert result.test_results is None
+    assert result.test_result is None
 
 
 def test_multivariate_log_rank_is_identital_to_log_rank_for_n_equals_2():
@@ -147,5 +146,20 @@ def test_multivariate_log_rank_is_identital_to_log_rank_for_n_equals_2():
     C = np.r_[C1, C2]
     G = np.array([1] * 200 + [2] * 200)
     result_m = stats.multivariate_logrank_test(T, G, C, alpha=0.95)
-    assert result.test_results == result_m.test_results
+    assert result.test_result == result_m.test_result
     assert result.p_value == result_m.p_value
+
+def test_StatisticalResult_class():
+    sr = stats.StatisticalResult(True, 0.04, 5.0)
+    assert sr.significant
+
+    sr = stats.StatisticalResult(None, 0.04, 5.0)
+    assert not sr.significant
+
+    sr = stats.StatisticalResult(True, 0.05, 5.0, kw='some_value')
+    assert hasattr(sr, 'kw')
+    assert getattr(sr, 'kw') == 'some_value'
+    assert 'some_value' in sr.__unicode__()
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ for ext_modules in [exts, []]:
     try:
         setup(
             name="lifelines",
-            version="0.6.1.0",
+            version="0.7.0.0",
             author="Cameron Davidson-Pilon, Jonas Kalderstam",
             author_email="cam.davidson.pilon@gmail.com",
             description="Survival analysis in Python, including Kaplan Meier, Nelson Aalen and regression",


### PR DESCRIPTION
What started off as a minor patch has turned into a bit more. Changes:

- statistical tests in `lifelines.statstics`. now return a `StatisticalResult` object with properties like `p_value`, `test_results`, and `summary`.  
- removed `suppress_print` kwarg in statistical tests. 
- fixed a bug in how log-rank statistical tests are performed. The covariance matrix was not being correctly calculated. This resulted in slightly different p-values. 
- `WeibullFitter`, `ExponentialFitter`, `KaplanMeierFitter` and `BreslowFlemingHarringtonFitter` all have a `conditional_time_to_event_` property that measures  the median duration remaining until the death event, given survival up until time t.


@spacecowboy for review please!