### PR TITLE
v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Changelog
 
+#### 0.20.1
+ - Some performance improvements to `CoxPHFitter` (about 30%). I know it may seem silly, but we are now about the same or slighty faster than the Cox model in R's `survival` package (for some testing datasets and some configurations). This is a big deal, because 1) lifelines does more error checking prior, 2) R's cox model is written in C, and we are still pure Python/NumPy, 3) R's cox model has decades of development.
+ - suppressed unimportant warnings
+
+##### API changes
+ - Previously, lifelines _always_ added a 0 row to `cph.baseline_hazard_`, even if there were no event at this time. This is no longer the case. A 0 will still be added if there is a duration (observed or not) at 0 occurs however.
+
+
 #### 0.20.0
  - Starting with 0.20.0, only Python3 will be supported. Over 75% of recent installs where Py3.
  - Updated minimum dependencies, specifically Matplotlib and Pandas.

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,12 +1,42 @@
 Changelog
 ~~~~~~~~~
 
+0.20.1
+^^^^^^
+
+-  Some performance improvements to ``CoxPHFitter`` (about 30%). I know
+   it may seem silly, but we are now about the same or slighty faster
+   than the Cox model in R’s ``survival`` package (for some testing
+   datasets and some configurations). This is a big deal, because 1)
+   lifelines does more error checking prior, 2) R’s cox model is written
+   in C, and we are still pure Python/NumPy, 3) R’s cox model has
+   decades of development.
+-  suppressed unimportant warnings
+
+API changes
+'''''''''''
+
+-  Previously, lifelines *always* added a 0 row to
+   ``cph.baseline_hazard_``, even if there were no event at this time.
+   This is no longer the case. A 0 will still be added if there is a
+   duration (observed or not) at 0 occurs however.
+
+.. _section-1:
+
 0.20.0
 ^^^^^^
 
 -  Starting with 0.20.0, only Python3 will be supported. Over 75% of
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
+
+New features
+''''''''''''
+
+-  smarter initialization for AFT models which should improve
+   convergence.
+
+.. _api-changes-1:
 
 API changes
 '''''''''''
@@ -23,10 +53,12 @@ Bug fixes
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-1:
+.. _section-2:
 
 0.19.5
 ^^^^^^
+
+.. _new-features-1:
 
 New features
 ''''''''''''
@@ -36,7 +68,7 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-2:
+.. _section-3:
 
 0.19.4
 ^^^^^^
@@ -48,12 +80,12 @@ Bug fixes
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-3:
+.. _section-4:
 
 0.19.3
 ^^^^^^
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ''''''''''''
@@ -65,12 +97,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-4:
+.. _section-5:
 
 0.19.2
 ^^^^^^
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ''''''''''''
@@ -88,12 +120,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-5:
+.. _section-6:
 
 0.19.1
 ^^^^^^
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ''''''''''''
@@ -101,7 +133,7 @@ New features
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API changes
 '''''''''''
@@ -110,12 +142,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-6:
+.. _section-7:
 
 0.19.0
 ^^^^^^
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ''''''''''''
@@ -128,7 +160,7 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API changes
 '''''''''''
@@ -171,7 +203,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-7:
+.. _section-8:
 
 0.18.6
 ^^^^^^
@@ -181,7 +213,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-8:
+.. _section-9:
 
 0.18.5
 ^^^^^^
@@ -202,7 +234,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-9:
+.. _section-10:
 
 0.18.4
 ^^^^^^
@@ -212,7 +244,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-10:
+.. _section-11:
 
 0.18.3
 ^^^^^^
@@ -222,7 +254,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-11:
+.. _section-12:
 
 0.18.2
 ^^^^^^
@@ -238,7 +270,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-12:
+.. _section-13:
 
 0.18.1
 ^^^^^^
@@ -249,7 +281,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-13:
+.. _section-14:
 
 0.18.0
 ^^^^^^
@@ -286,7 +318,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-14:
+.. _section-15:
 
 0.17.5
 ^^^^^^
@@ -294,7 +326,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-15:
+.. _section-16:
 
 0.17.4
 ^^^^^^
@@ -306,7 +338,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-16:
+.. _section-17:
 
 0.17.3
 ^^^^^^
@@ -314,7 +346,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-17:
+.. _section-18:
 
 0.17.2
 ^^^^^^
@@ -325,7 +357,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-18:
+.. _section-19:
 
 0.17.1
 ^^^^^^
@@ -342,7 +374,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-19:
+.. _section-20:
 
 0.17.0
 ^^^^^^
@@ -363,7 +395,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-20:
+.. _section-21:
 
 0.16.3
 ^^^^^^
@@ -371,7 +403,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-21:
+.. _section-22:
 
 0.16.2
 ^^^^^^
@@ -382,14 +414,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-22:
+.. _section-23:
 
 0.16.1
 ^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-23:
+.. _section-24:
 
 0.16.0
 ^^^^^^
@@ -425,7 +457,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-24:
+.. _section-25:
 
 0.15.4
 ^^^^^^
@@ -433,14 +465,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-25:
+.. _section-26:
 
 0.15.3
 ^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-26:
+.. _section-27:
 
 0.15.2
 ^^^^^^
@@ -451,7 +483,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-27:
+.. _section-28:
 
 0.15.1
 ^^^^^^
@@ -460,7 +492,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-28:
+.. _section-29:
 
 0.15.0
 ^^^^^^
@@ -531,7 +563,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-29:
+.. _section-30:
 
 0.14.6
 ^^^^^^
@@ -539,7 +571,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-30:
+.. _section-31:
 
 0.14.5
 ^^^^^^
@@ -547,7 +579,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-31:
+.. _section-32:
 
 0.14.4
 ^^^^^^
@@ -564,7 +596,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-32:
+.. _section-33:
 
 0.14.3
 ^^^^^^
@@ -576,7 +608,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-33:
+.. _section-34:
 
 0.14.2
 ^^^^^^
@@ -584,7 +616,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-34:
+.. _section-35:
 
 0.14.1
 ^^^^^^
@@ -602,7 +634,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-35:
+.. _section-36:
 
 0.14.0
 ^^^^^^
@@ -624,7 +656,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-36:
+.. _section-37:
 
 0.13.0
 ^^^^^^
@@ -653,7 +685,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-37:
+.. _section-38:
 
 0.12.0
 ^^^^^^
@@ -670,7 +702,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-38:
+.. _section-39:
 
 0.11.3
 ^^^^^^
@@ -682,7 +714,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-39:
+.. _section-40:
 
 0.11.2
 ^^^^^^
@@ -690,14 +722,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-40:
+.. _section-41:
 
 0.11.1
 ^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-41:
+.. _section-42:
 
 0.11.0
 ^^^^^^
@@ -711,14 +743,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-42:
+.. _section-43:
 
 0.10.1
 ^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-43:
+.. _section-44:
 
 0.10.0
 ^^^^^^
@@ -733,7 +765,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-44:
+.. _section-45:
 
 0.9.4
 ^^^^^
@@ -756,7 +788,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-45:
+.. _section-46:
 
 0.9.2
 ^^^^^
@@ -765,7 +797,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-46:
+.. _section-47:
 
 0.9.1
 ^^^^^
@@ -773,7 +805,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-47:
+.. _section-48:
 
 0.9.0
 ^^^^^
@@ -789,7 +821,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-48:
+.. _section-49:
 
 0.8.1
 ^^^^^
@@ -806,7 +838,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-49:
+.. _section-50:
 
 0.8.0
 ^^^^^
@@ -825,7 +857,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-50:
+.. _section-51:
 
 0.7.1
 ^^^^^
@@ -844,7 +876,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-51:
+.. _section-52:
 
 0.7.0
 ^^^^^
@@ -863,7 +895,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-52:
+.. _section-53:
 
 0.6.1
 ^^^^^
@@ -875,7 +907,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-53:
+.. _section-54:
 
 0.6.0
 ^^^^^
@@ -898,7 +930,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-54:
+.. _section-55:
 
 0.5.1
 ^^^^^
@@ -919,7 +951,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-55:
+.. _section-56:
 
 0.5.0
 ^^^^^
@@ -932,7 +964,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-56:
+.. _section-57:
 
 0.4.4
 ^^^^^
@@ -944,7 +976,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-57:
+.. _section-58:
 
 0.4.3
 ^^^^^
@@ -965,7 +997,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-58:
+.. _section-59:
 
 0.4.2
 ^^^^^
@@ -985,7 +1017,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-59:
+.. _section-60:
 
 0.4.1.1
 ^^^^^^^
@@ -998,7 +1030,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-60:
+.. _section-61:
 
 0.4.1
 ^^^^^
@@ -1017,7 +1049,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-61:
+.. _section-62:
 
 0.4.0
 ^^^^^

--- a/docs/Survival analysis with lifelines.rst
+++ b/docs/Survival analysis with lifelines.rst
@@ -646,7 +646,7 @@ of time to birth. This is available as the ``cumulative_density_`` property afte
 
 .. image:: images/lifelines_intro_lcd.png
 
- .. note:: Other types of censoring, like interval-censoring, are not implemented in *lifelines* yet.
+.. note:: Other types of censoring, like interval-censoring, are not implemented in *lifelines* yet.
 
 
 Left truncated data

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ copyright = "2014-{},  Cam Davidson-Pilon".format(date.today().year)
 #
 # The short X.Y version.
 
-version = "0.20.0"
+version = "0.20.1"
 # The full version, including dev info
 release = version
 

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -330,7 +330,6 @@ class ParametericUnivariateFitter(UnivariateFitter):
         return anp.log(hz)
 
     def _negative_log_likelihood(self, params, T, E, entry):
-        warnings.filterwarnings("ignore")
 
         n = T.shape[0]
         log_hz = self._log_hazard(params, T[E])
@@ -359,7 +358,6 @@ class ParametericUnivariateFitter(UnivariateFitter):
         ci_labels: tuple
 
         """
-
         alpha2 = 1 - alpha / 2.0
         z = inv_normal_cdf(alpha2)
         df = pd.DataFrame(index=self.timeline)
@@ -790,7 +788,7 @@ class ParametericRegressionFitter(BaseFitter):
         return anp.log(hz)
 
     def _negative_log_likelihood(self, params, T, E, W, *Xs):
-        warnings.filterwarnings("ignore")
+        warnings.simplefilter(action="ignore", category=FutureWarning)
 
         ll = (W * E * self._log_hazard(params, T, *Xs)).sum() - (W * self._cumulative_hazard(params, T, *Xs)).sum()
         if self.penalizer > 0:
@@ -1100,6 +1098,7 @@ class ParametericRegressionFitter(BaseFitter):
     def _compute_sandwich_errors(self, T, E, weights, *Xs):
         with np.errstate(all="ignore"):
             # convergence will fail catastrophically elsewhere.
+
             ll_gradient = grad(self._negative_log_likelihood)
             params = self.params_.values
             n_params = params.shape[0]

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -682,11 +682,11 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         # used for log-likelihood test
         n = T.shape[0]
         log_lik = 0
-        unique_death_times_and_counts = zip(*np.unique(-T, return_counts=True))
+        _, counts = np.unique(-T, return_counts=True)
         risk_phi = 0
         pos = n
 
-        for _, count_of_removals in unique_death_times_and_counts:
+        for count_of_removals in counts:
 
             slice_ = slice(pos - count_of_removals, pos)
 
@@ -801,11 +801,12 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         risk_phi_x, tie_phi_x = np.zeros((d,)), np.zeros((d,))
         risk_phi_x_x, tie_phi_x_x = np.zeros((d, d)), np.zeros((d, d))
 
-        unique_death_times_and_counts = zip(*np.unique(-T, return_counts=True))
+        # counts are sorted by -T
+        _, counts = np.unique(-T, return_counts=True)
         scores = weights * np.exp(np.dot(X, beta))
         pos = n
 
-        for _, count_of_removals in unique_death_times_and_counts:
+        for count_of_removals in counts:
 
             slice_ = slice(pos - count_of_removals, pos)
 
@@ -873,6 +874,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             # given a matrix t, for each row, m, compute it's outer product: m.dot(m.T), and stack these new matrices together.
             # which would be: np.einsum("Bi, Bj->Bij", t, t)
             a2 = summand.T.dot(summand)
+
             gradient = gradient + x_death_sum - weighted_average * summand.sum(0)
             log_lik = log_lik + np.dot(x_death_sum, beta) + weighted_average * np.log(denom).sum()
             hessian = hessian + weighted_average * (a2 - a1)

--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -210,4 +210,4 @@ class KaplanMeierFitter(UnivariateFitter):
 
     def _additive_var(self, population, deaths):
         np.seterr(divide="ignore")
-        return (1.0 * deaths / (population * (population - deaths))).replace([np.inf], 0)
+        return (deaths / (population * (population - deaths))).replace([np.inf], 0)

--- a/lifelines/fitters/nelson_aalen_fitter.py
+++ b/lifelines/fitters/nelson_aalen_fitter.py
@@ -186,7 +186,7 @@ class NelsonAalenFitter(UnivariateFitter):
         )
 
     def _variance_f_discrete(self, population, deaths):
-        return 1.0 * (population - deaths) * deaths / population ** 3
+        return (population - deaths) * deaths / population ** 3
 
     def _additive_f_smooth(self, population, deaths):
         cum_ = np.cumsum(1.0 / np.arange(1, np.max(population) + 1))
@@ -196,7 +196,7 @@ class NelsonAalenFitter(UnivariateFitter):
         )
 
     def _additive_f_discrete(self, population, deaths):
-        return (1.0 * deaths / population).replace([np.inf], 0)
+        return (deaths / population).replace([np.inf], 0)
 
     def smoothed_hazard_(self, bandwidth):
         """

--- a/lifelines/fitters/piecewise_exponential_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_fitter.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-
+import warnings
 import autograd.numpy as np
-
 from lifelines.fitters import KnownModelParametericUnivariateFitter
 
 
@@ -77,11 +76,12 @@ class PiecewiseExponentialFitter(KnownModelParametericUnivariateFitter):
         super(PiecewiseExponentialFitter, self).__init__(*args, **kwargs)
 
     def _cumulative_hazard(self, params, times):
+        warnings.simplefilter(action="ignore", category=FutureWarning)
 
         n = times.shape[0]
         times = times.reshape((n, 1))
 
         bp = self.breakpoints
         M = np.minimum(np.tile(bp, (n, 1)), times)
-        M = np.hstack([M[:, (0,)], np.diff(M, axis=1)])
+        M = np.hstack([M[:, tuple([0])], np.diff(M, axis=1)])
         return np.dot(M, 1 / params)

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -905,13 +905,17 @@ A very low variance means that the column {cols} completely determines whether a
         warnings.warn(warning_text, ConvergenceWarning)
 
 
+def correlation(x, y):
+    return np.corrcoef(x, y)[1, 0]
+
+
 def check_complete_separation_close_to_perfect_correlation(df, durations):
     # slow for many columns
     THRESHOLD = 0.99
     n, _ = df.shape
 
     if n > 500:
-        # let's sample to speed this n**2 algo up.
+        # let's sample to speed this up.
         df = df.sample(n=500, random_state=0).copy()
         durations = durations.sample(n=500, random_state=0).copy()
 
@@ -919,7 +923,7 @@ def check_complete_separation_close_to_perfect_correlation(df, durations):
     for col, series in df.iteritems():
         with np.errstate(invalid="ignore", divide="ignore"):
             rank_series = series.values.argsort()
-            if abs(np.corrcoef(rank_durations, rank_series)[1, 0]) >= THRESHOLD:
+            if abs(correlation(rank_durations, rank_series)) >= THRESHOLD:
                 warning_text = (
                     "Column %s has high sample correlation with the duration column. This may harm convergence. This could be a form of 'complete separation'. \
     See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-separation-in-logistic-regression"
@@ -943,7 +947,7 @@ def check_nans_or_infs(df_or_array):
             raise TypeError("NaNs were detected in the dataset. Try using pd.isnull to find the problematic values.")
     # isinf check is done after isnull check since np.isinf doesn't work on None values
     if isinstance(df_or_array, (pd.Series, pd.DataFrame)):
-        infs = df_or_array.values.astype(float) == np.Inf
+        infs = df_or_array.values == np.Inf
     else:
         infs = np.isinf(df_or_array)
 

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -915,9 +915,11 @@ def check_complete_separation_close_to_perfect_correlation(df, durations):
         df = df.sample(n=500, random_state=0).copy()
         durations = durations.sample(n=500, random_state=0).copy()
 
+    rank_durations = durations.argsort()
     for col, series in df.iteritems():
         with np.errstate(invalid="ignore", divide="ignore"):
-            if abs(stats.spearmanr(series, durations).correlation) >= THRESHOLD:
+            rank_series = series.values.argsort()
+            if abs(np.corrcoef(rank_durations, rank_series)[1, 0]) >= THRESHOLD:
                 warning_text = (
                     "Column %s has high sample correlation with the duration column. This may harm convergence. This could be a form of 'complete separation'. \
     See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-separation-in-logistic-regression"
@@ -941,7 +943,7 @@ def check_nans_or_infs(df_or_array):
             raise TypeError("NaNs were detected in the dataset. Try using pd.isnull to find the problematic values.")
     # isinf check is done after isnull check since np.isinf doesn't work on None values
     if isinstance(df_or_array, (pd.Series, pd.DataFrame)):
-        infs = df_or_array.values == np.Inf
+        infs = df_or_array.values.astype(float) == np.Inf
     else:
         infs = np.isinf(df_or_array)
 

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"

--- a/perf_tests/batch_vs_single.py
+++ b/perf_tests/batch_vs_single.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from time import time
 import pandas as pd
 import numpy as np
@@ -13,11 +14,11 @@ ROSSI_ROWS = 432
 results = {}
 
 
-for n_copies in [1, 2, 4, 6, 8, 10, 13, 17, 20]:
+for n_copies in [1, 2, 4, 6, 8, 10, 13, 17, 20, 25]:
 
     # lower percents means more ties.
     # original rossi dataset has 0.113
-    for fraction in np.linspace(0.01, 0.99, 12):
+    for fraction in np.linspace(0.01, 0.99, 15):
         print(n_copies, fraction)
 
         df = pd.concat([load_rossi()] * n_copies)

--- a/perf_tests/cp_perf_test.py
+++ b/perf_tests/cp_perf_test.py
@@ -11,10 +11,11 @@ if __name__ == "__main__":
     from lifelines.datasets import load_rossi
 
     df = load_rossi()
-    df = pd.concat([df] * 500)
+    df = pd.concat([df] * 20)
     # df = df.reset_index()
     # df['week'] = np.random.exponential(1, size=df.shape[0])
     cp = CoxPHFitter()
     start_time = time.time()
-    cp.fit(df, duration_col="week", event_col="arrest", batch_mode=True, show_progress=True)
+    cp.fit(df, duration_col="week", event_col="arrest", batch_mode=True)
     print("--- %s seconds ---" % (time.time() - start_time))
+    cp.print_summary()

--- a/perf_tests/cp_perf_test.py
+++ b/perf_tests/cp_perf_test.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     from lifelines.datasets import load_rossi
 
     df = load_rossi()
-    df = pd.concat([df] * 20)
+    df = pd.concat([df] * 16)
     # df = df.reset_index()
     # df['week'] = np.random.exponential(1, size=df.shape[0])
     cp = CoxPHFitter()

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -3026,13 +3026,18 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
     def test_warning_is_raised_if_complete_separation_is_present(self, cph):
         # check for a warning if we have complete separation
 
-        df = pd.DataFrame.from_records(
-            [(-5, 1), (-4, 2), (-3, 3), (-2, 4), (-1, 5), (1, 6), (2, 7), (3, 8), (4, 9)], columns=["x", "T"]
-        )
-        df["E"] = np.random.binomial(1, 0.9, df.shape[0])
-
+        df = pd.DataFrame.from_records(zip(np.arange(-5, 5), np.arange(1, 10)), columns=["x", "T"])
         with pytest.warns(ConvergenceWarning, match="complete separation") as w:
-            cph.fit(df, "T", "E")
+            cph.fit(df, "T")
+
+        df = pd.DataFrame.from_records(zip(np.arange(1, 10), np.arange(1, 10)), columns=["x", "T"])
+        with pytest.warns(ConvergenceWarning, match="complete separation") as w:
+            cph.fit(df, "T")
+
+        df = pd.DataFrame.from_records(zip(np.arange(0, 100), np.arange(0, 100)), columns=["x", "T"])
+        df["x"] += np.random.randn(100)
+        with pytest.warns(ConvergenceWarning, match="complete separation") as w:
+            cph.fit(df, "T")
 
     def test_what_happens_when_column_is_constant_for_all_non_deaths(self, rossi):
         # this is known as complete separation: See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-separation-in-logistic-regression

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -518,7 +518,7 @@ class TestUnivariateFitters:
             assert dif == 0
 
 
-class TestLogNormal:
+class TestLogNormalFitter:
     @pytest.fixture()
     def lnf(self):
         return LogNormalFitter()
@@ -2906,8 +2906,6 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
         rossi = rossi[["week", "arrest", "fin", "age"]]
         cp = CoxPHFitter()
         cp.fit(rossi, "week", "arrest", weights_col="age")
-
-        npt.assert_almost_equal(cp.baseline_cumulative_hazard_["baseline hazard"].loc[0.0], 0.0, decimal=4)
         npt.assert_almost_equal(cp.baseline_cumulative_hazard_["baseline hazard"].loc[1.0], 0.00183466, decimal=4)
         npt.assert_almost_equal(cp.baseline_cumulative_hazard_["baseline hazard"].loc[2.0], 0.005880265, decimal=4)
         npt.assert_almost_equal(cp.baseline_cumulative_hazard_["baseline hazard"].loc[10.0], 0.035425868, decimal=4)
@@ -3226,7 +3224,7 @@ class TestAalenAdditiveFitter:
         assert abs((T_pred.values > T).mean() - 0.5) < 0.05
 
     def test_dataframe_input_with_nonstandard_index(self):
-        aaf = AalenAdditiveFitter(coef_penalizer=2.0)
+        aaf = AalenAdditiveFitter(coef_penalizer=5.0)
         df = pd.DataFrame(
             [(16, True, True), (1, True, True), (4, False, True)],
             columns=["duration", "done_feeding", "white"],


### PR DESCRIPTION
#### 0.20.1
 - Some performance improvements to `CoxPHFitter` (about 30%). I know it may seem silly, but we are now about the same or slighty faster than the Cox model in R's `survival` package (for some testing datasets and some configurations). This is a big deal, because 1) lifelines does more error checking prior, 2) R's cox model is written in C, and we are still pure Python/NumPy, 3) R's cox model has decades of development.
 - suppressed unimportant warnings

##### API changes
 - Previously, lifelines _always_ added a 0 row to `cph.baseline_hazard_`, even if there were no event at this time. This is no longer the case. A 0 will still be added if there is a duration (observed or not) at 0 occurs however.
