### PR TITLE
Aalen johansen fixes

### DIFF
--- a/lifelines/fitters/aalen_johansen_fitter.py
+++ b/lifelines/fitters/aalen_johansen_fitter.py
@@ -30,16 +30,16 @@ class AalenJohansenFitter(UnivariateFitter):
         self._seed = seed  # Seed is for the jittering process
 
     def fit(
-        self,
-        durations,
-        event_observed,
-        event_of_interest,
-        timeline=None,
-        entry=None,
-        label="AJ_estimate",
-        alpha=None,
-        ci_labels=None,
-        weights=None,
+            self,
+            durations,
+            event_observed,
+            event_of_interest,
+            timeline=None,
+            entry=None,
+            label="AJ_estimate",
+            alpha=None,
+            ci_labels=None,
+            weights=None,
     ):  # pylint: disable=too-many-arguments,too-many-locals
         """
         Parameters
@@ -184,17 +184,16 @@ class AalenJohansenFitter(UnivariateFitter):
         for _, r in df.iterrows():
             sf = df.loc[df.index <= r.name].copy()
             F_t = float(r["Ft"])
-            sf["part1"] = ((F_t - sf["Ft"]) ** 2) * (
-                sf["observed"] / (sf["at_risk"] * (sf["at_risk"] - sf["observed"]))
-            )
-            sf["part2"] = (
-                ((sf["lagS"]) ** 2)
-                * sf[self.label_cmprisk]
-                * ((sf["at_risk"] - sf[self.label_cmprisk]))
-                / (sf["at_risk"] ** 3)
-            )
-            sf["part3"] = (F_t - sf["Ft"]) * sf["lagS"] * (sf[self.label_cmprisk] / (sf["at_risk"] ** 2))
-            variance = (np.sum(sf["part1"])) + (np.sum(sf["part2"])) - 2 * (np.sum(sf["part3"]))
+            variance = np.sum((F_t - sf["Ft"]) ** 2 *
+                              sf["observed"]
+                              / sf["at_risk"]
+                              / (sf["at_risk"] - sf["observed"])
+                              ) + np.sum(sf["lagS"] ** 2 / sf['at_risk']
+                                         * sf[self.label_cmprisk] / sf['at_risk']
+                                         * (sf["at_risk"] - sf[self.label_cmprisk]) / sf["at_risk"]
+                                         ) - 2 * np.sum((F_t - sf["Ft"]) / sf['at_risk'] *
+                                                        sf["lagS"] *
+                                                        sf[self.label_cmprisk] / sf["at_risk"])
             all_vars.append(variance)
         df["variance"] = all_vars
 

--- a/lifelines/fitters/aalen_johansen_fitter.py
+++ b/lifelines/fitters/aalen_johansen_fitter.py
@@ -197,16 +197,25 @@ class AalenJohansenFitter(UnivariateFitter):
         for _, r in df.iterrows():
             sf = df.loc[df.index <= r.name].copy()
             F_t = float(r["Ft"])
-            variance = np.sum((F_t - sf["Ft"]) ** 2 *
-                              sf["observed"]
-                              / sf["at_risk"]
-                              / (sf["at_risk"] - sf["observed"])
-                              ) + np.sum(sf["lagS"] ** 2 / sf['at_risk']
-                                         * sf[self.label_cmprisk] / sf['at_risk']
-                                         * (sf["at_risk"] - sf[self.label_cmprisk]) / sf["at_risk"]
-                                         ) - 2 * np.sum((F_t - sf["Ft"]) / sf['at_risk'] *
-                                                        sf["lagS"] *
-                                                        sf[self.label_cmprisk] / sf["at_risk"])
+            first_term = np.sum((F_t - sf["Ft"]) ** 2 *
+                                sf["observed"] /
+                                sf["at_risk"] /
+                                (sf["at_risk"] - sf["observed"])
+                                )
+            second_term = np.sum(sf["lagS"] ** 2 /
+                                 sf['at_risk'] *
+                                 sf[self.label_cmprisk] /
+                                 sf['at_risk'] *
+                                 (sf["at_risk"] - sf[self.label_cmprisk]) /
+                                 sf["at_risk"]
+                                 )
+            third_term = np.sum((F_t - sf["Ft"]) /
+                                sf['at_risk'] *
+                                sf["lagS"] *
+                                sf[self.label_cmprisk] /
+                                sf["at_risk"]
+                                )
+            variance = first_term + second_term - 2 * third_term
             all_vars.append(variance)
         df["variance"] = all_vars
 

--- a/lifelines/fitters/aalen_johansen_fitter.py
+++ b/lifelines/fitters/aalen_johansen_fitter.py
@@ -24,10 +24,11 @@ class AalenJohansenFitter(UnivariateFitter):
     slightly. This will be done automatically and generates a warning.
     """
 
-    def __init__(self, jitter_level=0.0001, seed=None, alpha=0.95):
+    def __init__(self, jitter_level=0.0001, seed=None, alpha=0.95, calculate_variance=True):
         UnivariateFitter.__init__(self, alpha=alpha)
         self._jitter_level = jitter_level
         self._seed = seed  # Seed is for the jittering process
+        self._calc_var = calculate_variance  # Optionally skips calculating variance to save time on bootstraps
 
     def fit(
             self,
@@ -122,9 +123,10 @@ class AalenJohansenFitter(UnivariateFitter):
         self.event_table = aj[
             ["removed", "observed", self.label_cmprisk, "censored", "entrance", "at_risk"]
         ]  # Event table
-        self.variance, self.confidence_interval_ = self._bounds(
-            aj["lagged_overall_survival"], alpha=alpha, ci_labels=ci_labels
-        )
+        if self._calc_var:
+            self.variance, self.confidence_interval_ = self._bounds(
+                aj["lagged_overall_survival"], alpha=alpha, ci_labels=ci_labels
+            )
         return self
 
     def _jitter(self, durations, event, jitter_level, seed=None):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -3302,14 +3302,12 @@ class TestAalenJohansenFitter:
         # Based on the new setup of ties, should not detect any ties as existing
         d = [1, 2, 2, 4, 5, 6]
         fitter.fit(durations=d, event_observed=[0, 1, 1, 1, 2, 0], event_of_interest=1)
-        print(fitter.event_table.index)
         npt.assert_equal(np.asarray([0, 1, 2, 4, 5, 6]), np.asarray(fitter.event_table.index))
 
     def test_updated_censor_ties(self, fitter):
         # Based on the new setup of ties, should not detect any ties as existing
         d = [1, 2, 2, 4, 5, 6]
         fitter.fit(durations=d, event_observed=[0, 0, 1, 1, 2, 0], event_of_interest=1)
-        print(fitter.event_table.index)
         npt.assert_equal(np.asarray([0, 1, 2, 4, 5, 6]), np.asarray(fitter.event_table.index))
 
     def test_event_table_is_correct(self, fitter, duration, event_observed):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -3293,9 +3293,24 @@ class TestAalenJohansenFitter:
         npt.assert_equal(np.any(np.not_equal(d, e)), True)
 
     def test_tied_input_data(self, fitter):
+        # Based on new setup of ties, this counts as a valid tie
         d = [1, 2, 2, 4, 5, 6]
         fitter.fit(durations=d, event_observed=[0, 1, 2, 1, 2, 0], event_of_interest=2)
         npt.assert_equal(np.any(np.not_equal([0] + d, fitter.event_table.index)), True)
+
+    def test_updated_input_ties(self, fitter):
+        # Based on the new setup of ties, should not detect any ties as existing
+        d = [1, 2, 2, 4, 5, 6]
+        fitter.fit(durations=d, event_observed=[0, 1, 1, 1, 2, 0], event_of_interest=1)
+        print(fitter.event_table.index)
+        npt.assert_equal(np.asarray([0, 1, 2, 4, 5, 6]), np.asarray(fitter.event_table.index))
+
+    def test_updated_censor_ties(self, fitter):
+        # Based on the new setup of ties, should not detect any ties as existing
+        d = [1, 2, 2, 4, 5, 6]
+        fitter.fit(durations=d, event_observed=[0, 0, 1, 1, 2, 0], event_of_interest=1)
+        print(fitter.event_table.index)
+        npt.assert_equal(np.asarray([0, 1, 2, 4, 5, 6]), np.asarray(fitter.event_table.index))
 
     def test_event_table_is_correct(self, fitter, duration, event_observed):
         fitter.fit(duration, event_observed, event_of_interest=2)


### PR DESCRIPTION
Fixes for `AalenJohansenFitter` as mentioned in #629 and #630 Pointed to master branch, since no new version branches currently available

**What this adds:**

- More specific tied event detection. The type of ties that break Aalen-Johansen are tied event times of different events. Original code detected any ties, regardless of event type. New update only looks for ties where events are not the same

- Added tests to check the new event-detection process

- Variance calculation avoids problems when large sample sizes are provided. The potentially large divisions are spaced throughout the calculation to avoid overflow. Tested on sample size of 20,000+ and had no issues

- Variance calculation takes a long time, since the calculation requires iterating over every event time. This can make processes like bootstrapping to take long then need be. In `AalenJohansenFitter.__init__` there is now the optional argument `calculate_variance` which allows the user to skip the variance calculation. Dramatically speeds up calculation time for bootstrapping