### PR TITLE
Correction for Stratified Cindex Calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt-get update
 install:
   - "pip install -r dev-requirements.txt"
-  - "pip install python-coveralls pytest-cov seaborn"
+  - "pip install python-coveralls 'coverage>=4.4' pytest-cov seaborn"
 # command to run tests
 script:
   - py.test -s --cov=lifelines -vv --block=False --cov-report term-missing

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+coverage
 pytest
 python-coveralls
 pytest-cov


### PR DESCRIPTION
Greetings Developers,
I came across inconsistent cindex calculations in stratified-mode between lifelines and R's survival,
I looked into the issue and realized that lifelines compares pairs across strata, which it shoudn't.
I have created this solution and tested it with R and it's 100% now consistent. 
Best--
Arya