### PR TITLE
Properly forward fill cumulative sums when making covariate timeline

### DIFF
--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1172,7 +1172,7 @@ known observation. This could case null values in the resulting dataframe."
             expanded_df['enum'] = np.arange(1, n + 1)
 
         if cumulative_sum:
-            expanded_df[cv.columns] = expanded_df[cv.columns].fillna(0)
+            expanded_df[cv.columns] = expanded_df[cv.columns].ffill().fillna(0)
 
         return expanded_df.ffill()
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -510,6 +510,15 @@ class TestLongDataFrameUtils(object):
 
         assert_frame_equal(df21, df12, check_like=True)
 
+    def test_order_of_adding_covariates_doesnt_matter_in_cumulative_sum(self, seed_df, cv1, cv2):
+        df12 = seed_df.pipe(utils.add_covariate_to_timeline, cv1, 'id', 't', 'E', cumulative_sum=True)\
+                      .pipe(utils.add_covariate_to_timeline, cv2, 'id', 't', 'E', cumulative_sum=True)
+
+        df21 = seed_df.pipe(utils.add_covariate_to_timeline, cv2, 'id', 't', 'E', cumulative_sum=True)\
+                      .pipe(utils.add_covariate_to_timeline, cv1, 'id', 't', 'E', cumulative_sum=True)
+
+        assert_frame_equal(df21, df12, check_like=True)
+
     def test_adding_cvs_with_the_same_column_name_will_insert_appropriately(self, seed_df):
         seed_df = seed_df[seed_df['id'] == 1]
 


### PR DESCRIPTION
There is an issue where `add_covariate_to_timeline` is filling `0` values downstream of accumulated sums instead of persisting the accumulated value. For example, the expected output of cumulatively summing `covariate_one` that enters following states `covariate_one = [1, 1, 1]` should be `cumsum_covariate_one = [0, 1, 2, 3, 3, ...]` if there are additional state changes of a different covariate after these events. However, the actual output is `cumsum_covariate_one = [0, 1, 2, 3, 0, ...]`. This is easy to reproduce by running code as in the test below, which would have failed previously.

This PR fixes the issue quick and easy.

