### PR TITLE
Use setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.pyc
 *.so
+build
+dist
+*.egg-info
+*.iml

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -465,7 +465,7 @@ of AUC, another common loss function, and is interpretted similarly:
 * 1.0 is perfect concordance and,
 * 0.0 is perfect anti-concordance (multiply predictions with -1 to get 1.0)
 
-The measure is implemented in lifelines under `lifelines.statistics.concordance_index` and accepts the actual times (along with any censorships), and the predicted times.
+The measure is implemented in lifelines under `lifelines.util.concordance_index` and accepts the actual times (along with any censorships), and the predicted times.
 
 Cross Validation
 ######################################

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -465,7 +465,7 @@ of AUC, another common loss function, and is interpretted similarly:
 * 1.0 is perfect concordance and,
 * 0.0 is perfect anti-concordance (multiply predictions with -1 to get 1.0)
 
-The measure is implemented in lifelines under `lifelines.util.concordance_index` and accepts the actual times (along with any censorships), and the predicted times.
+The measure is implemented in lifelines under `lifelines.utils.concordance_index` and accepts the actual times (along with any censorships), and the predicted times.
 
 Cross Validation
 ######################################

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
-import sys
 
-from distutils.core import setup
+from setuptools import setup
 
 
 # Utility function to read the README file.


### PR DESCRIPTION
It seems like setuptools is favored over distutils and allows things like installing in develop mode, which is handing when developing/debugging a package (I use that ability frequently). Setuptools isn't in the standard Python distro, but this package already has a ton of other dependencies; it seems reasonable to assume that setuptools is installed in whatever environment lifelines is deployed.

Thanks for an awesome project! I'm working on calculating lifetimes and have already found it very valuable (even just the documentation). I'm looking forward to contributing more.