### PR TITLE
#351 Replace "an plot" with "a plot".

### DIFF
--- a/docs/Examples.rst
+++ b/docs/Examples.rst
@@ -178,7 +178,7 @@ Alternatively, perhaps you are interested in viewing the survival table given so
 
 
 
-Plotting multiple figures on an plot 
+Plotting multiple figures on a plot 
 ##############################################
 
 When `.plot` is called, an `axis` object is returned which can be passed into future calls of `.plot`:


### PR DESCRIPTION
Small grammar fix in the Examples documentation.