### PR TITLE
Fix deprecation warning

### DIFF
--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -270,7 +270,7 @@ def datetimes_to_durations(start_times, end_times, fill_date=datetime.today(), f
     C = ~(pd.isnull(end_times).values | end_times.isin(na_values or [""]))
     end_times[~C] = fill_date
     start_times_ = to_datetime(start_times, dayfirst=dayfirst)
-    end_times_ = to_datetime(end_times, dayfirst=dayfirst, coerce=True)
+    end_times_ = to_datetime(end_times, dayfirst=dayfirst, errors='coerce')
 
     deaths_after_cutoff = end_times_ > fill_date
     C[deaths_after_cutoff] = False


### PR DESCRIPTION
`coerce=True` is rising deprecation warning when using pandas v0.17 and above, how about to use `errors='coerce'` instead?