### PR TITLE
Added explicit pypi trove classifiers for supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ setup(
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Topic :: Scientific/Engineering",
         ],
     install_requires=[


### PR DESCRIPTION
Adding this will allow libraries like [`caniusepython3`](https://pypi.python.org/pypi/caniusepython3) and [sites that rely on it](http://py3readiness.org/) to recognize that this library supports Python 3.