### PR TITLE
difference also sorts columns

### DIFF
--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -475,7 +475,7 @@ def k_fold_cross_validation(fitters, df, duration_col, event_col=None,
     assignments = np.array((n // k + 1) * list(range(1, k + 1)))
     assignments = assignments[:n]
 
-    testing_columns = df.columns.difference([duration_col, event_col])
+    testing_columns = df.columns.drop([duration_col, event_col])
 
     for i in range(1, k + 1):
 


### PR DESCRIPTION
The training set in the k fold CV has the original column order, but when picking out the test set using testing_columns, the columns get sorted by pd.index.difference. --> switched to drop.