### PR TITLE
fixing left censorship + improved test

### DIFF
--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -582,10 +582,12 @@ def _additive_estimate(events, timeline, _additive_f, _additive_var, reverse):
     """
     if reverse:
         events = events.sort_index(ascending=False)
-        at_risk = events['at_risk']
-        deaths = events['observed'].shift(1).fillna(0)
-        estimate_ = np.cumsum(_additive_f(at_risk, deaths)).ffill().sort_index()
-        var_ = np.cumsum(_additive_var(at_risk, deaths)).ffill().sort_index()
+        at_risk = events['entrance'].sum() - events['removed'].cumsum().shift(1).fillna(0)
+        
+        deaths = events['observed']
+        
+        estimate_ = np.cumsum(_additive_f(at_risk, deaths)).sort_index().shift(-1).fillna(0)
+        var_ = np.cumsum(_additive_var(at_risk, deaths)).sort_index().shift(-1).fillna(0)
     else:
         deaths = events['observed']
         at_risk = events['at_risk']

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -349,12 +349,14 @@ class TestKaplanMeierFitter():
         assert not hasattr(kmf, 'survival_function_')
 
     def test_kmf_left_censorship_stats(self):
+        # from http://www.public.iastate.edu/~pdixon/stat505/Chapter%2011.pdf
         T = [3, 5, 5, 5, 6, 6, 10, 12]
-        C = [1, 0, 0, 1, 1, 1, 0, 1]
+        C = [1, 0, 0, 1, 1, 1,  0,  1]
         kmf = KaplanMeierFitter()
         kmf.fit(T, C, left_censorship=True)
-        assert kmf.cumulative_density_[kmf._label].ix[0] == 0.0
-        assert kmf.cumulative_density_[kmf._label].ix[12] == 1.0
+
+        actual = kmf.cumulative_density_[kmf._label].values 
+        npt.assert_almost_equal(actual, np.array([0, 0.437500, 0.5833333, 0.875, 0.875, 1]))
 
     def test_shifting_durations_doesnt_affect_survival_function_values(self):
         T = np.random.exponential(10, size=100)


### PR DESCRIPTION
whoop! Found a bug

- Kaplain Meier estimation of the CDF for left-censored data would give incorrect results if censorshop was present. 