### PR TITLE
0.16.0 Formatting and address linting errors

### DIFF
--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -35,7 +35,7 @@ from lifelines.utils import (
     StepSizer,
     ConvergenceError,
     string_justify,
-    _to_list
+    _to_list,
 )
 
 
@@ -51,17 +51,17 @@ class CoxPHFitter(BaseFitter):
 
       alpha: float, optional (default=0.95)
         the level in the confidence intervals.
-      
+
       tie_method: string, optional
         specify how the fitter should deal with ties. Currently only
         'Efron' is available.
-      
+
       penalizer: float, optional (default=0.0)
         Attach a L2 penalizer to the size of the coeffcients during regression. This improves
         stability of the estimates and controls for high correlation between covariates.
         For example, this shrinks the absolute value of :math:`\beta_i`. Recommended, even if a small value.
         The penalty is :math:`1/2  \text{penalizer}  ||beta||^2`.
-      
+
       strata: list, optional
         specify a list of columns to use in stratification. This is useful if a
          catagorical covariate does not obey the proportional hazard assumption. This
@@ -111,19 +111,19 @@ class CoxPHFitter(BaseFitter):
         ----------
         df: DataFrame
             a Pandas dataframe with necessary columns `duration_col` and
-            `event_col` (see below), covariates columns, and special columns (weights, strata). 
+            `event_col` (see below), covariates columns, and special columns (weights, strata).
             `duration_col` refers to
             the lifetimes of the subjects. `event_col` refers to whether
             the 'death' events was observed: 1 if observed, 0 else (censored).
-        
+
         duration_col: string
             the name of the column in dataframe that contains the subjects'
             lifetimes.
-        
+
         event_col: string, optional
             the  name of thecolumn in dataframe that contains the subjects' death
             observation. If left as None, assume all individuals are uncensored.
-        
+
         weights_col: string, optional
             an optional column in the dataframe, df, that denotes the weight per subject.
             This column is expelled and not used as a covariate, but as a weight in the
@@ -131,29 +131,29 @@ class CoxPHFitter(BaseFitter):
             This can be used for case-weights. For example, a weight of 2 means there were two subjects with
             identical observations.
             This can be used for sampling weights. In that case, use `robust=True` to get more accurate standard errors.
-        
+
         show_progress: boolean, optional (default=False)
             since the fitter is iterative, show convergence
-            diagnostics. Useful if convergence is failing. 
-        
+            diagnostics. Useful if convergence is failing.
+
         initial_beta: numpy array, optional
             initialize the starting point of the iterative
             algorithm. Default is the zero vector.
-        
+
         strata: list or string, optional
             specify a column or list of columns n to use in stratification. This is useful if a
             catagorical covariate does not obey the proportional hazard assumption. This
             is used similar to the `strata` expression in R.
             See http://courses.washington.edu/b515/l17.pdf.
-        
+
         step_size: float, optional
             set an initial step size for the fitting algorithm.
-        
+
         robust: boolean, optional (default=False)
             Compute the robust errors using the Huber sandwich estimator, aka Wei-Lin estimate. This does not handle
             ties, so if there are high number of ties, results may significantly differ. See
             "The Robust Inference for the Cox Proportional Hazards Model", Journal of the American Statistical Association, Vol. 84, No. 408 (Dec., 1989), pp. 1074- 1078
-        
+
         cluster_col: string, optional
             specifies what column has unique identifers for clustering covariances. Using this forces the sandwich estimator (robust variance estimator) to
             be used.
@@ -172,7 +172,7 @@ class CoxPHFitter(BaseFitter):
         Examples
         --------
         >>> from lifelines import CoxPHFitter
-        >>> 
+        >>>
         >>> df = pd.DataFrame({
         >>>     'T': [5, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
         >>>     'E': [1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0],
@@ -187,7 +187,7 @@ class CoxPHFitter(BaseFitter):
 
 
         >>> from lifelines import CoxPHFitter
-        >>> 
+        >>>
         >>> df = pd.DataFrame({
         >>>     'T': [5, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
         >>>     'E': [1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0],
@@ -256,8 +256,6 @@ class CoxPHFitter(BaseFitter):
 
         df = df.copy()
 
-
-        
         if self.strata is not None:
             df = df.sort_values(by=[self.duration_col] + _to_list(self.strata))
             original_index = df.index.copy()
@@ -266,18 +264,17 @@ class CoxPHFitter(BaseFitter):
             df = df.sort_values(by=self.duration_col)
             original_index = df.index.copy()
 
-
         # Extract time and event
         T = df.pop(self.duration_col)
         E = (
             df.pop(self.event_col)
             if (self.event_col is not None)
-            else pd.Series(np.ones(self._n_examples), index=df.index, name='weights')
+            else pd.Series(np.ones(self._n_examples), index=df.index, name="weights")
         )
         W = (
             df.pop(self.weights_col)
             if (self.weights_col is not None)
-            else pd.Series(np.ones((self._n_examples,)), index=df.index, name='E')
+            else pd.Series(np.ones((self._n_examples,)), index=df.index, name="E")
         )
 
         # check to make sure their weights are okay
@@ -293,7 +290,6 @@ estimate the variances. See paper "Variance estimation when using inverse probab
             if (W <= 0).any():
                 raise ValueError("values in weight column %s must be positive." % self.weights_col)
 
-        
         _clusters = df.pop(self.cluster_col).values if self.cluster_col else None
 
         self._check_values(df, T, E)
@@ -623,31 +619,23 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
     def _compute_martingale(self, X, T, E, weights, index=None):
         # TODO: decide if I want to attach T and E to the final dataframe...
         partial_hazard = self.predict_partial_hazard(X)[0].values
-        
+
         if not self.strata:
-            baseline_at_T = self.baseline_cumulative_hazard_.loc[T, 'baseline hazard'].values
+            baseline_at_T = self.baseline_cumulative_hazard_.loc[T, "baseline hazard"].values
         else:
-            baseline_at_T = np.empty(0)    
+            baseline_at_T = np.empty(0)
             for name, T_ in T.groupby(level=0):
                 baseline_at_T = np.append(baseline_at_T, self.baseline_cumulative_hazard_.loc[T_, name])
-        
+
         martingale = E - (partial_hazard * baseline_at_T)
         martingale.index = index  # overrides the strata index, if necessary
-        return pd.DataFrame({
-            self.duration_col: T, 
-            self.event_col: E,
-            'martingale': martingale
-        })
+        return pd.DataFrame({self.duration_col: T, self.event_col: E, "martingale": martingale})
 
     def _compute_deviance(self, X, T, E, weights, index=None):
-        rmart = self._compute_martingale(X, T, E, weights, index)['martingale']
+        rmart = self._compute_martingale(X, T, E, weights, index)["martingale"]
         log_term = np.where((E.values - rmart.values) <= 0, 0, E.values * np.log(E.values - rmart.values))
-        deviance = np.sign(rmart) * np.sqrt(-2 *(rmart + log_term))
-        return pd.DataFrame({
-            self.duration_col: T, 
-            self.event_col: E,
-            'deviance': deviance
-        })
+        deviance = np.sign(rmart) * np.sqrt(-2 * (rmart + log_term))
+        return pd.DataFrame({self.duration_col: T, self.event_col: E, "deviance": deviance})
 
     def _compute_schoenfeld(self, X, T, E, weights, index=None):
         # Assumes sorted on T and on strata
@@ -667,7 +655,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
         else:
             schoenfeld_residuals = self._compute_schoenfeld_within_strata(X.values, T, E.values, weights.values)
 
-        # schoenfeld residuals are only defined for subjects with a non-zero event. 
+        # schoenfeld residuals are only defined for subjects with a non-zero event.
         return pd.DataFrame(schoenfeld_residuals[E, :], columns=self.hazards_.columns, index=index[E])
 
     def _compute_schoenfeld_within_strata(self, X, T, E, weights):
@@ -834,7 +822,6 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
 
         resids = getattr(self, "_compute_%s" % kind)(X, T, E, weights, index=shuffled_original_index)
         return resids
-
 
     def _compute_confidence_intervals(self):
         alpha2 = inv_normal_cdf((1.0 + self.alpha) / 2.0)
@@ -1026,7 +1013,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
         """
         Parameters
         ----------
-        
+
         X: numpy array or DataFrame
             a (n,d) covariate numpy array or DataFrame. If a DataFrame, columns
             can be in any order. If a numpy array, columns must be in the
@@ -1075,12 +1062,12 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
 
     def predict_survival_function(self, X, times=None):
         """
-        Predict the survival function for individuals, given their covariates. This assumes that the individual 
+        Predict the survival function for individuals, given their covariates. This assumes that the individual
         just entered the study (that is, we do not condition on how long they have already lived for.)
 
         Parameters
         ----------
-        
+
         X: numpy array or DataFrame
             a (n,d) covariate numpy array or DataFrame. If a DataFrame, columns
             can be in any order. If a numpy array, columns must be in the
@@ -1129,7 +1116,7 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
         """
         Predict the median lifetimes for the individuals. If the survival curve of an
         individual does not cross 0.5, then the result is infinity.
-        
+
         Parameters
         ----------
         X: numpy array or DataFrame
@@ -1137,7 +1124,7 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
             can be in any order. If a numpy array, columns must be in the
             same order as the training data.
 
-        Returns 
+        Returns
         -------
         percentiles: DataFrame
             the median lifetimes for the individuals. If the survival curve of an
@@ -1163,7 +1150,7 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
 
         Parameters
         ----------
-        
+
         X: numpy array or DataFrame
             a (n,d) covariate numpy array or DataFrame. If a DataFrame, columns
             can be in any order. If a numpy array, columns must be in the
@@ -1253,7 +1240,7 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
         columns : list, optional
             specifiy a subset of the columns to plot
         display_significance_code: bool, optional (default: True)
-            display asteriks beside statistically significant variables 
+            display asteriks beside statistically significant variables
         errorbar_kwargs:
             pass in additional plotting commands to matplotlib errorbar command
 
@@ -1266,13 +1253,13 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
         from matplotlib import pyplot as plt
 
         ax = errorbar_kwargs.get("ax", None) or plt.figure().add_subplot(111)
-        
-        errorbar_kwargs.setdefault('c', 'k')
-        errorbar_kwargs.setdefault('fmt', 's')
-        errorbar_kwargs.setdefault('markerfacecolor', 'white')
-        errorbar_kwargs.setdefault('markeredgewidth', 1.25)
-        errorbar_kwargs.setdefault('elinewidth', 1.25)
-        errorbar_kwargs.setdefault('capsize', 3)
+
+        errorbar_kwargs.setdefault("c", "k")
+        errorbar_kwargs.setdefault("fmt", "s")
+        errorbar_kwargs.setdefault("markerfacecolor", "white")
+        errorbar_kwargs.setdefault("markeredgewidth", 1.25)
+        errorbar_kwargs.setdefault("elinewidth", 1.25)
+        errorbar_kwargs.setdefault("capsize", 3)
 
         alpha2 = inv_normal_cdf((1.0 + self.alpha) / 2.0)
 
@@ -1288,7 +1275,7 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
 
         ax.errorbar(hazards[order], yaxis_locations, xerr=symmetric_errors[order], **errorbar_kwargs)
         best_ylim = ax.get_ylim()
-        ax.vlines(0, -2, len(columns)+1, linestyles='dashed', linewidths=1, alpha=0.65)
+        ax.vlines(0, -2, len(columns) + 1, linestyles="dashed", linewidths=1, alpha=0.65)
         ax.set_ylim(best_ylim)
 
         if display_significance_code:
@@ -1298,7 +1285,7 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
 
         plt.yticks(yaxis_locations, tick_labels)
         plt.xlabel("log(HR) (%g%% CI)" % (self.alpha * 100))
-        
+
         return ax
 
     def plot_covariate_groups(self, covariate, groups, **kwargs):
@@ -1340,18 +1327,18 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
     def check_assumptions(self, help=True):
         """section 5 in https://socialsciences.mcmaster.ca/jfox/Books/Companion/appendices/Appendix-Cox-Regression.pdf
         http://www.mwsug.org/proceedings/2006/stats/MWSUG-2006-SD08.pdf"""
-        
+
         pass
 
     @property
     def score_(self):
         """
         The concordance score (also known as the c-index) of the fit.  The c-index is a generalization of the AUC
-        to survival data, including censorships. 
-        
+        to survival data, including censorships.
+
         For this purpose, the ``score_`` is a measure of the predictive accuracy of the fitted model
-        onto the training dataset. It's analgous to the R^2 in linear models. 
-        
+        onto the training dataset. It's analgous to the R^2 in linear models.
+
         """
         # pylint: disable=access-member-before-definition
         if hasattr(self, "_concordance_score_"):

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -616,7 +616,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
         for (stratified_X, stratified_T, stratified_E, stratified_W), _ in self._partition_by_strata(X, T, E, weights):
             yield function(stratified_X, stratified_T, stratified_E, stratified_W, *args)
 
-    def _compute_martingale(self, X, T, E, weights, index=None):
+    def _compute_martingale(self, X, T, E, _weights, index=None):
         # TODO: decide if I want to attach T and E to the final dataframe...
         partial_hazard = self.predict_partial_hazard(X)[0].values
 
@@ -714,7 +714,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
 
             # There was atleast one event and no more ties remain. Time to sum.
             weighted_mean = np.zeros((1, d))
-            weighted_average = weight_count / tie_count
+            _weighted_average = weight_count / tie_count
 
             for l in range(tie_count):
 
@@ -761,7 +761,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
 
         return pd.DataFrame(score_residuals, columns=self.hazards_.columns, index=index)
 
-    def _compute_score_within_strata(self, X, T, E, weights):
+    def _compute_score_within_strata(self, X, _T, E, weights):
         # https://www.stat.tamu.edu/~carroll/ftp/gk001.pdf
         # lin1989
         # https://www.ics.uci.edu/~dgillen/STAT255/Handouts/lecture10.pdf
@@ -1324,7 +1324,7 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
         self.baseline_survival_.plot(ax=ax, ls="--")
         return ax
 
-    def check_assumptions(self, help=True):
+    def check_assumptions(self, help_me=True):
         """section 5 in https://socialsciences.mcmaster.ca/jfox/Books/Companion/appendices/Appendix-Cox-Regression.pdf
         http://www.mwsug.org/proceedings/2006/stats/MWSUG-2006-SD08.pdf"""
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -618,6 +618,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
 
     def _compute_martingale(self, X, T, E, _weights, index=None):
         # TODO: decide if I want to attach T and E to the final dataframe...
+        # TODO: _weights unused
         partial_hazard = self.predict_partial_hazard(X)[0].values
 
         if not self.strata:
@@ -714,6 +715,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
 
             # There was atleast one event and no more ties remain. Time to sum.
             weighted_mean = np.zeros((1, d))
+            # TODO: _weighted_average unused
             _weighted_average = weight_count / tie_count
 
             for l in range(tie_count):
@@ -767,6 +769,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
         # https://www.ics.uci.edu/~dgillen/STAT255/Handouts/lecture10.pdf
         # Assumes X already sorted by T
         # TODO: doesn't handle ties.
+        # TODO: _T unused
 
         n, d = X.shape
 

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -104,10 +104,10 @@ def add_at_risk_counts(*fitters, **kwargs):
         # There are equivalent
         add_at_risk_counts(f1, f2)
         add_at_risk_counts(f1, f2, ax=ax, fig=fig)
-        
+
         # This overrides the labels
         add_at_risk_counts(f1, f2, labels=['fitter one', 'fitter two'])
-        
+
         # This hides the labels
         add_at_risk_counts(f1, f2, labels=None)
     """
@@ -332,16 +332,8 @@ def plot_estimate(
       ax: a pyplot axis object
     """
 
-    config = PlotEstimateConfig(
-        cls,
-        estimate,
-        loc,
-        iloc,
-        show_censors,
-        censor_styles,
-        bandwidth,
-        **kwargs)
-    
+    config = PlotEstimateConfig(cls, estimate, loc, iloc, show_censors, censor_styles, bandwidth, **kwargs)
+
     dataframe_slicer = create_dataframe_slicer(iloc, loc)
 
     if show_censors and cls.event_table["censored"].sum() > 0:
@@ -350,7 +342,7 @@ def plot_estimate(
         times = dataframe_slicer(cls.event_table.loc[(cls.event_table["censored"] > 0)]).index.values.astype(float)
         v = cls.predict(times)
         config.ax.plot(times, v, linestyle="None", color=config.colour, **cs)
-    
+
     dataframe_slicer(config.estimate_).plot(**kwargs)
 
     # plot confidence intervals
@@ -390,15 +382,7 @@ def plot_estimate(
 
 
 class PlotEstimateConfig:
-    def __init__(self,
-                 cls,
-                 estimate,
-                 loc,
-                 iloc,
-                 show_censors,
-                 censor_styles,
-                 bandwidth,
-                 **kwargs):
+    def __init__(self, cls, estimate, loc, iloc, show_censors, censor_styles, bandwidth, **kwargs):
         self.estimate = estimate
         self.loc = loc
         self.iloc = iloc
@@ -418,13 +402,15 @@ class PlotEstimateConfig:
         set_kwargs_drawstyle(kwargs)
 
         if self.estimate is None:
-            self.estimate = cls._estimate_name # qqUMI fix
+            self.estimate = cls._estimate_name  # qqUMI fix
 
         if estimate == "hazard_":
             if bandwidth is None:
                 raise ValueError("Must specify a bandwidth parameter in the call to plot_hazard.")
             self.estimate_ = cls.smoothed_hazard_(bandwidth)
-            self.confidence_interval_ = cls.smoothed_hazard_confidence_intervals_(bandwidth, hazard_=self.estimate_.values[:, 0])
+            self.confidence_interval_ = cls.smoothed_hazard_confidence_intervals_(
+                bandwidth, hazard_=self.estimate_.values[:, 0]
+            )
         else:
             self.estimate_ = getattr(cls, estimate)
             self.confidence_interval_ = getattr(cls, "confidence_interval_")

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -55,17 +55,17 @@ class ConvergenceWarning(RuntimeWarning):
 
 def qth_survival_times(q, survival_functions, cdf=False):
     """
-    Find the times when one or more survival functions reach the qth percentile. 
+    Find the times when one or more survival functions reach the qth percentile.
 
     Parameters
     ----------
-    q: float 
+    q: float
       a float between 0 and 1 that represents the time when the survival function hit's the qth percentile.
     survival_functions: a (n,d) dataframe or numpy array.
       If dataframe, will return index values (actual times)
       If numpy array, will return indices.
     cdf: boolean, optional
-      When doing left-censored data, cdf=True is used. 
+      When doing left-censored data, cdf=True is used.
 
     Returns
     -------
@@ -100,15 +100,15 @@ def qth_survival_times(q, survival_functions, cdf=False):
 
 def qth_survival_time(q, survival_function, cdf=False):
     """
-    Returns the time when a single survival function reachess the qth percentile. 
+    Returns the time when a single survival function reachess the qth percentile.
 
     Parameters
     ----------
-    q: float 
+    q: float
       a float between 0 and 1 that represents the time when the survival function hit's the qth percentile.
     survival_function: Series or single-column DataFrame.
     cdf: boolean, optional
-      When doing left-censored data, cdf=True is used. 
+      When doing left-censored data, cdf=True is used.
 
     Returns
     -------
@@ -150,7 +150,7 @@ def group_survival_table_from_events(
 
     Parameters
     ----------
-    groups: a (n,) array 
+    groups: a (n,) array
       individuals' group ids.
     durations: a (n,)  array
       durations of each individual
@@ -262,9 +262,9 @@ def survival_table_from_events(
     """
     Parameters
     ----------
-    death_times: (n,) array 
+    death_times: (n,) array
       represent the event times
-    event_observed: (n,) array 
+    event_observed: (n,) array
       1 if observed event, 0 is censored event.
     birth_times: a (n,) array, optional
       representing when the subject was first observed. A subject's death event is then at [birth times + duration observed].
@@ -279,7 +279,7 @@ def survival_table_from_events(
     intervals: iterable, optional
       Default None, otherwise a list/(n,1) array of interval edge measures. If left as None
       while collapse=True, then Freedman-Diaconis rule for histogram bins will be used to determine intervals.
-    
+
     Returns
     -------
     output: DataFrame
@@ -386,7 +386,7 @@ def survival_events_from_table(event_table, observed_deaths_col="observed", cens
     -------
     T: array
       durations of observation -- one element for each individual in the population.
-    C: array 
+    C: array
       event observations -- one element for each individual in the population. 1 if observed, 0 else.
 
     Example
@@ -435,7 +435,7 @@ def datetimes_to_durations(
         iterable representing end times. These can be strings, or datetimes. These values can be None, or an empty string, which corresponds to censorship.
     fill_date: datetime, optional (default=datetime.Today())
         the date to use if end_times is a None or empty string. This corresponds to last date
-        of observation. Anything after this date is also censored. 
+        of observation. Anything after this date is also censored.
     freq: string, optional (default='D')
         the units of time to use.  See Pandas 'freq'. Default 'D' for days.
     day_first: boolean, optional (default=False)
@@ -445,9 +445,9 @@ def datetimes_to_durations(
 
     Returns
     -------
-    T: numpy array 
+    T: numpy array
         array of floats representing the durations with time units given by freq.
-    C: numpy array 
+    C: numpy array
         boolean array of event observations: 1 if death observed, 0 else.
 
     """
@@ -549,7 +549,7 @@ def concordance_index(event_times, predicted_scores, event_observed=None):
 
     Returns
     -------
-    c-index: float 
+    c-index: float
       a value between 0 and 1.
     """
     event_times = np.asarray(event_times, dtype=float)
@@ -604,7 +604,7 @@ def k_fold_cross_validation(
     """
     Perform cross validation on a dataset. If multiple models are provided,
     all models will train on each of the k subsets.
-    
+
     Parameters
     ----------
     fitter(s): one or several objects which possess a method:
@@ -1274,7 +1274,7 @@ def to_long_format(df, duration_col):
         a Dataframe in the standard survival analysis form (one for per observation, with covariates, duration and event flag)
     duration_col: string
         string representing the column in df that represents the durations of each subject.
-    
+
     Returns
     -------
     long_form_df: DataFrame
@@ -1529,6 +1529,7 @@ def _to_array(x):
     if not isinstance(x, collections.Iterable):
         return np.array([x])
     return np.asarray(x)
+
 
 def _to_list(x):
     if not isinstance(x, list):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -868,7 +868,6 @@ class TestRegressionFitters:
 
 
 class TestCoxPHFitter:
-
     def test_schoenfeld_residuals_no_strata_but_with_censorship(self):
         """
         library(survival)
@@ -883,17 +882,17 @@ class TestCoxPHFitter:
         """
         df = pd.DataFrame(
             {
-                "var1": [-0.71163379, -0.87481227,  0.99557251, -0.83649751,  1.42737105],
-                "T": [ 5, 6, 7, 8, 9],
+                "var1": [-0.71163379, -0.87481227, 0.99557251, -0.83649751, 1.42737105],
+                "T": [5, 6, 7, 8, 9],
                 "E": [1, 1, 1, 1, 1],
             }
         )
 
         cph = CoxPHFitter()
-        cph.fit(df, 'T', 'E')
+        cph.fit(df, "T", "E")
 
-        results = cph.compute_residuals(df, 'schoenfeld')
-        expected = pd.DataFrame([-0.2165282492, -0.4573005808, 1.1117589644, -0.4379301344,  0.0], columns=['var1'])
+        results = cph.compute_residuals(df, "schoenfeld")
+        expected = pd.DataFrame([-0.2165282492, -0.4573005808, 1.1117589644, -0.4379301344, 0.0], columns=["var1"])
         assert_frame_equal(results, expected, check_less_precise=3)
 
     def test_schoenfeld_residuals_with_censorship_and_ties(self):
@@ -910,19 +909,18 @@ class TestCoxPHFitter:
         """
         df = pd.DataFrame(
             {
-                "var1": [-0.71163379, -0.87481227,  0.99557251, -0.83649751,  1.42737105],
-                "T": [ 6, 6, 7, 8, 9],
+                "var1": [-0.71163379, -0.87481227, 0.99557251, -0.83649751, 1.42737105],
+                "T": [6, 6, 7, 8, 9],
                 "E": [1, 1, 1, 0, 1],
             }
         )
 
         cph = CoxPHFitter()
-        cph.fit(df, 'T', 'E')
+        cph.fit(df, "T", "E")
 
-        results = cph.compute_residuals(df, 'schoenfeld')
-        expected = pd.DataFrame([-0.3903793341, -0.5535578141,  0.9439371482, 0.0], columns=['var1'], index=[0, 1, 2, 4])
+        results = cph.compute_residuals(df, "schoenfeld")
+        expected = pd.DataFrame([-0.3903793341, -0.5535578141, 0.9439371482, 0.0], columns=["var1"], index=[0, 1, 2, 4])
         assert_frame_equal(results, expected, check_less_precise=3)
-
 
     def test_schoenfeld_residuals_with_weights(self):
         """
@@ -938,18 +936,18 @@ class TestCoxPHFitter:
         """
         df = pd.DataFrame(
             {
-                "var1": [-0.71163379, -0.87481227,  0.99557251, -0.83649751,  1.42737105],
+                "var1": [-0.71163379, -0.87481227, 0.99557251, -0.83649751, 1.42737105],
                 "T": [5, 6, 7, 8, 9],
                 "E": [1, 1, 1, 1, 1],
-                "w": [0.5, 1.0, 3.0, 1.0, 1.0]
+                "w": [0.5, 1.0, 3.0, 1.0, 1.0],
             }
         )
 
         cph = CoxPHFitter()
-        cph.fit(df, 'T', 'E', weights_col="w", robust=True)
+        cph.fit(df, "T", "E", weights_col="w", robust=True)
 
-        results = cph.compute_residuals(df, 'schoenfeld')
-        expected = pd.DataFrame([-0.6633324862, -0.9107785234,  0.6176009038, -0.6103579448, 0.0], columns=['var1'])
+        results = cph.compute_residuals(df, "schoenfeld")
+        expected = pd.DataFrame([-0.6633324862, -0.9107785234, 0.6176009038, -0.6103579448, 0.0], columns=["var1"])
         assert_frame_equal(results, expected, check_less_precise=3)
 
     def test_schoenfeld_residuals_with_strata(self):
@@ -968,26 +966,26 @@ class TestCoxPHFitter:
 
         df = pd.DataFrame(
             {
-                "var1": [-0.71163379, -0.87481227,  0.99557251, -0.83649751,  1.42737105],
-                "T": [ 6, 6, 7, 8, 9],
+                "var1": [-0.71163379, -0.87481227, 0.99557251, -0.83649751, 1.42737105],
+                "T": [6, 6, 7, 8, 9],
                 "E": [1, 1, 1, 1, 1],
-                "s": [1, 2, 2, 1, 1]
+                "s": [1, 2, 2, 1, 1],
             }
         )
 
         cph = CoxPHFitter()
-        cph.fit(df, 'T', 'E', strata=['s'])
+        cph.fit(df, "T", "E", strata=["s"])
 
-        results = cph.compute_residuals(df, 'schoenfeld')
-        expected = pd.DataFrame([ 5.898252711e-02, -2.074325854e-02,  0.0, -3.823926885e-02, 0.0], columns=['var1'])
+        results = cph.compute_residuals(df, "schoenfeld")
+        expected = pd.DataFrame([5.898252711e-02, -2.074325854e-02, 0.0, -3.823926885e-02, 0.0], columns=["var1"])
         assert_frame_equal(results, expected, check_less_precise=3)
 
     def test_scaled_schoenfeld_residuals_with_weights(self, regression_dataset):
 
         cph = CoxPHFitter()
-        cph.fit(regression_dataset, 'T', 'E', weights_col='var3')
+        cph.fit(regression_dataset, "T", "E", weights_col="var3")
 
-        results = cph.compute_residuals(regression_dataset, 'scaled_schoenfeld')
+        results = cph.compute_residuals(regression_dataset, "scaled_schoenfeld")
         print(results.values + cph.hazards_.values)
         assert False
 
@@ -996,55 +994,49 @@ class TestCoxPHFitter:
 
         df = pd.DataFrame(
             {
-                "var1": [-0.71163379, -0.87481227,  0.99557251, -0.83649751,  1.42737105],
-                "T": [ 6, 6, 7, 8, 9],
-                "s": [1, 2, 2, 1, 1]
+                "var1": [-0.71163379, -0.87481227, 0.99557251, -0.83649751, 1.42737105],
+                "T": [6, 6, 7, 8, 9],
+                "s": [1, 2, 2, 1, 1],
             }
         )
-        df.index = ['A', 'B', 'C', 'D', 'E']
-        
-        cph.fit(df, 'T')
+        df.index = ["A", "B", "C", "D", "E"]
 
-        for kind in {'martingale', 'schoenfeld', 'score', 'delta_beta', 'deviance'}:
+        cph.fit(df, "T")
+
+        for kind in {"martingale", "schoenfeld", "score", "delta_beta", "deviance"}:
             resids = cph.compute_residuals(df, kind)
-            assert resids.sort_index().index.tolist() == ['A', 'B', 'C', 'D', 'E']
+            assert resids.sort_index().index.tolist() == ["A", "B", "C", "D", "E"]
 
     def test_original_index_is_respected_in_all_residual_tests_with_strata(self):
         cph = CoxPHFitter()
 
         df = pd.DataFrame(
             {
-                "var1": [-0.71163379, -0.87481227,  0.99557251, -0.83649751,  1.42737105],
-                "T": [ 6, 6, 7, 8, 9],
-                "s": [1, 2, 2, 1, 1]
+                "var1": [-0.71163379, -0.87481227, 0.99557251, -0.83649751, 1.42737105],
+                "T": [6, 6, 7, 8, 9],
+                "s": [1, 2, 2, 1, 1],
             }
         )
-        df.index = ['A', 'B', 'C', 'D', 'E']
-        
-        cph.fit(df, 'T', strata=["s"])
+        df.index = ["A", "B", "C", "D", "E"]
 
-        for kind in {'martingale', 'schoenfeld', 'score', 'delta_beta', 'deviance'}:
+        cph.fit(df, "T", strata=["s"])
+
+        for kind in {"martingale", "schoenfeld", "score", "delta_beta", "deviance"}:
             resids = cph.compute_residuals(df, kind)
-            assert resids.sort_index().index.tolist() == ['A', 'B', 'C', 'D', 'E']
-
+            assert resids.sort_index().index.tolist() == ["A", "B", "C", "D", "E"]
 
     def test_martingale_residuals(self, regression_dataset):
 
         cph = CoxPHFitter()
-        cph.fit(regression_dataset, 'T', 'E')
+        cph.fit(regression_dataset, "T", "E")
 
-        results = cph.compute_residuals(regression_dataset, 'martingale')
+        results = cph.compute_residuals(regression_dataset, "martingale")
         npt.assert_allclose(results.loc[0], -2.315035744901, rtol=1e-05)
         npt.assert_allclose(results.loc[1], 0.774216356429, rtol=1e-05)
         npt.assert_allclose(results.loc[199], 0.868510420157, rtol=1e-05)
 
-
     def test_error_is_raised_if_using_non_numeric_data_in_prediction(self):
-        df = pd.DataFrame({
-            "t": [1.0, 2.0, 3.0, 4.0], 
-            "int_": [1, -1, 0, 0], 
-            "float_": [1.2, -0.5, 0.0, 0.1]
-        })
+        df = pd.DataFrame({"t": [1.0, 2.0, 3.0, 4.0], "int_": [1, -1, 0, 0], "float_": [1.2, -0.5, 0.0, 0.1]})
 
         cp = CoxPHFitter()
         cp.fit(df, duration_col="t")


### PR DESCRIPTION
For #577 
Ran formatter and addressed linting errors.

I added `_` underscores to the unused arguments but I would reccomend they just be removed and add a comment or TODO if they were meant as placeholders.

```
Messages
========

lifelines/fitters/coxph_fitter.py
  Line: 619
    pylint: unused-argument / Unused argument 'weights' (col 43)
  Line: 717
    pylint: unused-variable / Unused variable 'weighted_average' (col 12)
  Line: 764
    pylint: unused-argument / Unused argument 'T' (col 46)
  Line: 1327
    pylint: redefined-builtin / Redefining built-in 'help' (col 32)



Check Information
=================
         Started: 2018-12-21 06:46:14.057368
        Finished: 2018-12-21 06:47:00.913090
      Time Taken: 46.86 seconds
       Formatter: grouped
        Profiles: .prospector.yaml, strictness_medium, strictness_high, strictness_veryhigh, no_doc_warnings, no_member_warnings, no_test_warnings
      Strictness: from profile
  Libraries Used:
       Tools Run: dodgy, mccabe, pep8, profile-validator, pyflakes, pylint, pyroma
  Messages Found: 4
```

-------------------------------

After addressing the above issues I'm now seeing this...

I didn't want to suppress this in-case it has something to do with the failing unit-tests.

```
lifelines/generate_datasets.py
  Line: 26
    pylint: invalid-unary-operand-type / bad operand type for unary -: result (col 20)
    pylint: invalid-unary-operand-type / bad operand type for unary -: tuple (col 20)
```

