### PR TITLE
Enforce 2DP when printing summary

### DIFF
--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -498,7 +498,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
         df = self.summary
         # Significance codes last
         df[""] = [significance_code(p) for p in df["p"]]
-        print(df.to_string(float_format=lambda f: "{:4.4f}".format(f)))
+        print(df.to_string(float_format=lambda f: "{:4.2f}".format(f)))
         # Significance code explanation
         print("---")
         print(significance_codes_as_text(), end="\n\n")

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -934,7 +934,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
         df = self.summary
         # Significance codes last
         df[""] = [significance_code(p) for p in df["p"]]
-        print(df.to_string(float_format=lambda f: "{:4.4f}".format(f)))
+        print(df.to_string(float_format=lambda f: "{:4.2f}".format(f)))
         # Significance code explanation
         print("---")
         print(significance_codes_as_text(), end="\n\n")

--- a/lifelines/fitters/exponential_fitter.py
+++ b/lifelines/fitters/exponential_fitter.py
@@ -178,6 +178,6 @@ class ExponentialFitter(UnivariateFitter):
 
         df = self.summary
         df[""] = [significance_code(p) for p in df["p"]]
-        print(df.to_string(float_format=lambda f: "{:4.4f}".format(f)))
+        print(df.to_string(float_format=lambda f: "{:4.2f}".format(f)))
         print("---")
         print(significance_codes_as_text(), end="\n\n")

--- a/lifelines/fitters/weibull_fitter.py
+++ b/lifelines/fitters/weibull_fitter.py
@@ -316,6 +316,6 @@ class WeibullFitter(UnivariateFitter):
 
         df = self.summary
         df[""] = [significance_code(p) for p in df["p"]]
-        print(df.to_string(float_format=lambda f: "{:4.4f}".format(f)))
+        print(df.to_string(float_format=lambda f: "{:4.2f}".format(f)))
         print("---")
         print(significance_codes_as_text(), end="\n\n")

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -503,7 +503,7 @@ class StatisticalResult(object):
         df[""] = [significance_code(p) for p in self.p_values]
 
         s = ""
-        s += "\n" + meta_data + "\n\n"
+        s += "\n" + meta_data + "\n"
         s += "---\n"
         s += df.to_string(float_format=lambda f: "{:4.2f}".format(f), index=self.names is not None)
 

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -484,7 +484,7 @@ class StatisticalResult(object):
 
         s = ""
         s += "\n" + meta_data + "\n\n"
-        s += df.to_string(float_format=lambda f: "{:4.4f}".format(f), index=self.names is not None)
+        s += df.to_string(float_format=lambda f: "{:4.2f}".format(f), index=self.names is not None)
 
         s += "\n---"
         s += "\n" + significance_codes_as_text()


### PR DESCRIPTION
Fixes Issue #578 
There are currently a lot of broken tests on this branch.  These changes don't break any more tests, but once they're sorted out they may need further fixes for this stuff

I searched for all instances of `print_summary` - if they're named anything else I will have missed them