### PR TITLE
improve baseline survival performance

### DIFF
--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -516,10 +516,8 @@ class CoxPHFitter(BaseFitter):
 
         event_table = survival_table_from_events(durations, event_observed)
         event_table = event_table.join(ind_hazards_summed_over_durations)
-        baseline_hazard = pd.DataFrame(event_table['observed'] / event_table['hazards'], columns=[name])
-        return baseline_hazard.fillna(0)
-
-
+        baseline_hazard = pd.DataFrame(event_table['observed'] / event_table['hazards'], columns=[name]).fillna(0)
+        return baseline_hazard
 
     def _compute_baseline_hazards(self, df, T, E):
         if self.strata:

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -195,7 +195,6 @@ def survival_table_from_events(death_times, event_observed, birth_times=None,
     births = pd.DataFrame(birth_times, columns=['event_at'])
     births[entrance] = 1
     births_table = births.groupby('event_at').sum()
-
     event_table = death_table.join(births_table, how='outer', sort=True).fillna(0)  # http://wesmckinney.com/blog/?p=414
     event_table[at_risk] = event_table[entrance].cumsum() - event_table[removed].cumsum().shift(1).fillna(0)
     return event_table.astype(int)


### PR DESCRIPTION
```
from lifelines import CoxPHFitter
from lifelines.datasets import load_rossi

rossi = load_rossi()
cp = CoxPHFitter()


%timeit cp.fit(rossi, 'week', 'arrest', strata=['race', 'paro', 'mar', 'wexp'])
# with statra: 529 ms vs 636 ms

%timeit cp.fit(rossi, 'week', 'arrest')
# no strata: 38 ms vs 54.5 ms

```


part of #271 