### PR TITLE
solve linear system rather than explicitly computing inverse

### DIFF
--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -4,7 +4,7 @@ import warnings
 from datetime import datetime
 
 import numpy as np
-from numpy.linalg import inv
+from numpy.linalg import solve
 import pandas as pd
 from pandas import to_datetime
 
@@ -564,11 +564,11 @@ def ridge_regression(X, Y, c1=0.0, c2=0.0, offset=None):
     if offset is None:
         offset = np.zeros((d,))
 
-    V_1 = inv(np.dot(X.T, X) + penalizer_matrix)
-    V_2 = (np.dot(X.T, Y) + c2 * offset)
-    beta = np.dot(V_1, V_2)
+    A = (np.dot(X.T, X) + penalizer_matrix)
+    b = (np.dot(X.T, Y) + c2 * offset)
 
-    return beta, np.dot(V_1, X.T)
+    # rather than explicitly computing the inverse, just solve the system of equations
+    return (solve(A, b), solve(A, X.T))
 
 
 def _smart_search(minimizing_function, n, *args):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -49,6 +49,19 @@ def test_lstsq_returns_similar_values_to_ridge_regression():
     assert norm(utils.ridge_regression(X, Y)[0] - expected) < 10e-4
 
 
+def test_lstsq_returns_correct_values():
+    X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],
+                  [1.0, 1.0], [1.0, 0.0]])
+    y = [1, 1, 1, -1, -1]
+    beta,V = ridge_regression(X, y)
+    expected_beta = [-0.98684211, -0.07894737]
+    expected_v = [[-0.03289474, -0.49342105, 0.06578947, 0.03289474, 0.49342105],
+		  [-0.30263158, 0.46052632, -0.39473684, 0.30263158, -0.46052632]]
+    assert(norm(beta - expected_beta) < 10e-4)
+    for V_row, e_v_row in zip(V, expected_v):
+       assert(norm(V_row - e_v_row) < 1e-4)
+
+
 def test_l1_log_loss_with_no_observed():
     actual = np.array([1, 1, 1])
     predicted = np.array([1, 1, 1])

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -53,7 +53,7 @@ def test_lstsq_returns_correct_values():
     X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],
                   [1.0, 1.0], [1.0, 0.0]])
     y = [1, 1, 1, -1, -1]
-    beta,V = ridge_regression(X, y)
+    beta,V = utils.ridge_regression(X, y)
     expected_beta = [-0.98684211, -0.07894737]
     expected_v = [[-0.03289474, -0.49342105, 0.06578947, 0.03289474, 0.49342105],
 		  [-0.30263158, 0.46052632, -0.39473684, 0.30263158, -0.46052632]]


### PR DESCRIPTION
[It is reported](https://github.com/CamDavidsonPilon/lifelines/issues/35) that the AalenAdditiveFitter is extremely slow for large matricies. Digging in, it seems like the solution to the ridge regression was explicitly computing the inverse, which is often [unnecessary in practice](https://www.johndcook.com/blog/2010/01/19/dont-invert-that-matrix/). This PR should reduce the runtime from O(n^3) to O(n^2) by not computing the inverse and instead solving the system of equations directly.

