### PR TITLE
Summaries + datetime_to_duration bug fix

### DIFF
--- a/lifelines/fitters/weibull_fitter.py
+++ b/lifelines/fitters/weibull_fitter.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division
 import numpy as np
 import pandas as pd
-
+import scipy.stats as stats
 from numpy.linalg import solve, norm, inv
 from lifelines.fitters import UnivariateFitter
 from lifelines.utils import inv_normal_cdf
@@ -184,3 +184,48 @@ class WeibullFitter(UnivariateFitter):
         df[ci_labels[0]] = self.cumulative_hazard_at_times(self.timeline) + alpha2 * std_cumulative_hazard
         df[ci_labels[1]] = self.cumulative_hazard_at_times(self.timeline) - alpha2 * std_cumulative_hazard
         return df
+
+    def _compute_standard_errors(self):
+        var_lambda_, var_rho_ = inv(self._jacobian).diagonal()
+        return pd.DataFrame([[np.sqrt(var_lambda_), np.sqrt(var_rho_)]],
+                            index=['se'], columns=['lambda_', 'rho_'])
+
+
+    def _compute_confidence_bounds_of_parameters(self):
+        se = self._compute_standard_errors().ix['se']
+        alpha2 = inv_normal_cdf((1. + self.alpha) / 2.)
+        return pd.DataFrame([
+                np.array([self.lambda_, self.rho_]) + alpha2*se,
+                np.array([self.lambda_, self.rho_]) - alpha2*se,
+            ], columns=['lambda_', 'rho_'], index=['upper-bound', 'lower-bound'])
+        
+    @property
+    def summary(self):
+        """Summary statistics describing the fit.
+        Set alpha property in the object before calling.
+
+        Returns
+        -------
+        df : pd.DataFrame
+            Contains columns coef, exp(coef), se(coef), z, p, lower, upper"""
+        lower_upper_bounds = self._compute_confidence_bounds_of_parameters()
+        df = pd.DataFrame(index=['lambda_', 'rho_'])
+        df['coef'] = [self.lambda_, self.rho_]
+        df['se(coef)'] = self._compute_standard_errors().ix['se']
+        df['lower %.2f' % self.alpha] = lower_upper_bounds.ix['lower-bound']
+        df['upper %.2f' % self.alpha] = lower_upper_bounds.ix['upper-bound']
+        return df
+
+    def print_summary(self):
+        """
+        Print summary statistics describing the fit.
+
+        """
+        df = self.summary
+
+        # Print information about data first
+        print('n={}, number of events={}'.format(self.durations.shape[0],
+                                                 np.where(self.event_observed)[0].shape[0]),
+              end='\n\n')
+        print(df.to_string(float_format=lambda f: '{:.3e}'.format(f)))
+        return

--- a/lifelines/fitters/weibull_fitter.py
+++ b/lifelines/fitters/weibull_fitter.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division
 import numpy as np
 import pandas as pd
-import scipy.stats as stats
+
 from numpy.linalg import solve, norm, inv
 from lifelines.fitters import UnivariateFitter
 from lifelines.utils import inv_normal_cdf
@@ -190,15 +190,14 @@ class WeibullFitter(UnivariateFitter):
         return pd.DataFrame([[np.sqrt(var_lambda_), np.sqrt(var_rho_)]],
                             index=['se'], columns=['lambda_', 'rho_'])
 
-
     def _compute_confidence_bounds_of_parameters(self):
         se = self._compute_standard_errors().ix['se']
         alpha2 = inv_normal_cdf((1. + self.alpha) / 2.)
         return pd.DataFrame([
-                np.array([self.lambda_, self.rho_]) + alpha2*se,
-                np.array([self.lambda_, self.rho_]) - alpha2*se,
-            ], columns=['lambda_', 'rho_'], index=['upper-bound', 'lower-bound'])
-        
+                np.array([self.lambda_, self.rho_]) + alpha2 * se,
+                np.array([self.lambda_, self.rho_]) - alpha2 * se,
+               ], columns=['lambda_', 'rho_'], index=['upper-bound', 'lower-bound'])
+
     @property
     def summary(self):
         """Summary statistics describing the fit.

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -275,10 +275,10 @@ def datetimes_to_durations(start_times, end_times, fill_date=datetime.today(), f
     deaths_after_cutoff = end_times_ > fill_date
     C[deaths_after_cutoff] = False
 
-    T = (end_times_ - start_times_).map(lambda x: x.astype(freq_string).astype(float))
+    T = (end_times_ - start_times_).values.astype(freq_string).astype(float)
     if (T < 0).sum():
         warnings.warn("Warning: some values of start_times are after end_times")
-    return T.values, C.values
+    return T, C.values
 
 
 def l1_log_loss(event_times, predicted_event_times, event_observed=None):

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-__version__ = '0.9.0.0'
+__version__ = '0.9.1.0'


### PR DESCRIPTION
This adds two summary functions to `Weibull` and `Exponential` fitter, solves #224 

```
from lifelines import WeibullFitter
w = WeibullFitter()
s = np.random.weibull(2.5, size=10000)
w.fit(s)
w.summary
```
```
             coef  se(coef)  lower 0.95  upper 0.95
lambda_  1.004762  0.004245    0.996441    1.013083
rho_     2.490955  0.019517    2.452694    2.529215
```