### PR TITLE
Fix error for IPW Kaplan Meier

### DIFF
--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -251,14 +251,14 @@ or "Adjusted Kaplan-Meier estimator and log-rank test with inverse probability o
 
     # deal with deaths and censorships
     df = pd.DataFrame(death_times, columns=["event_at"])
-    df[removed] = weights
-    df[observed] = weights * np.asarray(event_observed)
+    df[removed] = np.asarray(weights)
+    df[observed] = np.asarray(weights) * np.asarray(event_observed)
     death_table = df.groupby("event_at").sum()
     death_table[censored] = (death_table[removed] - death_table[observed]).astype(int)
 
     # deal with late births
     births = pd.DataFrame(birth_times, columns=['event_at'])
-    births[entrance] = weights
+    births[entrance] = np.asarray(weights)
     births_table = births.groupby('event_at').sum()
     event_table = death_table.join(births_table, how='outer', sort=True).fillna(0)  # http://wesmckinney.com/blog/?p=414
     event_table[at_risk] = event_table[entrance].cumsum() - event_table[removed].cumsum().shift(1).fillna(0)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -514,6 +514,19 @@ class TestKaplanMeierFitter():
             kmf = KaplanMeierFitter().fit(T, E, weights=np.random.random(n))
             assert True
 
+    def test_weights_with_unaligned_index(self):
+        pd.DataFrame(index=[5,6,7,8])
+        df = pd.DataFrame(index=[5,6,7,8])
+        df['t'] = [0.6,0.4,0.8,0.9]
+        df['y'] = [0,1,1,0]
+        df['w'] = [1.5,2,0.8,0.9]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            k.fit(durations=df['t'],event_observed=df['y'],weights=df['w'])
+            a = list(k.survival_function_.KM_estimate)
+            assert a == [1.0,0.6153846153846154,0.6153846153846154,0.32579185520362,0.32579185520362]
+
+
 class TestNelsonAalenFitter():
 
     def nelson_aalen(self, lifetimes, observed=None):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -515,15 +515,14 @@ class TestKaplanMeierFitter():
             assert True
 
     def test_weights_with_unaligned_index(self):
-        pd.DataFrame(index=[5,6,7,8])
         df = pd.DataFrame(index=[5,6,7,8])
         df['t'] = [0.6,0.4,0.8,0.9]
         df['y'] = [0,1,1,0]
         df['w'] = [1.5,2,0.8,0.9]
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            k.fit(durations=df['t'],event_observed=df['y'],weights=df['w'])
-            a = list(k.survival_function_.KM_estimate)
+            kmf = KaplanMeierFitter().fit(durations=df['t'],event_observed=df['y'],weights=df['w'])
+            a = list(kmf.survival_function_.KM_estimate)
             assert a == [1.0,0.6153846153846154,0.6153846153846154,0.32579185520362,0.32579185520362]
 
 


### PR DESCRIPTION
Finally got around to checking KM for propensity scores/inverse probability weights. When running the KM fitter, if weights=df['weights'] is not converted to a np.array, then unexpected behaviors occur. I have rewritten survival_table_from_events to convert the specified weights to a np.asarray(). Without this change the user would have to specify weights=np.asarray(df['weights']). Results were compared to SAS and consistent results were obtained with this fix