### PR TITLE
Removed inversion of plotting lifetimes

### DIFF
--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -231,11 +231,11 @@ def plot_lifetimes(
 
     for i in range(N):
         c = event_observed_color if event_observed[i] else event_censored_color
-        ax.hlines(N - 1 - i, entry[i], entry[i] + durations[i], color=c, lw=1.5)
+        ax.hlines(i, entry[i], entry[i] + durations[i], color=c, lw=1.5)
         if left_truncated:
-            ax.hlines(N - 1 - i, 0, entry[i], color=c, lw=1.0, linestyle="--")
+            ax.hlines(i, 0, entry[i], color=c, lw=1.0, linestyle="--")
         m = "" if not event_observed[i] else "o"
-        ax.scatter(entry[i] + durations[i], N - 1 - i, color=c, marker=m, s=10)
+        ax.scatter(entry[i] + durations[i], i, color=c, marker=m, s=10)
 
     ax.set_ylim(-0.5, N)
     return ax


### PR DESCRIPTION
On the back of https://github.com/CamDavidsonPilon/lifelines/issues/666 👿 

It is a small change, but as mentioned in the issue it got me confused and I had to go through the source code and figure out what actually happens.

There is no clear indication in the code of why this inverse. The initial commit came in about 6 years ago from [here](https://github.com/CamDavidsonPilon/lifelines/commit/fa4c24456d83bef64858bf497b5cb8d08529ca37#diff-81b7d793b0503ee1c576beec8145aad6R47) . If that rings a bell I am more than happy to reconsider.

Here is the notebook I used for testing, as this particular point is not covered in the tests and I wasn't quite sure how to add it.

[notebook.zip](https://github.com/CamDavidsonPilon/lifelines/files/2984026/notebook.zip)
(had to compress due to GitHub not allowing me to upload this filetype)

Please let me know your thoughts. 💭 