### PR TITLE
use newer python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ python:
    - "3.4"
    - "3.5"
    - "3.6"
-   - "3.7-dev"
+# Enable newer 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 before_install:
   - sudo apt-get update
 install:


### PR DESCRIPTION
Update the Travis CI to use an up to date version of Python3.7 instead of unreleased development version of 3.7