### PR TITLE
ci_updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ script:
   - make test
 after_success:
   - coveralls
+  # run linter but don't fail for errors
+  - make lint
 # Don't want notifications
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 init:
 ifeq ($(TRAVIS), true)
 		pip install -r reqs/travis-requirements.txt
+		pip list --local
 else
 		pip install -r reqs/dev-requirements.txt
 		pre-commit install

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![DOI](https://zenodo.org/badge/12420595.svg)](https://zenodo.org/badge/latestdoi/12420595)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/CamDavidsonPilon/lifelines.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/alerts/)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/CamDavidsonPilon/lifelines.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/alerts/)
 
 
 [What is survival analysis and why should I learn it?](http://lifelines.readthedocs.org/en/latest/Survival%20Analysis%20intro.html)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/CamDavidsonPilon/lifelines.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/CamDavidsonPilon/lifelines.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/context:python)
 [![Join the chat at https://gitter.im/python-lifelines/Lobby](https://badges.gitter.im/python-lifelines/Lobby.svg)](https://gitter.im/python-lifelines/Lobby)
-[![DOI](https://zenodo.org/badge/12420595.svg)](https://zenodo.org/badge/latestdoi/12420595)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![DOI](https://zenodo.org/badge/12420595.svg)](https://zenodo.org/badge/latestdoi/12420595)
 
 
 [What is survival analysis and why should I learn it?](http://lifelines.readthedocs.org/en/latest/Survival%20Analysis%20intro.html)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 [![PyPI version](https://badge.fury.io/py/lifelines.svg)](https://badge.fury.io/py/lifelines)
 [![Build Status](https://travis-ci.org/CamDavidsonPilon/lifelines.svg?branch=master)](https://travis-ci.org/CamDavidsonPilon/lifelines)
 [![Coverage Status](https://coveralls.io/repos/github/CamDavidsonPilon/lifelines/badge.svg?branch=master)](https://coveralls.io/github/CamDavidsonPilon/lifelines?branch=master)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/CamDavidsonPilon/lifelines.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/alerts/)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/CamDavidsonPilon/lifelines.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/context:python)
 [![Join the chat at https://gitter.im/python-lifelines/Lobby](https://badges.gitter.im/python-lifelines/Lobby.svg)](https://gitter.im/python-lifelines/Lobby)
 [![DOI](https://zenodo.org/badge/12420595.svg)](https://zenodo.org/badge/latestdoi/12420595)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/CamDavidsonPilon/lifelines.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/alerts/)
 
 
 [What is survival analysis and why should I learn it?](http://lifelines.readthedocs.org/en/latest/Survival%20Analysis%20intro.html)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Join the chat at https://gitter.im/python-lifelines/Lobby](https://badges.gitter.im/python-lifelines/Lobby.svg)](https://gitter.im/python-lifelines/Lobby)
 [![DOI](https://zenodo.org/badge/12420595.svg)](https://zenodo.org/badge/latestdoi/12420595)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/CamDavidsonPilon/lifelines.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/alerts/)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/CamDavidsonPilon/lifelines.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/alerts/)
 
 
 [What is survival analysis and why should I learn it?](http://lifelines.readthedocs.org/en/latest/Survival%20Analysis%20intro.html)

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -1,10 +1,10 @@
 -r base-requirements.txt
 # installs lifelines as editiable dependancy in develop mode
 -e .
-pytest
+pytest>=3.6
 pytest-icdiff;python_version > '3.5'
 coverage>=4.4
-pytest-cov<=v2.6.0
+pytest-cov
 pypandoc
 prospector[with_pyroma]
 pre-commit

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -4,7 +4,7 @@
 pytest
 pytest-icdiff;python_version > '3.5'
 coverage>=4.4
-pytest-cov
+pytest-cov<=v2.6.0
 pypandoc
 prospector[with_pyroma]
 pre-commit


### PR DESCRIPTION
Because of all the checks being done in the TravisCI things are getting a little bit flakey.
Made a few changes to hopefully reduce it's flakeyness like running the linters after the build has already succeeded. 

Something that could also help is to seperate some of the responsibilities. Right knowing that the Travis build failed doesn't mean very much. It could be some minor linting/formatting error, a dependency problem or actually a major bug. 

I suggest we start using [LGTM](https://lgtm.com/) as an additional CI tool in order to reduce some of the responsibility the TravisCI has. We can then also be more strict about failed Travis builds.  
https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/alerts/?mode=list
I went ahead and added badges for it to the repo, but it still requires an [admin to authorize CI access.](https://lgtm.com/projects/g/CamDavidsonPilon/lifelines/ci/)

### Changes
1. fix `pytest-cov` dependency issue
   * The version of pytest in the Travis environment was very old. Set  `pytest>=3.6`. (Latest version is `4.1`)
2. add back linting check but don't fail build because of it
3. added LGTM code quality badges
4. Fix the build