### PR TITLE
V0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Changelogs
 
+#### 0.16.2
+ - Fixed `CoxTimeVaryingFitter` to allow more than one variable to be stratafied
+ - Significant performance improvements for `CoxPHFitter` with dataset has lots of duplicate times. See https://github.com/CamDavidsonPilon/lifelines/issues/591
+
 #### 0.16.1
  - Fixed py2 division error in `concordance` method.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ copyright = "2014, Cam Davidson-Pilon"
 #
 # The short X.Y version.
 
-version = "0.16.1"
+version = "0.16.2"
 # The full version, including dev info
 release = version
 

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -385,8 +385,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
         gradient: (1, d) numpy array
         log_likelihood: float
         """
-        # import pdb
-        # pdb.set_trace()
+
         _, d = df.shape
         hessian = np.zeros((d, d))
         gradient = np.zeros(d)

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -198,7 +198,7 @@ class CoxTimeVaryingFitter(BaseFitter):
 
     def _partition_by_strata(self, X, stop_times_events, weights):
         for stratum, stratified_X in X.groupby(self.strata):
-            stratified_stop_times_events, stratified_W = (stop_times_events.loc[[stratum]], weights.loc[[stratum]])
+            stratified_stop_times_events, stratified_W = (stop_times_events.loc[stratum], weights.loc[stratum])
             yield (stratified_X, stratified_stop_times_events, stratified_W), stratum
 
     def _partition_by_strata_and_apply(self, X, stop_times_events, weights, function, *args):
@@ -454,16 +454,17 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
                     a1 = risk_phi_x_x / denom
 
                 # Gradient
-                partial_gradient += weighted_average * numer / denom
+                partial_gradient += numer / denom
                 # In case numer and denom both are really small numbers,
                 # make sure to do division before multiplications
-                a2 = np.outer(numer / denom, numer / denom)
+                t = numer[:, None] / denom
+                a2 = t.dot(t.T)
 
                 hessian -= weighted_average * (a1 - a2)
                 log_lik -= weighted_average * np.log(denom)
 
             # Values outside tie sum
-            gradient += x_death_sum - partial_gradient
+            gradient += x_death_sum - weighted_average * partial_gradient
             log_lik += dot(x_death_sum, beta)[0]
 
         return hessian, gradient.reshape(1, d), log_lik

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -628,8 +628,7 @@ See https://stats.idre.ucla.edu/other/mult-pkg/faq/general/faqwhat-is-complete-o
         gradient: (1, d) numpy array
         log_likelihood: float
         """
-        # import pdb
-        # pdb.set_trace()
+
         _, d = X.shape
         hessian = np.zeros((d, d))
         gradient = np.zeros(d)

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.16.1"
+__version__ = "0.16.2"

--- a/perf_tests/batch_vs_single.py
+++ b/perf_tests/batch_vs_single.py
@@ -1,0 +1,59 @@
+from time import time
+import pandas as pd
+import numpy as np
+from lifelines.datasets import load_rossi
+from lifelines import CoxPHFitter
+import statsmodels.api as sm
+
+# This compares the batch algorithm (in CTV) vs the single iteration algorithm (original in CPH)
+# N vs (% ties == unique(T) / N)
+
+
+ROSSI_ROWS = 432
+results = {}
+
+
+for n_copies in [1, 2, 4, 6, 8, 10, 12, 14]:
+
+    # lower percents means more ties.
+    # original rossi dataset has 0.113
+    for fraction in np.linspace(0.01, 0.30, 10):
+        print(n_copies, fraction)
+
+        df = pd.concat([load_rossi()] * n_copies)
+        n_unique_durations = int(df.shape[0] * fraction) + 1
+        unique_durations = np.round(np.random.exponential(10, size=n_unique_durations), 5)
+
+        df["week"] = np.tile(unique_durations, int(np.ceil(1 / fraction)))[: df.shape[0]]
+
+        cph_batch = CoxPHFitter()
+        start_time = time()
+        cph_batch.fit(df, "week", "arrest", batch_mode=True)
+        batch_time = time() - start_time
+
+        cph_single = CoxPHFitter()
+        start_time = time()
+        cph_single.fit(df, "week", "arrest", batch_mode=False)
+        single_time = time() - start_time
+
+        print({"batch": batch_time, "single": single_time})
+        results[(n_copies * ROSSI_ROWS, fraction)] = {"batch": batch_time, "single": single_time}
+
+results = pd.DataFrame(results).T.sort_index()
+results["ratio"] = results["batch"] / results["single"]
+print(results)
+
+results = results.reset_index()
+results = results.rename(columns={"level_0": "N", "level_1": "frac"})
+
+
+results["N * frac"] = results["N"] * results["frac"]
+
+X = results[["N", "frac", "N * frac"]]
+X = sm.add_constant(X)
+
+Y = results["ratio"]
+
+
+model = sm.OLS(Y, X).fit()
+model.summary()

--- a/perf_tests/cp_perf_test.py
+++ b/perf_tests/cp_perf_test.py
@@ -11,10 +11,10 @@ if __name__ == "__main__":
     from lifelines.datasets import load_rossi
 
     df = load_rossi()
-    df = pd.concat([df] * 5)
-    df['week'] = np.random.exponential(1, size=df.shape[0])
+    df = pd.concat([df] * 40)
+    # df['week'] = np.random.exponential(1, size=df.shape[0])
     cp = CoxPHFitter()
     start_time = time.time()
-    cp.fit(df, duration_col="week", event_col="arrest")
+    cp.fit(df, duration_col="week", event_col="arrest", batch_mode=False)
     print("--- %s seconds ---" % (time.time() - start_time))
     cp.print_summary()

--- a/perf_tests/cp_perf_test.py
+++ b/perf_tests/cp_perf_test.py
@@ -5,13 +5,16 @@
 if __name__ == "__main__":
     import pandas as pd
     import time
+    import numpy as np
 
     from lifelines import CoxPHFitter
     from lifelines.datasets import load_rossi
 
     df = load_rossi()
-    df = pd.concat([df] * 20)
+    df = pd.concat([df] * 5)
+    df['week'] = np.random.exponential(1, size=df.shape[0])
     cp = CoxPHFitter()
     start_time = time.time()
     cp.fit(df, duration_col="week", event_col="arrest")
     print("--- %s seconds ---" % (time.time() - start_time))
+    cp.print_summary()

--- a/perf_tests/ctv_perf_test.py
+++ b/perf_tests/ctv_perf_test.py
@@ -3,13 +3,16 @@ if __name__ == "__main__":
     import time
     import pandas as pd
     from lifelines import CoxTimeVaryingFitter
-    from lifelines.datasets import load_stanford_heart_transplants
+    from lifelines.datasets import load_rossi
+    from lifelines.utils import to_long_format
 
-    dfcv = load_stanford_heart_transplants()
-    dfcv = pd.concat([dfcv] * 50)
+    df = load_rossi()
+    df = pd.concat([df] * 20)
+    df = df.reset_index()
+    df = to_long_format(df, duration_col='week')
     ctv = CoxTimeVaryingFitter()
     start_time = time.time()
-    ctv.fit(dfcv, id_col="id", event_col="event", start_col="start", stop_col="stop")
+    ctv.fit(df, id_col="index", event_col="arrest", start_col="start", stop_col="stop", strata=['wexp', 'prio'])
     time_took = time.time() - start_time
     print("--- %s seconds ---" % time_took)
     ctv.print_summary()

--- a/perf_tests/ctv_perf_test.py
+++ b/perf_tests/ctv_perf_test.py
@@ -9,10 +9,10 @@ if __name__ == "__main__":
     df = load_rossi()
     df = pd.concat([df] * 20)
     df = df.reset_index()
-    df = to_long_format(df, duration_col='week')
+    df = to_long_format(df, duration_col="week")
     ctv = CoxTimeVaryingFitter()
     start_time = time.time()
-    ctv.fit(df, id_col="index", event_col="arrest", start_col="start", stop_col="stop", strata=['wexp', 'prio'])
+    ctv.fit(df, id_col="index", event_col="arrest", start_col="start", stop_col="stop", strata=["wexp", "prio"])
     time_took = time.time() - start_time
     print("--- %s seconds ---" % time_took)
     ctv.print_summary()

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1158,8 +1158,8 @@ Likelihood ratio test = 33.27 on 7 df, log(p)=-10.65
         l, u, _ = cph._get_efron_values(X, T, E, weights, beta)
         l = -l
 
-        assert np.abs(l[0][0] - 77.13) < 0.05
         assert np.abs(u[0] - -2.51) < 0.05
+        assert np.abs(l[0][0] - 77.13) < 0.05
         beta = beta + u / l
         assert np.abs(beta - -0.0326) < 0.05
 
@@ -2873,6 +2873,10 @@ Likelihood ratio test = 15.11 on 4 df, log(p)=-5.41
         npt.assert_allclose(summary["se(coef)"].tolist(), [0.0139, 0.3707, 0.0710], atol=0.001)
         npt.assert_allclose(summary["z"].tolist(), [2.11, -1.67, -2.15], atol=0.01)
 
+
+    def test_ctv_with_multiple_strata(self, ctv, heart):
+        ctv.fit(heart, id_col="id", event_col="event", strata=["transplant", "surgery"])
+        assert True
 
 class TestAalenJohansenFitter:
     @pytest.fixture  # pytest fixtures are functions that are "executed" before every test

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -2873,10 +2873,10 @@ Likelihood ratio test = 15.11 on 4 df, log(p)=-5.41
         npt.assert_allclose(summary["se(coef)"].tolist(), [0.0139, 0.3707, 0.0710], atol=0.001)
         npt.assert_allclose(summary["z"].tolist(), [2.11, -1.67, -2.15], atol=0.01)
 
-
     def test_ctv_with_multiple_strata(self, ctv, heart):
         ctv.fit(heart, id_col="id", event_col="event", strata=["transplant", "surgery"])
         assert True
+
 
 class TestAalenJohansenFitter:
     @pytest.fixture  # pytest fixtures are functions that are "executed" before every test

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1222,6 +1222,7 @@ Likelihood ratio test = 33.27 on 7 df, log(p)=-10.65
         assert np.abs(beta - -0.0335) < 0.01
 
     def test_efron_newtons_method(self, data_nus, cph):
+        cph._batch_mode = False
         newton = cph._newton_rhaphson
         X, T, E, W = (data_nus[["x"]], data_nus["t"], data_nus["E"], pd.Series(np.ones_like(data_nus["t"])))
         assert np.abs(newton(X, T, E, W)[0][0] - -0.0335) < 0.0001

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1137,7 +1137,7 @@ Likelihood ratio test = 33.27 on 7 df, log(p)=-10.65
         cph.fit(data_nus, duration_col="t", event_col="E")
         assert abs(cph._log_likelihood - -12.7601409152) < 0.001
 
-    def test_efron_computed_by_hand_examples(self, data_nus, cph):
+    def test_single_efron_computed_by_hand_examples(self, data_nus, cph):
 
         X = data_nus["x"][:, None]
         T = data_nus["t"]
@@ -1155,7 +1155,7 @@ Likelihood ratio test = 33.27 on 7 df, log(p)=-10.65
         # tests from http://courses.nus.edu.sg/course/stacar/internet/st3242/handouts/notes3.pdf
         beta = np.array([[0]])
 
-        l, u, _ = cph._get_efron_values(X, T, E, weights, beta)
+        l, u, _ = cph._get_efron_values_single(X, T, E, weights, beta)
         l = -l
 
         assert np.abs(u[0] - -2.51) < 0.05
@@ -1163,7 +1163,7 @@ Likelihood ratio test = 33.27 on 7 df, log(p)=-10.65
         beta = beta + u / l
         assert np.abs(beta - -0.0326) < 0.05
 
-        l, u, _ = cph._get_efron_values(X, T, E, weights, beta)
+        l, u, _ = cph._get_efron_values_single(X, T, E, weights, beta)
         l = -l
 
         assert np.abs(l[0][0] - 72.83) < 0.05
@@ -1171,7 +1171,49 @@ Likelihood ratio test = 33.27 on 7 df, log(p)=-10.65
         beta = beta + u / l
         assert np.abs(beta - -0.0325) < 0.01
 
-        l, u, _ = cph._get_efron_values(X, T, E, weights, beta)
+        l, u, _ = cph._get_efron_values_single(X, T, E, weights, beta)
+        l = -l
+
+        assert np.abs(l[0][0] - 72.70) < 0.01
+        assert np.abs(u[0] - -0.000061) < 0.01
+        beta = beta + u / l
+        assert np.abs(beta - -0.0335) < 0.01
+
+    def test_batch_efron_computed_by_hand_examples(self, data_nus, cph):
+
+        X = data_nus["x"][:, None]
+        T = data_nus["t"]
+        E = data_nus["E"]
+        weights = np.ones_like(T)
+
+        # Enforce numpy arrays
+        X = np.array(X)
+        T = np.array(T)
+        E = np.array(E)
+
+        # Want as bools
+        E = E.astype(bool)
+
+        # tests from http://courses.nus.edu.sg/course/stacar/internet/st3242/handouts/notes3.pdf
+        beta = np.array([[0]])
+
+        l, u, _ = cph._get_efron_values_batch(X, T, E, weights, beta)
+        l = -l
+
+        assert np.abs(u[0] - -2.51) < 0.05
+        assert np.abs(l[0][0] - 77.13) < 0.05
+        beta = beta + u / l
+        assert np.abs(beta - -0.0326) < 0.05
+
+        l, u, _ = cph._get_efron_values_batch(X, T, E, weights, beta)
+        l = -l
+
+        assert np.abs(l[0][0] - 72.83) < 0.05
+        assert np.abs(u[0] - -0.069) < 0.05
+        beta = beta + u / l
+        assert np.abs(beta - -0.0325) < 0.01
+
+        l, u, _ = cph._get_efron_values_batch(X, T, E, weights, beta)
         l = -l
 
         assert np.abs(l[0][0] - 72.70) < 0.01


### PR DESCRIPTION
#### 0.16.2
 - Fixed `CoxTimeVaryingFitter` to allow more than one variable to be stratafied
 - Significant performance improvements for `CoxPHFitter` with dataset has lots of duplicate times. See https://github.com/CamDavidsonPilon/lifelines/issues/591

For context, lifelines 0.14.0 `CoxPHFitter` did 20 Rossi datasets in ~6 seconds. We now do it in ~1.1 seconds. 

closes #591