### PR TITLE
Update Survival Analysis intro.rst

### DIFF
--- a/docs/Survival Analysis intro.rst
+++ b/docs/Survival Analysis intro.rst
@@ -51,7 +51,7 @@ Consider a case where the population is actually made up of two
 subpopulations, :math:`A` and :math:`B`. Population :math:`A` has a very
 small lifespan, say 2 months on average, and population :math:`B`
 enjoys a much larger lifespan, say 12 months on average. We might
-not know this distinction before hand. At :math:`t=10, we
+not know this distinction before hand. At :math:`t=10`, we
 wish to investigate the average lifespan. Below is an example of such a
 situation.
 


### PR DESCRIPTION
In my previous pull request, there was a typo on line 54 that causes the math markup to be displayed as plain text. My apologies. I have fixed it in this change.