### PR TITLE
Enable plotting tests on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env: MATPLOTLIB_VERSION=v1.4.3
+      env: MATPLOTLIB_VERSION=1.4.3
     - python: 3.3
-      env: MATPLOTLIB_VERSION=v1.4.3
+      env: MATPLOTLIB_VERSION=1.4.3
     - python: 3.4
-      env: MATPLOTLIB_VERSION=v1.4.3
+      env: MATPLOTLIB_VERSION=1.4.3
     - python: 3.5
-      env: MATPLOTLIB_VERSION=v1.4.3
+      env: MATPLOTLIB_VERSION=1.4.3
     - python: 2.7
-      env: MATPLOTLIB_VERSION=v1.5.0rc2
+      env: MATPLOTLIB_VERSION=1.5.0rc2
     - python: 3.5
-      env: MATPLOTLIB_VERSION=v1.5.0rc2
+      env: MATPLOTLIB_VERSION=1.5.0rc2
 #  allow_failures:
 #    - python: "nightly"
 
@@ -62,7 +62,7 @@ install:
   - if [[ "$MATPLOTLIB_VERSION" == "1.4.3" ]]; then
       conda install -n test-environment matplotlib=$MATPLOTLIB_VERSION;
     else
-      pip install git+https://github.com/matplotlib/matplotlib.git@$MATPLOTLIB_VERSION;
+      pip install git+https://github.com/matplotlib/matplotlib.git@v$MATPLOTLIB_VERSION;
     fi
 
   # Build in place so we can run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,12 @@ matrix:
       env: MATPLOTLIB_VERSION=v1.4.3
     - python: 3.5
       env: MATPLOTLIB_VERSION=v1.4.3
-    - python: "nightly"
-      env: MATPLOTLIB_VERSION=v1.4.3
     - python: 2.7
       env: MATPLOTLIB_VERSION=v1.5.0rc2
     - python: 3.5
       env: MATPLOTLIB_VERSION=v1.5.0rc2
-  allow_failures:
-    - python: "nightly"
+#  allow_failures:
+#    - python: "nightly"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,42 @@
 sudo: false
 
 language: python
-python:
-   - "2.7"
-   - "3.3"
-   - "3.4"
-   - "3.5"
+
+matrix:
+  include:
+    - python: 2.7
+      env: MATPLOTLIB_VERSION=v1.4.3
+    - python: 3.3
+      env: MATPLOTLIB_VERSION=v1.4.3
+    - python: 3.4
+      env: MATPLOTLIB_VERSION=v1.4.3
+    - python: 3.5
+      env: MATPLOTLIB_VERSION=v1.4.3
+    - python: "nightly"
+      env: MATPLOTLIB_VERSION=v1.4.3
+    - python: 2.7
+      env: MATPLOTLIB_VERSION=v1.5.0rc2
+    - python: 3.5
+      env: MATPLOTLIB_VERSION=v1.5.0rc2
+  allow_failures:
+    - python: "nightly"
+
 addons:
   apt:
     packages:
     - gcc
     - gfortran
+    # Deps for matplotlib, can remove once 1.5.0 is released and installable via conda
+    - inkscape
+    - libav-tools
+    - gdb
+    - mencoder
+    - dvipng
+    - texlive-latex-base
+    - texlive-latex-extra
+    - texlive-fonts-recommended
+    - texlive-latex-recommended
+    - graphviz
 # See http://conda.pydata.org/docs/travis.html
 install:
   # You may want to periodically update this, although the conda update
@@ -31,8 +57,16 @@ install:
   - conda info -a
 
   # Should match requirements.txt
-  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy scipy pandas matplotlib pytest
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy scipy pandas pytest
   - source activate test-environment
+
+  # When 1.5.0 is released, can use only conda.
+  - if [[ "$MATPLOTLIB_VERSION" == "1.4.3" ]]; then
+      conda install -n test-environment matplotlib=$MATPLOTLIB_VERSION;
+    else
+      pip install git+https://github.com/matplotlib/matplotlib.git@$MATPLOTLIB_VERSION;
+    fi
+
   # Build in place so we can run tests
   - pip install .
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
   - pip install coveralls pytest-cov
   - pip install .
 # command to run tests
-script: py.test --cov=lifelines -vv
+script: py.test --cov=lifelines -vv --block=False
 after_success:
   coveralls
 # Don't want notifications

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,8 @@ install:
     fi
 
   # Build in place so we can run tests
+  - pip install coveralls pytest-cov
   - pip install .
-  - pip install coveralls
-  - pip install pytest-cov
 # command to run tests
 script: py.test --cov=lifelines -vv
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
    - "2.7"
    - "3.3"
    - "3.4"
+   - "3.5"
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,20 @@ sudo: false
 
 language: python
 
-# To be able to run plotting tests
-env:
-  - DISPLAY=:99.0
-
 matrix:
   include:
     - python: 2.7
-      env: MATPLOTLIB_VERSION=1.4.3
+      env: MATPLOTLIB_VERSION=1.4.3 DISPLAY=:99.0
     - python: 3.3
-      env: MATPLOTLIB_VERSION=1.4.3
+      env: MATPLOTLIB_VERSION=1.4.3 DISPLAY=:99.0
     - python: 3.4
-      env: MATPLOTLIB_VERSION=1.4.3
+      env: MATPLOTLIB_VERSION=1.4.3 DISPLAY=:99.0
     - python: 3.5
-      env: MATPLOTLIB_VERSION=1.4.3
+      env: MATPLOTLIB_VERSION=1.4.3 DISPLAY=:99.0
     - python: 2.7
-      env: MATPLOTLIB_VERSION=1.5.0rc2
+      env: MATPLOTLIB_VERSION=1.5.0rc2 DISPLAY=:99.0
     - python: 3.5
-      env: MATPLOTLIB_VERSION=1.5.0rc2
+      env: MATPLOTLIB_VERSION=1.5.0rc2 DISPLAY=:99.0
 #  allow_failures:
 #    - python: "nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 
 language: python
 
+# To be able to run plotting tests
+env:
+  - DISPLAY=:99.0
+
 matrix:
   include:
     - python: 2.7
@@ -36,6 +40,11 @@ addons:
     - texlive-fonts-recommended
     - texlive-latex-recommended
     - graphviz
+
+# To be able to run plotting tests
+before_install:
+  - sh -e /etc/init.d/xvfb start
+
 # See http://conda.pydata.org/docs/travis.html
 install:
   # You may want to periodically update this, although the conda update

--- a/lifelines/generate_datasets.py
+++ b/lifelines/generate_datasets.py
@@ -42,7 +42,7 @@ class coeff_func(object):
 
     def __call__(self, *args, **kwargs):
         def __repr__():
-            s = self.f.__doc__.replace("alpha", "%.2f" % kwargs["alpha"]).replace("beta", "%.2f" % kwargs["beta"])
+            s = self.f.__doc__.replace("alpha", "%.4f" % kwargs["alpha"]).replace("beta", "%.4f" % kwargs["beta"])
             return s
         self.__doc__ = __repr__()
         self.__repr__ = __repr__

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -207,7 +207,7 @@ def plot_lifetimes(lifetimes, event_observed=None, birthtimes=None,
         plt.scatter((birthtimes[i]) + lifetimes[i], N - 1 - i, color=c, s=30, marker=m)
 
     plt.ylim(-0.5, N)
-    plt.show()
+    plt.show(block=block)
     return
 
 

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -169,7 +169,7 @@ def add_at_risk_counts(*fitters, **kwargs):
 
 
 def plot_lifetimes(lifetimes, event_observed=None, birthtimes=None,
-                   order=False):
+                   order=False, block=True):
     """
     Parameters:
       lifetimes: an (n,) numpy array of lifetimes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,22 @@
 from __future__ import print_function
 import numpy as np
+import pytest
 
 
 def pytest_runtest_setup(item):
     seed = np.random.randint(1000)
     print("Seed used in np.random.seed(): %d" % seed)
     np.random.seed(seed)
+
+
+def pytest_addoption(parser):
+    parser.addoption("--block", action="store", default=True,
+                     help="Should plotting block or not.")
+
+
+@pytest.fixture
+def block(request):
+    try:
+        return request.config.getoption("--block") not in "False,false,no,0".split(",")
+    except ValueError:
+        return True

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -355,7 +355,7 @@ class TestKaplanMeierFitter():
         kmf = KaplanMeierFitter()
         kmf.fit(T, C, left_censorship=True)
 
-        actual = kmf.cumulative_density_[kmf._label].values 
+        actual = kmf.cumulative_density_[kmf._label].values
         npt.assert_almost_equal(actual, np.array([0, 0.437500, 0.5833333, 0.875, 0.875, 1]))
 
     def test_shifting_durations_doesnt_affect_survival_function_values(self):
@@ -387,7 +387,7 @@ class TestKaplanMeierFitter():
 
         kmf.fit(basin_trough['T'], basin_trough['C'], left_censorship=True, label='basin_trough')
         ax = kmf.plot(ax=ax)
-        plt.show()
+        plt.show(block=False)
         return
 
     def test_kmf_survival_curve_output_against_R(self):
@@ -1059,7 +1059,7 @@ class TestAalenAdditiveFitter():
             col = cumulative_hazards.columns[i]
             ax = cumulative_hazards[col].ix[:15].plot(legend=False, ax=ax)
             ax = aaf.plot(ix=slice(0, 15), ax=ax, columns=[col], legend=False)
-        plt.show()
+        plt.show(block=False)
         return
 
     @pytest.mark.plottest
@@ -1089,7 +1089,8 @@ class TestAalenAdditiveFitter():
             col = cumulative_hazards.columns[i]
             ax = cumulative_hazards[col].ix[:15].plot(legend=False, ax=ax)
             ax = aaf.plot(ix=slice(0, 15), ax=ax, columns=[col], legend=False)
-        plt.show()
+        plt.show(block=False)
+        return
 
     def test_dataframe_input_with_nonstandard_index(self):
         aaf = AalenAdditiveFitter()

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -374,7 +374,7 @@ class TestKaplanMeierFitter():
 
     @pytest.mark.plottest
     @pytest.mark.skipif("DISPLAY" not in os.environ, reason="requires display")
-    def test_kmf_left_censorship_plots(self):
+    def test_kmf_left_censorship_plots(self, block):
         matplotlib = pytest.importorskip("matplotlib")
         from matplotlib import pyplot as plt
 
@@ -387,7 +387,7 @@ class TestKaplanMeierFitter():
 
         kmf.fit(basin_trough['T'], basin_trough['C'], left_censorship=True, label='basin_trough')
         ax = kmf.plot(ax=ax)
-        plt.show(block=False)
+        plt.show(block=block)
         return
 
     def test_kmf_survival_curve_output_against_R(self):
@@ -1035,7 +1035,7 @@ class TestAalenAdditiveFitter():
 
     @pytest.mark.plottest
     @pytest.mark.skipif("DISPLAY" not in os.environ, reason="requires display")
-    def test_aalen_additive_fit_no_censor(self):
+    def test_aalen_additive_fit_no_censor(self, block):
         # this is a visual test of the fitting the cumulative
         # hazards.
         matplotlib = pytest.importorskip("matplotlib")
@@ -1059,12 +1059,12 @@ class TestAalenAdditiveFitter():
             col = cumulative_hazards.columns[i]
             ax = cumulative_hazards[col].ix[:15].plot(legend=False, ax=ax)
             ax = aaf.plot(ix=slice(0, 15), ax=ax, columns=[col], legend=False)
-        plt.show(block=False)
+        plt.show(block=block)
         return
 
     @pytest.mark.plottest
     @pytest.mark.skipif("DISPLAY" not in os.environ, reason="requires display")
-    def test_aalen_additive_fit_with_censor(self):
+    def test_aalen_additive_fit_with_censor(self, block):
         # this is a visual test of the fitting the cumulative
         # hazards.
         matplotlib = pytest.importorskip("matplotlib")
@@ -1089,7 +1089,7 @@ class TestAalenAdditiveFitter():
             col = cumulative_hazards.columns[i]
             ax = cumulative_hazards[col].ix[:15].plot(legend=False, ax=ax)
             ax = aaf.plot(ix=slice(0, 15), ax=ax, columns=[col], legend=False)
-        plt.show(block=False)
+        plt.show(block=block)
         return
 
     def test_dataframe_input_with_nonstandard_index(self):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -17,7 +17,7 @@ class TestPlotting():
         from matplotlib import pyplot as plt
         self.plt = plt
 
-    def test_negative_times_still_plots(self):
+    def test_negative_times_still_plots(self, block):
         n = 40
         T = np.linspace(-2, 3, n)
         C = np.random.randint(2, size=n)
@@ -25,10 +25,10 @@ class TestPlotting():
         kmf.fit(T, C)
         ax = kmf.plot()
         self.plt.title('test_negative_times_still_plots')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_kmf_plotting(self):
+    def test_kmf_plotting(self, block):
         data1 = np.random.exponential(10, size=(100))
         data2 = np.random.exponential(2, size=(200, 1))
         data3 = np.random.exponential(4, size=(500, 1))
@@ -40,18 +40,18 @@ class TestPlotting():
         kmf.fit(data3, label='test label 3')
         kmf.plot(ax=ax)
         self.plt.title("test_kmf_plotting")
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_kmf_with_risk_counts(self):
+    def test_kmf_with_risk_counts(self, block):
         data1 = np.random.exponential(10, size=(100))
         kmf = KaplanMeierFitter()
         kmf.fit(data1)
         kmf.plot(at_risk_counts=True)
         self.plt.title("test_kmf_with_risk_counts")
-        self.plt.show(block=False)
+        self.plt.show(block=block)
 
-    def test_naf_plotting_with_custom_colours(self):
+    def test_naf_plotting_with_custom_colours(self, block):
         data1 = np.random.exponential(5, size=(200, 1))
         data2 = np.random.exponential(1, size=(500))
         naf = NelsonAalenFitter()
@@ -60,10 +60,10 @@ class TestPlotting():
         naf.fit(data2)
         naf.plot(ax=ax, c="k")
         self.plt.title('test_naf_plotting_with_custom_coloirs')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_aalen_additive_plot(self):
+    def test_aalen_additive_plot(self, block):
         # this is a visual test of the fitting the cumulative
         # hazards.
         n = 2500
@@ -82,10 +82,10 @@ class TestPlotting():
         ax = aaf.plot(iloc=slice(0, aaf.cumulative_hazards_.shape[0] - 100))
         ax.set_xlabel("time")
         ax.set_title('test_aalen_additive_plot')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_aalen_additive_smoothed_plot(self):
+    def test_aalen_additive_smoothed_plot(self, block):
         # this is a visual test of the fitting the cumulative
         # hazards.
         n = 2500
@@ -103,10 +103,10 @@ class TestPlotting():
         ax = aaf.smoothed_hazards_(1).iloc[0:aaf.cumulative_hazards_.shape[0] - 500].plot()
         ax.set_xlabel("time")
         ax.set_title('test_aalen_additive_smoothed_plot')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_naf_plotting_slice(self):
+    def test_naf_plotting_slice(self, block):
         data1 = np.random.exponential(5, size=(200, 1))
         data2 = np.random.exponential(1, size=(200, 1))
         naf = NelsonAalenFitter()
@@ -115,10 +115,10 @@ class TestPlotting():
         naf.fit(data2)
         naf.plot(ax=ax, ci_force_lines=True, iloc=slice(100, 180))
         self.plt.title('test_naf_plotting_slice')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_plot_lifetimes_calendar(self):
+    def test_plot_lifetimes_calendar(self, block):
         self.plt.figure()
         t = np.linspace(0, 20, 1000)
         hz, coef, covrt = generate_hazard_rates(1, 5, t)
@@ -126,63 +126,63 @@ class TestPlotting():
         current = 10
         birthtimes = current * np.random.uniform(size=(N,))
         T, C = generate_random_lifetimes(hz, t, size=N, censor=current - birthtimes)
-        plot_lifetimes(T, event_observed=C, birthtimes=birthtimes, block=False)
+        plot_lifetimes(T, event_observed=C, birthtimes=birthtimes, block=block)
 
-    def test_plot_lifetimes_relative(self):
+    def test_plot_lifetimes_relative(self, block):
         self.plt.figure()
         t = np.linspace(0, 20, 1000)
         hz, coef, covrt = generate_hazard_rates(1, 5, t)
         N = 20
         T, C = generate_random_lifetimes(hz, t, size=N, censor=True)
-        plot_lifetimes(T, event_observed=C, block=False)
+        plot_lifetimes(T, event_observed=C, block=block)
 
-    def test_naf_plot_cumulative_hazard(self):
+    def test_naf_plot_cumulative_hazard(self, block):
         data1 = np.random.exponential(5, size=(200, 1))
         naf = NelsonAalenFitter()
         naf.fit(data1)
         ax = naf.plot()
         naf.plot_cumulative_hazard(ax=ax, ci_force_lines=True)
         self.plt.title("I should have plotted the same thing, but different styles + color!")
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_naf_plot_cumulative_hazard_bandwidth_2(self):
+    def test_naf_plot_cumulative_hazard_bandwidth_2(self, block):
         data1 = np.random.exponential(5, size=(2000, 1))
         naf = NelsonAalenFitter()
         naf.fit(data1)
         naf.plot_hazard(bandwidth=1., ix=slice(0, 7.))
         self.plt.title('test_naf_plot_cumulative_hazard_bandwidth_2')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_naf_plot_cumulative_hazard_bandwith_1(self):
+    def test_naf_plot_cumulative_hazard_bandwith_1(self, block):
         data1 = np.random.exponential(5, size=(2000, 1)) ** 2
         naf = NelsonAalenFitter()
         naf.fit(data1)
         naf.plot_hazard(bandwidth=5., iloc=slice(0, 1700))
         self.plt.title('test_naf_plot_cumulative_hazard_bandwith_1')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_show_censor_with_discrete_date(self):
+    def test_show_censor_with_discrete_date(self, block):
         T = np.random.binomial(20, 0.1, size=100)
         C = np.random.binomial(1, 0.8, size=100)
         kmf = KaplanMeierFitter()
         kmf.fit(T, C).plot(show_censors=True)
         self.plt.title('test_show_censor_with_discrete_date')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_show_censor_with_index_0(self):
+    def test_show_censor_with_index_0(self, block):
         T = np.random.binomial(20, 0.9, size=100)  # lifelines should auto put a 0 in.
         C = np.random.binomial(1, 0.8, size=100)
         kmf = KaplanMeierFitter()
         kmf.fit(T, C).plot(show_censors=True)
         self.plt.title('test_show_censor_with_index_0')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_flat_style_and_marker(self):
+    def test_flat_style_and_marker(self, block):
         data1 = np.random.exponential(10, size=200)
         data2 = np.random.exponential(2, size=200)
         C1 = np.random.binomial(1, 0.9, size=200)
@@ -193,14 +193,14 @@ class TestPlotting():
         kmf.fit(data2, C2, label='test label 2')
         kmf.plot(ax=ax, censor_styles={'marker': 'o', 'ms': 7}, flat=True)
         self.plt.title("testing kmf flat styling + marker")
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return
 
-    def test_flat_style_no_censor(self):
+    def test_flat_style_no_censor(self, block):
         data1 = np.random.exponential(10, size=200)
         kmf = KaplanMeierFitter()
         kmf.fit(data1, label='test label 1')
         ax = kmf.plot(flat=True, censor_styles={'marker': '+', 'mew': 2, 'ms': 7})
         self.plt.title('test_flat_style_no_censor')
-        self.plt.show(block=False)
+        self.plt.show(block=block)
         return

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -25,7 +25,7 @@ class TestPlotting():
         kmf.fit(T, C)
         ax = kmf.plot()
         self.plt.title('test_negative_times_still_plots')
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_kmf_plotting(self):
@@ -40,7 +40,7 @@ class TestPlotting():
         kmf.fit(data3, label='test label 3')
         kmf.plot(ax=ax)
         self.plt.title("test_kmf_plotting")
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_kmf_with_risk_counts(self):
@@ -49,7 +49,7 @@ class TestPlotting():
         kmf.fit(data1)
         kmf.plot(at_risk_counts=True)
         self.plt.title("test_kmf_with_risk_counts")
-        self.plt.show()
+        self.plt.show(block=False)
 
     def test_naf_plotting_with_custom_colours(self):
         data1 = np.random.exponential(5, size=(200, 1))
@@ -60,7 +60,7 @@ class TestPlotting():
         naf.fit(data2)
         naf.plot(ax=ax, c="k")
         self.plt.title('test_naf_plotting_with_custom_coloirs')
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_aalen_additive_plot(self):
@@ -82,7 +82,7 @@ class TestPlotting():
         ax = aaf.plot(iloc=slice(0, aaf.cumulative_hazards_.shape[0] - 100))
         ax.set_xlabel("time")
         ax.set_title('test_aalen_additive_plot')
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_aalen_additive_smoothed_plot(self):
@@ -103,7 +103,7 @@ class TestPlotting():
         ax = aaf.smoothed_hazards_(1).iloc[0:aaf.cumulative_hazards_.shape[0] - 500].plot()
         ax.set_xlabel("time")
         ax.set_title('test_aalen_additive_smoothed_plot')
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_naf_plotting_slice(self):
@@ -115,7 +115,7 @@ class TestPlotting():
         naf.fit(data2)
         naf.plot(ax=ax, ci_force_lines=True, iloc=slice(100, 180))
         self.plt.title('test_naf_plotting_slice')
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_plot_lifetimes_calendar(self):
@@ -126,7 +126,7 @@ class TestPlotting():
         current = 10
         birthtimes = current * np.random.uniform(size=(N,))
         T, C = generate_random_lifetimes(hz, t, size=N, censor=current - birthtimes)
-        plot_lifetimes(T, event_observed=C, birthtimes=birthtimes)
+        plot_lifetimes(T, event_observed=C, birthtimes=birthtimes, block=False)
 
     def test_plot_lifetimes_relative(self):
         self.plt.figure()
@@ -134,7 +134,7 @@ class TestPlotting():
         hz, coef, covrt = generate_hazard_rates(1, 5, t)
         N = 20
         T, C = generate_random_lifetimes(hz, t, size=N, censor=True)
-        plot_lifetimes(T, event_observed=C)
+        plot_lifetimes(T, event_observed=C, block=False)
 
     def test_naf_plot_cumulative_hazard(self):
         data1 = np.random.exponential(5, size=(200, 1))
@@ -143,7 +143,7 @@ class TestPlotting():
         ax = naf.plot()
         naf.plot_cumulative_hazard(ax=ax, ci_force_lines=True)
         self.plt.title("I should have plotted the same thing, but different styles + color!")
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_naf_plot_cumulative_hazard_bandwidth_2(self):
@@ -152,7 +152,7 @@ class TestPlotting():
         naf.fit(data1)
         naf.plot_hazard(bandwidth=1., ix=slice(0, 7.))
         self.plt.title('test_naf_plot_cumulative_hazard_bandwidth_2')
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_naf_plot_cumulative_hazard_bandwith_1(self):
@@ -161,7 +161,7 @@ class TestPlotting():
         naf.fit(data1)
         naf.plot_hazard(bandwidth=5., iloc=slice(0, 1700))
         self.plt.title('test_naf_plot_cumulative_hazard_bandwith_1')
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_show_censor_with_discrete_date(self):
@@ -170,7 +170,7 @@ class TestPlotting():
         kmf = KaplanMeierFitter()
         kmf.fit(T, C).plot(show_censors=True)
         self.plt.title('test_show_censor_with_discrete_date')
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_show_censor_with_index_0(self):
@@ -179,7 +179,7 @@ class TestPlotting():
         kmf = KaplanMeierFitter()
         kmf.fit(T, C).plot(show_censors=True)
         self.plt.title('test_show_censor_with_index_0')
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_flat_style_and_marker(self):
@@ -193,7 +193,7 @@ class TestPlotting():
         kmf.fit(data2, C2, label='test label 2')
         kmf.plot(ax=ax, censor_styles={'marker': 'o', 'ms': 7}, flat=True)
         self.plt.title("testing kmf flat styling + marker")
-        self.plt.show()
+        self.plt.show(block=False)
         return
 
     def test_flat_style_no_censor(self):
@@ -202,5 +202,5 @@ class TestPlotting():
         kmf.fit(data1, label='test label 1')
         ax = kmf.plot(flat=True, censor_styles={'marker': '+', 'mew': 2, 'ms': 7})
         self.plt.title('test_flat_style_no_censor')
-        self.plt.show()
+        self.plt.show(block=False)
         return


### PR DESCRIPTION
In response to #191, this PR allows the plotting tests to run on Travis. It tests all python versions (added 3.5) with both 1.4.3 and 1.5.0 of matplotlib.

Once 1.5.0 is released for real, the .travis file can be simplified. Atm it installs 1.5.0 with pip (requires extra apt-packages) and 1.4.3 via conda (quick and easy).