### PR TITLE
fix for likelihood ratio in cox models, v15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changelogs
 
+#### 0.15.4
+ - bug fix for the Cox model likelihood ratio test when using non-trivial weights.
+
+#### 0.15.3
+ - Only allow matplotlib less than 3.0.
+
 #### 0.15.2
  - API changes to `plotting.plot_lifetimes`
  - `cluster_col` and `strata` can be used together in `CoxPHFitter`

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -252,9 +252,12 @@ estimate the variances. See paper "Variance estimation when using inverse probab
         # save fitting data for later
         self.durations = T.copy()
         self.event_observed = E.copy()
+        self.weights = weights.copy()
+        
         if self.strata is not None:
             self.durations.index = original_index
             self.event_observed.index = original_index
+            self.weights.index = original_index
         self.event_observed = self.event_observed.astype(bool)
 
         self._norm_mean = df.mean(0)
@@ -767,13 +770,13 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
         compare the existing model (with all the covariates) to the trivial model
         of no covariates.
 
-        Conviently, we can actually use the class itself to do most of the work.
+        Conveniently, we can actually use the class itself to do most of the work.
 
         """
-        trivial_dataset = pd.DataFrame({"E": self.event_observed, "T": self.durations})
+        trivial_dataset = pd.DataFrame({"E": self.event_observed, "T": self.durations, "W": self.weights})
 
         cp_null = CoxPHFitter()
-        cp_null.fit(trivial_dataset, "T", "E", show_progress=False)
+        cp_null.fit(trivial_dataset, "T", "E", weights_col="W", show_progress=False)
 
         ll_null = cp_null._log_likelihood
         ll_alt = self._log_likelihood

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.15.3"
+__version__ = "0.15.4"

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1512,6 +1512,16 @@ Likelihood ratio test = 33.266 on 7 df, p=0.00002
         assert with_weights[0] != without_weights[0]
 
     def test_log_likelihood_test_against_R_with_weights(self, rossi):
+        """
+        df <- data.frame(
+          "var1" = c(0.209325, 0.693919, 0.443804, 0.065636, 0.386294),
+          "T" = c(5.269797, 6.601666, 7.335846, 11.684092, 12.678458),
+          "w" = c(1, 0.5, 2, 1, 1)
+        )
+        df['E'] = 1
+        r = coxph(formula=Surv(T, E) ~ var1, data=df, weights=w)
+        summary(r)
+        """
         df = pd.DataFrame(
             {
                 "var1": [0.209325, 0.693919, 0.443804, 0.065636, 0.386294],

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1523,8 +1523,8 @@ Likelihood ratio test = 33.266 on 7 df, p=0.00002
 
         cph = CoxPHFitter()
         cph.fit(df, "T", "E", show_progress=True, weights_col="w")
-        expected = 0.12
-        assert (cph._compute_likelihood_ratio_test()[0] - expected) < 0.01
+        expected = 0.05
+        assert abs(cph._compute_likelihood_ratio_test()[0] - expected) < 0.01
 
 
     def test_trival_float_weights_with_no_ties_is_the_same_as_R(self, regression_dataset):


### PR DESCRIPTION
#### 0.15.4
 - bug fix for the Cox model likelihood ratio test when using non-trivial weights.