### PR TITLE
Exclude data storage in model

### DIFF
--- a/lifelines/fitters/aalen_additive_fitter.py
+++ b/lifelines/fitters/aalen_additive_fitter.py
@@ -215,7 +215,6 @@ class AalenAdditiveFitter(BaseFitter):
         else:
             self.timeline = self.hazards_.index.values.astype(float)
 
-        self.data = dataframe
         self.durations = T
         self.event_observed = C
         self._compute_confidence_intervals()
@@ -306,7 +305,6 @@ class AalenAdditiveFitter(BaseFitter):
         else:
             self.timeline = self.hazards_.index.values.astype(float)
 
-        self.data = wp
 
         self.durations = T
         self.event_observed = C

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -323,9 +323,8 @@ class CoxPHFitter(BaseFitter):
         self._train_concordance = concordance_index(self.durations,
                                                     -self.predict_partial_hazard(self.data).values.ravel(),
                                                     self.event_observed)
-        self._mean_covariates = self.data.mean(0).to_frame().T
         self._train_columns = self.data.columns
-        self._train_log_partial_hazard = self.predict_log_partial_hazard(self._mean_covariates)
+        self._train_log_partial_hazard = self.predict_log_partial_hazard(self.data.mean(0).to_frame().T)
         self.data = None
         return self
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -324,7 +324,8 @@ class CoxPHFitter(BaseFitter):
                                                     -self.predict_partial_hazard(self.data).values.ravel(),
                                                     self.event_observed)
         self._mean_covariates = self.data.mean(0).to_frame().T
-        self._train_columns = self.data.columns.copy()
+        self._train_columns = self.data.columns
+        self._train_log_partial_hazard = self.predict_log_partial_hazard(self._mean_covariates)
         self.data = None
         return self
 
@@ -451,7 +452,7 @@ class CoxPHFitter(BaseFitter):
         of R's predict.coxph. Equal to \beta X - \beta \bar{X}
         """
 
-        return self.predict_log_partial_hazard(X) - self.predict_log_partial_hazard(self._mean_covariates).squeeze()
+        return self.predict_log_partial_hazard(X) - self._train_log_partial_hazard.squeeze()
 
     def predict_cumulative_hazard(self, X, times=None):
         """

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -299,6 +299,7 @@ class CoxPHFitter(BaseFitter):
         self._check_values(df, E)
         df = df.astype(float)
         self.data = df if self.strata is None else df.reset_index()
+        self._n_examples = self.data.shape[0]
         self._norm_mean = df.mean(0)
         self._norm_std = df.std(0)
         df = normalize(df, self._norm_mean, self._norm_std)
@@ -318,6 +319,13 @@ class CoxPHFitter(BaseFitter):
         self.baseline_hazard_ = self._compute_baseline_hazards(df * self._norm_std + self._norm_mean, T, E)
         self.baseline_cumulative_hazard_ = self._compute_baseline_cumulative_hazard(self.baseline_hazard_)
         self.baseline_survival_ = self._compute_baseline_survival()
+
+        self._train_concordance = concordance_index(self.durations,
+                                                    -self.predict_partial_hazard(self.data).values.ravel(),
+                                                    self.event_observed)
+        self._mean_covariates = self.data.mean(0).to_frame().T
+        self._train_columns = self.data.columns.copy()
+        self.data = None
         return self
 
     def _compute_baseline_cumulative_hazard(self, baseline_hazard_):
@@ -383,7 +391,7 @@ class CoxPHFitter(BaseFitter):
         df[''] = [significance_code(p) for p in df['p']]
 
         # Print information about data first
-        print('n={}, number of events={}'.format(self.data.shape[0],
+        print('n={}, number of events={}'.format(self._n_examples,
                                                  np.where(self.event_observed)[0].shape[0]),
               end='\n\n')
         print(df.to_string(float_format=lambda f: '{:4.4f}'.format(f)))
@@ -392,9 +400,7 @@ class CoxPHFitter(BaseFitter):
         print("Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1 ",
               end='\n\n')
         print("Concordance = {:.3f}"
-              .format(concordance_index(self.durations,
-                                        -self.predict_partial_hazard(self.data).values.ravel(),
-                                        self.event_observed)))
+              .format(self._train_concordance))
         return
 
     def predict_partial_hazard(self, X):
@@ -444,8 +450,8 @@ class CoxPHFitter(BaseFitter):
         Returns the log hazard relative to the hazard of the mean covariates. This is the behaviour
         of R's predict.coxph. Equal to \beta X - \beta \bar{X}
         """
-        mean_covariates = self.data.mean(0).to_frame().T
-        return self.predict_log_partial_hazard(X) - self.predict_log_partial_hazard(mean_covariates).squeeze()
+
+        return self.predict_log_partial_hazard(X) - self.predict_log_partial_hazard(self._mean_covariates).squeeze()
 
     def predict_cumulative_hazard(self, X, times=None):
         """

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -298,8 +298,9 @@ class CoxPHFitter(BaseFitter):
 
         self._check_values(df, E)
         df = df.astype(float)
-        self.data = df if self.strata is None else df.reset_index()
-        self._n_examples = self.data.shape[0]
+        original_df = df if self.strata is None else df.reset_index()
+
+        self._n_examples = df.shape[0]
         self._norm_mean = df.mean(0)
         self._norm_std = df.std(0)
         df = normalize(df, self._norm_mean, self._norm_std)
@@ -321,11 +322,11 @@ class CoxPHFitter(BaseFitter):
         self.baseline_survival_ = self._compute_baseline_survival()
 
         self._train_concordance = concordance_index(self.durations,
-                                                    -self.predict_partial_hazard(self.data).values.ravel(),
+                                                    -self.predict_partial_hazard(original_df).values.ravel(),
                                                     self.event_observed)
-        self._train_columns = self.data.columns
-        self._train_log_partial_hazard = self.predict_log_partial_hazard(self.data.mean(0).to_frame().T)
-        self.data = None
+
+        self._train_log_partial_hazard = self.predict_log_partial_hazard(original_df.mean(0).to_frame().T)
+
         return self
 
     def _compute_baseline_cumulative_hazard(self, baseline_hazard_):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -740,7 +740,7 @@ Concordance = 0.640""".strip().split()
         cf = CoxPHFitter()
         cf.fit(data_pred2, 't', 'E')
 
-        X = data_pred2[cf._train_columns]
+        X = data_pred2[data_pred2.columns.difference(['t', 'E'])]
         assert_frame_equal(
             cf.predict_partial_hazard(np.array(X)),
             cf.predict_partial_hazard(X)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -740,7 +740,7 @@ Concordance = 0.640""".strip().split()
         cf = CoxPHFitter()
         cf.fit(data_pred2, 't', 'E')
 
-        X = data_pred2[cf.data.columns]
+        X = data_pred2[cf._train_columns]
         assert_frame_equal(
             cf.predict_partial_hazard(np.array(X)),
             cf.predict_partial_hazard(X)
@@ -766,9 +766,7 @@ Concordance = 0.640""".strip().split()
         cf.fit(data_pred2, duration_col='t', event_col='E')
 
         # Internal training set
-        ci_trn = concordance_index(cf.durations,
-                                   -cf.predict_partial_hazard(cf.data).values,
-                                   cf.event_observed)
+        ci_trn = cf._train_concordance
         # New data should normalize in the exact same way
         ci_org = concordance_index(data_pred2['t'],
                                    -cf.predict_partial_hazard(data_pred2[['x1', 'x2']]).values,

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -458,7 +458,7 @@ def test_concordance_index_fast_is_same_as_slow():
     cp.fit(df, duration_col='week', event_col='arrest')
 
     T = cp.durations.values.ravel()
-    P = -cp.predict_partial_hazard(cp.data).values.ravel()
+    P = -cp.predict_partial_hazard(df[cp._train_columns]).values.ravel()
     E = cp.event_observed.values.ravel()
 
     assert slow_cindex(T, P, E) == fast_cindex(T, P, E)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -458,7 +458,8 @@ def test_concordance_index_fast_is_same_as_slow():
     cp.fit(df, duration_col='week', event_col='arrest')
 
     T = cp.durations.values.ravel()
-    P = -cp.predict_partial_hazard(df[cp._train_columns]).values.ravel()
+    P = -cp.predict_partial_hazard(df[df.columns.difference(["week", "arrest"])]).values.ravel()
+
     E = cp.event_observed.values.ravel()
 
     assert slow_cindex(T, P, E) == fast_cindex(T, P, E)


### PR DESCRIPTION
I've pickled a coxph model and it ended up with a large file size, I realized that the model stores the data inside it. This PR tries to address it, calculating training concordance and log partial hazard just after training, so it wouldn't need to store all the data anymore. I had to adapt some test cases that access the internal data too.

Is there any other reason to keep it? Is there a better way to approach this problem?



