### PR TITLE
v 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  - removes  `include_likelihood` from `CoxPHFitter.fit` - it was not slowing things down much (empirically), and often I wanted it for debugging (I suppose others do too). It's also another exit condition, so we many exit from the NR iterations faster. 
  - added `step_size` param to `CoxPHFitter.fit` - the default is good, but for extremely large or small datasets this may want to be set manually.
  - added a warning to `CoxPHFitter` to check for complete seperation: https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-or-quasi-complete-separation-in-logisticprobit-regression-and-how-do-we-deal-with-them/
- - 
+ - Additional functionality to `utils.survival_table_from_events` to bin the index to make the resulting table more readable.
 
 #### 0.11.3
  - No longer support matplotlib 1.X

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 0.12.0
  - removes  `include_likelihood` from `CoxPHFitter.fit` - it was not slowing things down much (empirically), and often I wanted it for debugging (I suppose others do too). It's also another exit condition, so we many exit from the NR iterations faster. 
  - added `step_size` param to `CoxPHFitter.fit` - the default is good, but for extremely large or small datasets this may want to be set manually.
+ - added a warning to `CoxPHFitter` to check for complete seperation: https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-or-quasi-complete-separation-in-logisticprobit-regression-and-how-do-we-deal-with-them/
  - 
 
 #### 0.11.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Changelogs
 
+#### 0.12.0
+ - removes  `include_likelihood` from `CoxPHFitter.fit` - it was not slowing things down much (empirically), and often I wanted it for debugging (I suppose others do too). It's also another exit condition, so we many exit from the NR iterations faster. 
+ - added `step_size` param to `CoxPHFitter.fit` - the default is good, but for extremely large or small datasets this may want to be set manually.
+ - 
+
 #### 0.11.3
  - No longer support matplotlib 1.X
  - Adding `times` argument to `CoxPHFitter`'s `predict_survival_function` and `predict_cumulative_hazard` to predict the estimates at, instead uses the default times of observation or censorship.

--- a/docs/Examples.rst
+++ b/docs/Examples.rst
@@ -416,3 +416,15 @@ Suppose you wish to measure the hazard ratio between two populations under the C
     postulated_hazard_ratio = 0.5
     power = power_under_cph(n_exp, n_con, p_exp, p_con, postulated_hazard_ratio)
     # 0.4957
+
+
+Problems with convergence in the Cox Proportional Hazard Model
+################################################################
+
+Since the estimation of the coefficients in the Cox proportional hazard model is done using the Newton-Raphson algorithm, there is sometimes a problem with convergence. Here are some common symptoms and possible resolutions:
+
+ - Some coefficients are many orders of magnitude larger than others, and the standard error of the coefficient is equally as large. This can be seen using the ``print_summary`` method on a fitted ``CoxPHFitter`` object. Look for a ``RuntimeWarning`` about variances being too small. The dataset may contain a constant column, which provides no information for the regression (Cox model doesn't have a traditional "intercept" term like other regression models). Or, the data is completely seperable, which means that there exists a covariate the completely determines whether an event occured or not. For example, for all "death" events in the dataset, there exists a covariate that is constant amongst all of them. Another problem may be a colinear relationship in your dataset - see the third point below. 
+
+ - Adding a very small ``penalizer_coef`` significantly changes the results. This probably means that the step size is too large. Try decreasing it, and returning the ``penalizer_coef`` term to 0. 
+
+ - ``LinAlgError: Singular matrix`` is thrown. This means that there is a linear combination in your dataset. That is, a column is equal to the linear combination of 1 or more other columns. Try to find the relationship by looking at the correlation matrix of your dataset. 

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -421,7 +421,7 @@ This example data is from the paper `here <http://socserv.socsci.mcmaster.ca/jfo
     Concordance = 0.640
     """
 
-To access the coefficients and the baseline hazard, you can use ``cph.hazards_`` and ``cph.baseline_hazard_`` respectively. After fitting, you can use use the suite of prediction methods (similar to Aalen's additve model above): ``.predict_partial_hazard``, ``.predict_survival_function``, etc.
+To access the coefficients and the baseline hazard, you can use ``cph.hazards_`` and ``cph.baseline_hazard_`` respectively. The likelihood is available too using ``cph._log_likelihood`` After fitting, you can use use the suite of prediction methods (similar to Aalen's additve model above): ``.predict_partial_hazard``, ``.predict_survival_function``, etc.
 
 .. code:: python
     

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+import warnings
 import numpy as np
 import pandas as pd
 
@@ -226,6 +227,7 @@ class CoxPHFitter(BaseFitter):
             elif i >= 50:
                 # 50 iterations steps with N-R is a lot.
                 # Expected convergence is ~10 steps
+                warnings.warn("Newton-Rhapson failed to converge sufficiently in 50 steps.", RuntimeWarning)
                 converging = False
             elif step_size <= 0.0001:
                 converging = False

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -144,7 +144,7 @@ class CoxPHFitter(BaseFitter):
         return hessian, gradient, log_lik
 
     def _newton_rhaphson(self, X, T, E, initial_beta=None, step_size=.5,
-                         precision=10e-6, show_progress=True):
+                         precision=10e-5, show_progress=True):
         """
         Newton Rhaphson algorithm for fitting CPH model.
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -144,7 +144,7 @@ class CoxPHFitter(BaseFitter):
         return hessian, gradient, log_lik
 
     def _newton_rhaphson(self, X, T, E, initial_beta=None, step_size=.5,
-                         precision=10e-5, show_progress=True):
+                         precision=10e-6, show_progress=True):
         """
         Newton Rhaphson algorithm for fitting CPH model.
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -296,8 +296,9 @@ class CoxPHFitter(BaseFitter):
             E = df[event_col]
             del df[event_col]
 
-        self.data = df if self.strata is None else df.reset_index()
         self._check_values(df, E)
+        df = df.astype(float)
+        self.data = df if self.strata is None else df.reset_index()
         self._norm_mean = df.mean(0)
         self._norm_std = df.std(0)
         df = normalize(df, self._norm_mean, self._norm_std)

--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -60,7 +60,7 @@ class KaplanMeierFitter(UnivariateFitter):
             n = self.event_table.shape[0]
             net_population = (self.event_table['entrance'] - self.event_table['removed']).cumsum()
             if net_population.iloc[:int(n / 2)].min() == 0:
-                ix = net_population.iloc[:int(n / 2)].argmin()
+                ix = net_population.iloc[:int(n / 2)].idxmin()
                 raise StatError("""There are too few early truncation times and too many events. S(t)==0 for all t>%.1f. Recommend BreslowFlemingHarringtonFitter.""" % ix)
 
         # estimation

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -930,3 +930,13 @@ def pass_for_numeric_dtypes_or_raise(df):
     nonnumeric_cols = df.select_dtypes(exclude=[np.number, bool]).columns.tolist()
     if len(nonnumeric_cols) > 0:
         raise TypeError("DataFrame contains nonnumeric columns: %s. Try using pandas.get_dummies to convert the column(s) to numerical data, or dropping the column(s)." % nonnumeric_cols)
+
+
+def check_low_var(X, prescript="", postscript=""):
+    low_var = (X.var(0) < 10e-5)
+    if low_var.any():
+        cols = str(list(X.columns[low_var]))
+        warning_text = "%sColumn(s) %s have very low variance. \
+This may harm convergence. Try dropping this redundant column before fitting \
+if convergence fails.%s" % (prescript, cols, postscript)
+        warnings.warn(warning_text, RuntimeWarning)

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -932,10 +932,10 @@ def pass_for_numeric_dtypes_or_raise(df):
         raise TypeError("DataFrame contains nonnumeric columns: %s. Try using pandas.get_dummies to convert the column(s) to numerical data, or dropping the column(s)." % nonnumeric_cols)
 
 
-def check_low_var(X, prescript="", postscript=""):
-    low_var = (X.var(0) < 10e-5)
+def check_low_var(df, prescript="", postscript=""):
+    low_var = (df.var(0) < 10e-5)
     if low_var.any():
-        cols = str(list(X.columns[low_var]))
+        cols = str(list(df.columns[low_var]))
         warning_text = "%sColumn(s) %s have very low variance. \
 This may harm convergence. Try dropping this redundant column before fitting \
 if convergence fails.%s" % (prescript, cols, postscript)

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-__version__ = '0.11.2'
+__version__ = '0.12.0'

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1100,10 +1100,15 @@ Concordance = 0.640""".strip().split()
         cp = CoxPHFitter()
         ix = rossi['arrest'] == 1
         rossi.loc[ix, 'paro'] = 1
-        rossi.loc[~ix, 'paro'] = 0
         cp.fit(rossi, 'week', 'arrest', show_progress=True)
-        assert cp.summary.loc['paro', 'exp(coef)'] > 100
-        assert False
+        assert cp.summary.loc['paro', 'exp(coef)'] < 100
+
+    @pytest.mark.xfail
+    def test_what_happens_with_colinear_inputs(self, rossi):
+        cp = CoxPHFitter()
+        rossi['duped'] = rossi['paro'] + rossi['prio']
+        cp.fit(rossi, 'week', 'arrest', show_progress=True)
+        assert cp.summary.loc['duped', 'se(coef)'] < 100
 
 
 class TestAalenAdditiveFitter():

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -681,7 +681,7 @@ Concordance = 0.640""".strip().split()
 
     def test_log_likelihood_is_available_in_output(self, data_nus):
         cox = CoxPHFitter()
-        cox.fit(data_nus, duration_col='t', event_col='E', include_likelihood=True)
+        cox.fit(data_nus, duration_col='t', event_col='E')
         assert abs(cox._log_likelihood - -12.7601409152) < 0.001
 
     def test_efron_computed_by_hand_examples(self, data_nus):
@@ -702,7 +702,7 @@ Concordance = 0.640""".strip().split()
         # tests from http://courses.nus.edu.sg/course/stacar/internet/st3242/handouts/notes3.pdf
         beta = np.array([[0]])
 
-        l, u = cox._get_efron_values(X, beta, T, E)
+        l, u, _ = cox._get_efron_values(X, beta, T, E)
         l = -l
 
         assert np.abs(l[0][0] - 77.13) < 0.05
@@ -710,7 +710,7 @@ Concordance = 0.640""".strip().split()
         beta = beta + u / l
         assert np.abs(beta - -0.0326) < 0.05
 
-        l, u = cox._get_efron_values(X, beta, T, E)
+        l, u, _ = cox._get_efron_values(X, beta, T, E)
         l = -l
 
         assert np.abs(l[0][0] - 72.83) < 0.05
@@ -718,7 +718,7 @@ Concordance = 0.640""".strip().split()
         beta = beta + u / l
         assert np.abs(beta - -0.0325) < 0.01
 
-        l, u = cox._get_efron_values(X, beta, T, E)
+        l, u, _ = cox._get_efron_values(X, beta, T, E)
         l = -l
 
         assert np.abs(l[0][0] - 72.70) < 0.01
@@ -890,7 +890,7 @@ Concordance = 0.640""".strip().split()
         """
         expected = np.array([[-0.3355, -0.0590, 0.1002]])
         cf = CoxPHFitter()
-        cf.fit(rossi, duration_col='week', event_col='arrest', strata=['race', 'paro', 'mar', 'wexp'])
+        cf.fit(rossi, duration_col='week', event_col='arrest', strata=['race', 'paro', 'mar', 'wexp'], show_progress=True)
         npt.assert_array_almost_equal(cf.hazards_.values, expected, decimal=3)
 
     def test_penalized_output_against_R(self, rossi):
@@ -970,7 +970,7 @@ Concordance = 0.640""".strip().split()
         """
 
         cp = CoxPHFitter()
-        cp.fit(rossi, 'week', 'arrest', strata=['race', 'paro', 'mar', 'wexp'], include_likelihood=True)
+        cp.fit(rossi, 'week', 'arrest', strata=['race', 'paro', 'mar', 'wexp'])
 
         npt.assert_almost_equal(cp.summary['coef'].values, [-0.335, -0.059, 0.100], decimal=3)
         assert abs(cp._log_likelihood - -436.9339) / 436.9339 < 0.01

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -248,6 +248,18 @@ def test_group_survival_table_from_events_works_with_series():
     npt.assert_array_equal(ug, np.array([3, 2]))
 
 
+def test_survival_table_from_events_will_collapse_if_asked():
+    T, C = np.array([1, 3, 4, 5]), np.array([True, True, True, True])
+    table = utils.survival_table_from_events(T, C, collapse=True)
+    assert table.index.tolist() == [pd.Interval(0, 3.5089999999999999, closed='right'), pd.Interval(3.5089999999999999,  7.0179999999999998, closed='right')]
+
+
+def test_survival_table_from_events_will_collapse_to_desired_bins():
+    T, C = np.array([1, 3, 4, 5]), np.array([True, True, True, True])
+    table = utils.survival_table_from_events(T, C, collapse=True, intervals=[0, 4, 8])
+    assert table.index.tolist() == [pd.Interval(0, 4, closed='right'), pd.Interval(4,  8, closed='right')]
+
+
 def test_cross_validator_returns_k_results():
     cf = CoxPHFitter()
     results = utils.k_fold_cross_validation(cf, load_regression_dataset(), duration_col='T', event_col='E', k=3)


### PR DESCRIPTION
#### 0.12.0
 - removes  `include_likelihood` from `CoxPHFitter.fit` - it was not slowing things down much (empirically), and often I wanted it for debugging (I suppose others do too). It's also another exit condition, so we many exit from the NR iterations faster. Closes #341 
 - added `step_size` param to `CoxPHFitter.fit` - the default is good, but for extremely large or small datasets this may want to be set manually. The better defaults here mean better convergence, generally.
 - Closes #338
 - added a warning for complete seperation: closes #342 
 - addes new binning logic to survival_table_from_events by @JaredStufft