### PR TITLE
[WIP] Add Development section to README 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,3 @@ repos:
     hooks:
     - id: black
       args: ["--line-length", "120"]
-      language_version: python3.6

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ kmf.plot()
 ### Roadmap
 You can find the roadmap for lifelines [here](https://www.notion.so/camdp/6e2965207f564eb2a3e48b5937873c14?v=47edda47ab774ca2ac7532bb0c750559).
 
+### Development
+
+#### Setting up a lifelines development environment
+
+1. From the root directory of `lifelines` activate your virtual environment (if you plan to use one).
+2. Install the development requirements and [`pre-commit`](https://pre-commit.com) hooks. If you are on Mac, Linux, or Windows WSL you can use the provided make file. Just type `make` into the console and you're ready to start developing.
+  * `pip install -r reqs/dev-requirements.txt`
+  * `pre-commit install`
+
 ### Citing lifelines
 
 You can use this badge below to generate a DOI and reference text for the latest related version of lifelines:

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -1,4 +1,6 @@
 -r base-requirements.txt
+# installs lifelines as editiable dependancy in develop mode
+-e .
 pytest
 coverage>=4.4
 pytest-cov

--- a/reqs/docs-requirements.txt
+++ b/reqs/docs-requirements.txt
@@ -1,2 +1,3 @@
+-r dev-requirements.txt
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Adding a short section to readme explaining how to use the provided `Makefile` to set up a dev environment, format their code and install/run the `pre-commit` hooks.

## Other changes
* Removed the language version for the `black` hook, to prevent hook failure if `python3.6` is not present.
* added `lifelines` as an editable dependency dev-requirement
* added the `dev-requirements.txt` to `doc-requirements.txt` so the developer doesn't need to execute 2 separate commands to install them. 