### PR TITLE
Added a naive reverse KaplanMeier for estimating median follow up time

### DIFF
--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -21,7 +21,7 @@ class KaplanMeierFitter(UnivariateFitter):
     """
 
     def fit(self, durations, event_observed=None, timeline=None, entry=None, label='KM_estimate',
-            alpha=None, left_censorship=False, ci_labels=None):
+            alpha=None, left_censorship=False, ci_labels=None, reverse=False):
         """
         Parameters:
           duration: an array, or pd.Series, of length n -- duration subject was observed for
@@ -37,6 +37,9 @@ class KaplanMeierFitter(UnivariateFitter):
           left_censorship: True if durations and event_observed refer to left censorship events. Default False
           ci_labels: add custom column names to the generated confidence intervals
                 as a length-2 list: [<lower-bound name>, <upper-bound name>]. Default: <label>_lower_<alpha>
+          reverse: reverse event-time indicator, censored values becomes values of interest. Used for
+          estimation of the median follow-up time. Schemper and Smith (Control Clin Trials, 1996,17:343–346)
+          suggested to estimate potential follow-up based on the Kaplan-Meier for the censored times.
 
 
         Returns:
@@ -45,6 +48,9 @@ class KaplanMeierFitter(UnivariateFitter):
         """
         # if the user is interested in left-censorship, we return the cumulative_density_, no survival_function_,
         estimate_name = 'survival_function_' if not left_censorship else 'cumulative_density_'
+        if event_observed is not None and reverse:
+            # bit-wise XOR to invert event indicators if not None
+            event_observed ^= 1
         v = _preprocess_inputs(durations, event_observed, timeline, entry)
         self.durations, self.event_observed, self.timeline, self.entry, self.event_table = v
         self._label = label


### PR DESCRIPTION
This is perhaps not a PR for immediate merge, rather a start of a conversation and feature request.

I added reverse Kaplan Meier, implemented in the R prodlim library `prodlim(Hist(time,cens)~1,data=GBSG2,reverse=TRUE))` used for "median follow up time estimation". The median follow-up is an indicator of how ‘mature’ your survival data is (e.g. how many months on ‘average’ the patients were followed since randomisation into the study). 
[https://www2.le.ac.uk/departments/health-sciences/research/biostats/youngsurv/pdf/MShanyinde.pdf]

This page [http://staff.pubhealth.ku.dk/~tag/Teaching/share/R-tutorials/SurvivalAnalysis.html] mentions that 

> An approximation of this so-called reverse Kaplan-Meier can be obtained by reversing the event indicator so that the outcome of interest becomes being censored. However, when there are ties in the data in the sense that some subjects have exactly the same event times then this would not be exactly correct.

Then goes on to say that the R implementation does account for this. However others doesn't seem to care about this such as [https://www.graphpad.com/support/faq/determining-the-median-followup-time-in-survival-anlaysis/] and the original Kaplan Meier paper [Kaplan EL, Meier P. Nonparametric estimation from incomplete observations. J Am Stat Assoc. 1958;53:457–481] page 461 just mentions that if there are ties in the data (two event same time) the censored event/patient should be placed AFTER the uncensored one. I haven't found any paper or reference on what happens when two event both censored or both uncensored occur at the same time ? 

So this naive approach is perhaps enough?  Missing is tests, not really sure how I would test this. I tested the R code `prodlim(Hist(time,cens)~1,data=GBSG2,reverse=TRUE))` which gives exactly the same results as this python implementation though.

Not sure it makes sense to have all methods available when you decide to reverse it either.  Sorry for the long text. Let me know if you think it might be of interest and also what might need to be changed for it to be accepted.