### PR TITLE
Coxph baseline fix; remove normalize; bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Changelogs
 
+#### 0.9.5
+ - corrected bug that was returning the wrong baseline survival and hazard values in `CoxPHFitter` is `normalize=True`. 
+ - correcting column name in `CoxPHFitter.baseline_survival_`
+ - compatibility changes with Pandas 0.20.0
+
 #### 0.9.4
  - adding `plot_loglogs` to `KaplanMeierFitter`
  - added a (correct) check to see if some columns in a dataset will cause convergence problems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - removed  `normalize` kwarg in `CoxPHFitter`. This was causing lots of confusion for users, and added code complexity. It's really nice to be able to remove it.
  - correcting column name in `CoxPHFitter.baseline_survival_`
  - `CoxPHFitter.baseline_cumulative_hazard_` is always centered, to mimic R's `basehaz` API.
+ - new `predict_log_partial_hazards` to `CoxPHFitter`
 
 #### 0.9.4
  - adding `plot_loglogs` to `KaplanMeierFitter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ### Changelogs
 
-#### 0.9.5
- - corrected bug that was returning the wrong baseline survival and hazard values in `CoxPHFitter` is `normalize=True`. 
+#### 0.10.0
+ - corrected bug that was returning the wrong baseline survival and hazard values in `CoxPHFitter` when `normalize=True`. 
+ - removed  `normalize` kwarg in `CoxPHFitter`. This was causing lots of confusion for users, and added code complexity. It's really nice to be able to remove it.
  - correcting column name in `CoxPHFitter.baseline_survival_`
- - compatibility changes with Pandas 0.20.0
+ - `CoxPHFitter.baseline_cumulative_hazard_` is always centered, to mimic R's `basehaz` API.
 
 #### 0.9.4
  - adding `plot_loglogs` to `KaplanMeierFitter`

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -420,7 +420,7 @@ class CoxPHFitter(BaseFitter):
         same as the training dataset.
 
         Returns the log of the partial hazard for the individuals, partial since the
-        baseline hazard is not included. Equal to \exp{\beta X}
+        baseline hazard is not included. Equal to \beta X
         """
         if isinstance(X, pd.DataFrame):
             order = self.hazards_.columns
@@ -436,7 +436,7 @@ class CoxPHFitter(BaseFitter):
             same order as the training data.
 
         Returns the log hazard relative to the hazard of the mean covariates. This is the behaviour
-        of R's predict.coxph.
+        of R's predict.coxph. Equal to \beta X - \beta \bar{X}
         """
         mean_covariates = self.data.mean(0).to_frame().T
         return self.predict_log_partial_hazard(X) - self.predict_log_partial_hazard(mean_covariates).squeeze()
@@ -446,6 +446,8 @@ class CoxPHFitter(BaseFitter):
         X: a (n,d) covariate numpy array or DataFrame. If a DataFrame, columns
             can be in any order. If a numpy array, columns must be in the
             same order as the training data.
+
+        Returns the cumulative hazard of individuals.
         """
         if self.strata:
             cumulative_hazard_ = pd.DataFrame()

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -388,7 +388,7 @@ class CoxPHFitter(BaseFitter):
               end='\n\n')
         print("Concordance = {:.3f}"
               .format(concordance_index(self.durations,
-                                        -self._predict_partial_hazard(self.data).values.ravel(),
+                                        -self.predict_partial_hazard(self.data).values.ravel(),
                                         self.event_observed)))
         return
 
@@ -398,8 +398,6 @@ class CoxPHFitter(BaseFitter):
             can be in any order. If a numpy array, columns must be in the
             same order as the training data.
 
-        If covariates were normalized during fitting, they are normalized
-        in the same way here.
 
         If X is a dataframe, the order of the columns do not matter. But
         if X is an array, then the column ordering is assumed to be the
@@ -412,18 +410,6 @@ class CoxPHFitter(BaseFitter):
             order = self.hazards_.columns
             X = X[order]
 
-        return self._predict_partial_hazard(X)
-
-    def _predict_partial_hazard(self, X):
-        """
-        X: a (n,d) covariate numpy array or DataFrame. If a DataFrame, columns
-            can be in any order. If a numpy array, columns must be in the
-            same order as the training data.
-
-
-        Returns the partial hazard for the individuals, partial since the
-        baseline hazard is not included. Equal to \exp{\beta X}
-        """
         index = _get_index(X)
         return pd.DataFrame(exp(np.dot(X, self.hazards_.T)), index=index)
 
@@ -506,7 +492,7 @@ class CoxPHFitter(BaseFitter):
 
     def _compute_baseline_hazard(self, data, durations, event_observed, name):
         # http://courses.nus.edu.sg/course/stacar/internet/st3242/handouts/notes3.pdf
-        ind_hazards = self._predict_partial_hazard(data)
+        ind_hazards = self.predict_partial_hazard(data)
         ind_hazards['event_at'] = durations
         ind_hazards_summed_over_durations = ind_hazards.groupby('event_at')[0].sum().sort_index(ascending=False).cumsum()
         ind_hazards_summed_over_durations.name = 'hazards'

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-__version__ = '0.9.4'
+__version__ = '0.10.0'

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -20,7 +20,7 @@ from lifelines.utils import k_fold_cross_validation, StatError
 from lifelines.estimation import CoxPHFitter, AalenAdditiveFitter, KaplanMeierFitter, \
     NelsonAalenFitter, BreslowFlemingHarringtonFitter, ExponentialFitter, \
     WeibullFitter, BaseFitter
-from lifelines.datasets importg load_larynx, load_waltons, load_kidney_transplant, load_rossi,\
+from lifelines.datasets import load_larynx, load_waltons, load_kidney_transplant, load_rossi,\
     load_lcd, load_panel_test, load_g3, load_holly_molly_polly
 from lifelines.generate_datasets import generate_hazard_rates, generate_random_lifetimes, cumulative_integral
 from lifelines.utils import concordance_index

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -619,7 +619,7 @@ prio  2.639e-01  1.302e+00 8.291e-02  3.182e+00 1.460e-03   1.013e-01   4.264e-0
 ---
 Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
 
-Concordance = 0.640""".strip().split()
+Concordance = 0.635""".strip().split()
             for i in [0, 1, 2, -2, -1]:
                 assert output[i] == expected[i]
         finally:

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -825,7 +825,7 @@ Concordance = 0.640""".strip().split()
         r = coxph(formula = Surv(week, arrest) ~ fin + age + strata(race,
                     paro, mar, wexp) + prio, data = rossi)
         """
-        expected = np.array([[-0.335, -0.059, 0.100]])
+        expected = np.array([[-0.3355, -0.0590, 0.1002]])
         cf = CoxPHFitter()
         cf.fit(rossi, duration_col='week', event_col='arrest', strata=['race', 'paro', 'mar', 'wexp'])
         npt.assert_array_almost_equal(cf.hazards_.values, expected, decimal=3)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -20,7 +20,7 @@ from lifelines.utils import k_fold_cross_validation, StatError
 from lifelines.estimation import CoxPHFitter, AalenAdditiveFitter, KaplanMeierFitter, \
     NelsonAalenFitter, BreslowFlemingHarringtonFitter, ExponentialFitter, \
     WeibullFitter, BaseFitter
-from lifelines.datasets import load_regression_dataset, load_larynx, load_waltons, load_kidney_transplant, load_rossi,\
+from lifelines.datasets importg load_larynx, load_waltons, load_kidney_transplant, load_rossi,\
     load_lcd, load_panel_test, load_g3, load_holly_molly_polly
 from lifelines.generate_datasets import generate_hazard_rates, generate_random_lifetimes, cumulative_integral
 from lifelines.utils import concordance_index


### PR DESCRIPTION

#### 0.10.0
 - corrected bug that was returning the wrong baseline survival and hazard values in `CoxPHFitter` when `normalize=True`. 
 - removed  `normalize` kwarg in `CoxPHFitter`. This was causing lots of confusion for users, and added code complexity. It's really nice to be able to remove it.
 - correcting column name in `CoxPHFitter.baseline_survival_`
 - `CoxPHFitter.baseline_cumulative_hazard_` is always centered, to mimic R's `basehaz` API.
 - new `predict_log_partial_hazards` to `CoxPHFitter`


Fixes: https://github.com/CamDavidsonPilon/lifelines/issues/289, https://github.com/CamDavidsonPilon/lifelines/issues/287