### PR TITLE
Making at_risk and deaths by time period available after KM is fit

### DIFF
--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -52,6 +52,9 @@ class KaplanMeierFitter(UnivariateFitter):
                                                                    self._additive_f, self._additive_var,
                                                                    left_censorship)
 
+        self.active = self.event_table['at_risk']
+        self.lost = self.event_table['observed']
+
         if entry is not None:
             # a serious problem with KM is that when the sample size is small and there are too few early
             # truncation times, it may happen that is the number of patients at risk and the number of deaths is the same.


### PR DESCRIPTION
I find it helpful to cut out time periods with low population sizes when fitting shifted-beta geometric models to KM curves. Making the number of observants still active by time period available allows me to truncate the KM curve at the appropriate cutoff.

Big fan of the package!!