### PR TITLE
v0.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ### Changelog
 
+#### 0.20.4
+
+##### New features
+ - left-truncation support in AFT models, using the `entry_col` kwarg in `fit()`
+ - `generate_datasets.piecewise_exponential_survival_data` for generating piecewise exp. data
+ - Faster `print_summary` for AFT models.
+
+##### API changes
+ - Pandas is now correctly pinned to >= 0.23.0. This was always the case, but not specified in setup.py correctly.
+
+##### Bug fixes
+ - Better handling for extremely large numbers in `print_summary`
+ - `PiecewiseExponentialFitter` is available with `from lifelines import *`.
+
+
 #### 0.20.3
 
 ##### New features

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,8 +1,37 @@
 Changelog
 ~~~~~~~~~
 
+0.20.4
+^^^^^^
+
+New features
+''''''''''''
+
+-  left-truncation support in AFT models, using the ``entry_col`` kwarg
+   in ``fit()``
+-  ``generate_datasets.piecewise_exponential_survival_data`` for
+   generating piecewise exp. data
+-  Faster ``print_summary`` for AFT models.
+
+API changes
+'''''''''''
+
+-  Pandas is now correctly pinned to >= 0.23.0. This was always the
+   case, but not specified in setup.py correctly.
+
+Bug fixes
+'''''''''
+
+-  Better handling for extremely large numbers in ``print_summary``
+-  ``PiecewiseExponentialFitter`` is available with
+   ``from lifelines import *``.
+
+.. _section-1:
+
 0.20.3
 ^^^^^^
+
+.. _new-features-1:
 
 New features
 ''''''''''''
@@ -15,12 +44,12 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-1:
+.. _section-2:
 
 0.20.2
 ^^^^^^
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ''''''''''''
@@ -35,12 +64,16 @@ New features
 -  add a ``lifelines.plotting.qq_plot`` for univariate parametric models
    that handles censored data.
 
+.. _api-changes-1:
+
 API changes
 '''''''''''
 
 -  ``plot_lifetimes`` no longer reverses the order when plotting. Thanks
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
+
+.. _bug-fixes-1:
 
 Bug fixes
 '''''''''
@@ -56,7 +89,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-2:
+.. _section-3:
 
 0.20.1
 ^^^^^^
@@ -70,7 +103,7 @@ Bug fixes
    decades of development.
 -  suppressed unimportant warnings
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API changes
 '''''''''''
@@ -80,7 +113,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-3:
+.. _section-4:
 
 0.20.0
 ^^^^^^
@@ -89,7 +122,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ''''''''''''
@@ -97,7 +130,7 @@ New features
 -  smarter initialization for AFT models which should improve
    convergence.
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API changes
 '''''''''''
@@ -109,19 +142,19 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-4:
+.. _section-5:
 
 0.19.5
 ^^^^^^
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ''''''''''''
@@ -131,24 +164,24 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-5:
+.. _section-6:
 
 0.19.4
 ^^^^^^
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-6:
+.. _section-7:
 
 0.19.3
 ^^^^^^
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ''''''''''''
@@ -160,12 +193,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-7:
+.. _section-8:
 
 0.19.2
 ^^^^^^
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ''''''''''''
@@ -173,7 +206,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -183,12 +216,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-8:
+.. _section-9:
 
 0.19.1
 ^^^^^^
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ''''''''''''
@@ -196,7 +229,7 @@ New features
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-3:
+.. _api-changes-4:
 
 API changes
 '''''''''''
@@ -205,12 +238,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-9:
+.. _section-10:
 
 0.19.0
 ^^^^^^
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ''''''''''''
@@ -223,7 +256,7 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-4:
+.. _api-changes-5:
 
 API changes
 '''''''''''
@@ -249,7 +282,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug Fixes
 '''''''''
@@ -266,7 +299,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-10:
+.. _section-11:
 
 0.18.6
 ^^^^^^
@@ -276,7 +309,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-11:
+.. _section-12:
 
 0.18.5
 ^^^^^^
@@ -297,7 +330,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-12:
+.. _section-13:
 
 0.18.4
 ^^^^^^
@@ -307,7 +340,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-13:
+.. _section-14:
 
 0.18.3
 ^^^^^^
@@ -317,7 +350,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-14:
+.. _section-15:
 
 0.18.2
 ^^^^^^
@@ -333,7 +366,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-15:
+.. _section-16:
 
 0.18.1
 ^^^^^^
@@ -344,7 +377,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-16:
+.. _section-17:
 
 0.18.0
 ^^^^^^
@@ -381,7 +414,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-17:
+.. _section-18:
 
 0.17.5
 ^^^^^^
@@ -389,7 +422,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-18:
+.. _section-19:
 
 0.17.4
 ^^^^^^
@@ -401,7 +434,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-19:
+.. _section-20:
 
 0.17.3
 ^^^^^^
@@ -409,7 +442,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-20:
+.. _section-21:
 
 0.17.2
 ^^^^^^
@@ -420,7 +453,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-21:
+.. _section-22:
 
 0.17.1
 ^^^^^^
@@ -437,7 +470,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-22:
+.. _section-23:
 
 0.17.0
 ^^^^^^
@@ -458,7 +491,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-23:
+.. _section-24:
 
 0.16.3
 ^^^^^^
@@ -466,7 +499,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-24:
+.. _section-25:
 
 0.16.2
 ^^^^^^
@@ -477,14 +510,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-25:
+.. _section-26:
 
 0.16.1
 ^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-26:
+.. _section-27:
 
 0.16.0
 ^^^^^^
@@ -520,7 +553,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-27:
+.. _section-28:
 
 0.15.4
 ^^^^^^
@@ -528,14 +561,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-28:
+.. _section-29:
 
 0.15.3
 ^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-29:
+.. _section-30:
 
 0.15.2
 ^^^^^^
@@ -546,7 +579,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-30:
+.. _section-31:
 
 0.15.1
 ^^^^^^
@@ -555,7 +588,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-31:
+.. _section-32:
 
 0.15.0
 ^^^^^^
@@ -626,7 +659,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-32:
+.. _section-33:
 
 0.14.6
 ^^^^^^
@@ -634,7 +667,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-33:
+.. _section-34:
 
 0.14.5
 ^^^^^^
@@ -642,7 +675,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-34:
+.. _section-35:
 
 0.14.4
 ^^^^^^
@@ -659,7 +692,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-35:
+.. _section-36:
 
 0.14.3
 ^^^^^^
@@ -671,7 +704,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-36:
+.. _section-37:
 
 0.14.2
 ^^^^^^
@@ -679,7 +712,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-37:
+.. _section-38:
 
 0.14.1
 ^^^^^^
@@ -697,7 +730,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-38:
+.. _section-39:
 
 0.14.0
 ^^^^^^
@@ -719,7 +752,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-39:
+.. _section-40:
 
 0.13.0
 ^^^^^^
@@ -748,7 +781,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-40:
+.. _section-41:
 
 0.12.0
 ^^^^^^
@@ -765,7 +798,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-41:
+.. _section-42:
 
 0.11.3
 ^^^^^^
@@ -777,7 +810,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-42:
+.. _section-43:
 
 0.11.2
 ^^^^^^
@@ -785,14 +818,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-43:
+.. _section-44:
 
 0.11.1
 ^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-44:
+.. _section-45:
 
 0.11.0
 ^^^^^^
@@ -806,14 +839,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-45:
+.. _section-46:
 
 0.10.1
 ^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-46:
+.. _section-47:
 
 0.10.0
 ^^^^^^
@@ -828,7 +861,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-47:
+.. _section-48:
 
 0.9.4
 ^^^^^
@@ -851,7 +884,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-48:
+.. _section-49:
 
 0.9.2
 ^^^^^
@@ -860,7 +893,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-49:
+.. _section-50:
 
 0.9.1
 ^^^^^
@@ -868,7 +901,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-50:
+.. _section-51:
 
 0.9.0
 ^^^^^
@@ -884,7 +917,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-51:
+.. _section-52:
 
 0.8.1
 ^^^^^
@@ -901,7 +934,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-52:
+.. _section-53:
 
 0.8.0
 ^^^^^
@@ -920,7 +953,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-53:
+.. _section-54:
 
 0.7.1
 ^^^^^
@@ -939,7 +972,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-54:
+.. _section-55:
 
 0.7.0
 ^^^^^
@@ -958,7 +991,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-55:
+.. _section-56:
 
 0.6.1
 ^^^^^
@@ -970,7 +1003,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-56:
+.. _section-57:
 
 0.6.0
 ^^^^^
@@ -993,7 +1026,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-57:
+.. _section-58:
 
 0.5.1
 ^^^^^
@@ -1014,7 +1047,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-58:
+.. _section-59:
 
 0.5.0
 ^^^^^
@@ -1027,7 +1060,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-59:
+.. _section-60:
 
 0.4.4
 ^^^^^
@@ -1039,7 +1072,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-60:
+.. _section-61:
 
 0.4.3
 ^^^^^
@@ -1060,7 +1093,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-61:
+.. _section-62:
 
 0.4.2
 ^^^^^
@@ -1080,7 +1113,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-62:
+.. _section-63:
 
 0.4.1.1
 ^^^^^^^
@@ -1093,7 +1126,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-63:
+.. _section-64:
 
 0.4.1
 ^^^^^
@@ -1112,7 +1145,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-64:
+.. _section-65:
 
 0.4.0
 ^^^^^

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -732,7 +732,7 @@ located under ``lifelines.AalenAdditiveFitter``.
     +-----------+--------+----------+--------------+-----------------+---------------------+---------------------------------------------------------+-------------+-------------+----------+--------+--------+
 
 
-I'm using the lovely library `patsy <https://github.com/pydata/patsy>`__ here to create a
+I'm using the lovely library `Patsy <https://github.com/pydata/patsy>`__ here to create a
 design matrix from my original dataframe.
 
 .. code:: python
@@ -856,6 +856,14 @@ Prime Minister Stephen Harper.
 
 Model selection in survival regression
 =========================================
+
+Parametric vs Semi-parametric models
+---------------------------------------
+Above, we've displayed two *semi-parametric* models (Cox model and Aalen's model), and a family of *parametric* AFT models. Which should you choose? What are the advantages and disadvantages of either? I suggest reading the two following StackExchange answers to get a better idea of what experts think:
+
+1. `In survival analysis, why do we use semi-parametric models (Cox proportional hazards) instead of fully parametric models? <https://stats.stackexchange.com/q/64739/11867>`__
+2. `In survival analysis, when should we use fully parametric models over semi-parametric ones? <https://stats.stackexchange.com/q/399544/11867>`__
+
 
 Model selection based on residuals
 -----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ copyright = "2014-{},  Cam Davidson-Pilon".format(date.today().year)
 #
 # The short X.Y version.
 
-version = "0.20.3"
+version = "0.20.4"
 # The full version, including dev info
 release = version
 

--- a/docs/lifelines.fitters.rst
+++ b/docs/lifelines.fitters.rst
@@ -8,7 +8,6 @@ lifelines.fitters.aalen\_additive\_fitter module
 .. automodule:: lifelines.fitters.aalen_additive_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.aalen\_johansen\_fitter module
 ------------------------------------------------
@@ -16,7 +15,6 @@ lifelines.fitters.aalen\_johansen\_fitter module
 .. automodule:: lifelines.fitters.aalen_johansen_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.breslow\_fleming\_harrington\_fitter module
 -------------------------------------------------------------
@@ -24,7 +22,6 @@ lifelines.fitters.breslow\_fleming\_harrington\_fitter module
 .. automodule:: lifelines.fitters.breslow_fleming_harrington_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.cox\_time\_varying\_fitter module
 ---------------------------------------------------
@@ -32,7 +29,6 @@ lifelines.fitters.cox\_time\_varying\_fitter module
 .. automodule:: lifelines.fitters.cox_time_varying_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.coxph\_fitter module
 --------------------------------------
@@ -40,7 +36,6 @@ lifelines.fitters.coxph\_fitter module
 .. automodule:: lifelines.fitters.coxph_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.exponential\_fitter module
 --------------------------------------------
@@ -48,7 +43,6 @@ lifelines.fitters.exponential\_fitter module
 .. automodule:: lifelines.fitters.exponential_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.kaplan\_meier\_fitter module
 ----------------------------------------------
@@ -56,7 +50,6 @@ lifelines.fitters.kaplan\_meier\_fitter module
 .. automodule:: lifelines.fitters.kaplan_meier_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.log\_logistic\_fitter module
 ----------------------------------------------
@@ -64,7 +57,6 @@ lifelines.fitters.log\_logistic\_fitter module
 .. automodule:: lifelines.fitters.log_logistic_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.log\_normal\_fitter module
 --------------------------------------------
@@ -72,7 +64,6 @@ lifelines.fitters.log\_normal\_fitter module
 .. automodule:: lifelines.fitters.log_normal_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.nelson\_aalen\_fitter module
 ----------------------------------------------
@@ -80,7 +71,6 @@ lifelines.fitters.nelson\_aalen\_fitter module
 .. automodule:: lifelines.fitters.nelson_aalen_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.piecewise\_exponential\_fitter module
 -------------------------------------------------------
@@ -88,7 +78,6 @@ lifelines.fitters.piecewise\_exponential\_fitter module
 .. automodule:: lifelines.fitters.piecewise_exponential_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 
 
@@ -98,7 +87,6 @@ lifelines.fitters.weibull\_fitter module
 .. automodule:: lifelines.fitters.weibull_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 
 lifelines.fitters.weibull\_aft\_fitter module
@@ -107,7 +95,6 @@ lifelines.fitters.weibull\_aft\_fitter module
 .. automodule:: lifelines.fitters.weibull_aft_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.log\_normal\_aft\_fitter module
 ---------------------------------------------------
@@ -115,7 +102,6 @@ lifelines.fitters.log\_normal\_aft\_fitter module
 .. automodule:: lifelines.fitters.log_normal_aft_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 lifelines.fitters.log\_logistic\_aft\_fitter module
 -----------------------------------------------------
@@ -123,7 +109,6 @@ lifelines.fitters.log\_logistic\_aft\_fitter module
 .. automodule:: lifelines.fitters.log_logistic_aft_fitter
     :members:
     :undoc-members:
-    :show-inheritance:
 
 
 
@@ -131,4 +116,3 @@ lifelines.fitters.log\_logistic\_aft\_fitter module
 .. automodule:: lifelines.fitters
     :members:
     :undoc-members:
-    :show-inheritance:

--- a/lifelines/__init__.py
+++ b/lifelines/__init__.py
@@ -36,4 +36,5 @@ __all__ = [
     "WeibullAFTFitter",
     "LogLogisticAFTFitter",
     "LogNormalAFTFitter",
+    "PiecewiseExponentialFitter",
 ]

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -977,7 +977,7 @@ class ParametericAFTRegressionFitter(BaseFitter):
             Specify a timeline that will be used for plotting and prediction
 
         weights_col: string
-            the column in df that specifies weights per observation.
+            the column in DataFrame that specifies weights per observation.
 
         robust: boolean, optional (default=False)
             Compute the robust errors using the Huber sandwich estimator.
@@ -986,7 +986,8 @@ class ParametericAFTRegressionFitter(BaseFitter):
             initialize the starting point of the iterative
             algorithm. Default is the zero vector.
 
-        entry_col: TODO
+        entry_col: specify a column in the DataFrame that denotes any late-entries (left truncation) that occurred. See
+            the docs on `left truncation <https://lifelines.readthedocs.io/en/latest/Survival%20analysis%20with%20lifelines.html#left-truncated-late-entry-data>`__
 
         Returns
         -------
@@ -996,7 +997,7 @@ class ParametericAFTRegressionFitter(BaseFitter):
 
         Examples
         --------
-        >>> from lifelines import WeibullAFTFitter
+        >>> from lifelines import WeibullAFTFitter, LogNormalAFTFitter, LogLogisticAFTFitter
         >>>
         >>> df = pd.DataFrame({
         >>>     'T': [5, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -34,6 +34,7 @@ from lifelines.utils import (
     string_justify,
     format_floats,
     format_p_value,
+    format_exp_floats,
     coalesce,
     check_nans_or_infs,
     pass_for_numeric_dtypes_or_raise_array,
@@ -303,7 +304,7 @@ class ParametericUnivariateFitter(UnivariateFitter):
 
         if len(self._bounds) != len(self._fitted_parameter_names) != self._initial_values.shape[0]:
             raise ValueError(
-                "_bounds must be the same shape as _fitted_parameters_names must be the same shape as _initial_values"
+                "_bounds must be the same shape as _fitted_parameter_names must be the same shape as _initial_values"
             )
 
     def _check_cumulative_hazard_is_monotone_and_positive(self, durations, values):
@@ -598,7 +599,12 @@ class ParametericUnivariateFitter(UnivariateFitter):
         print("---")
 
         df = self.summary
-        print(df.to_string(float_format=format_floats(decimals), formatters={"p": format_p_value(decimals)}))
+        print(
+            df.to_string(
+                float_format=format_floats(decimals),
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+            )
+        )
 
     def fit(
         self,
@@ -1336,7 +1342,12 @@ class ParametericRegressionFitter(BaseFitter):
 
         df = self.summary
         # Significance codes as last column
-        print(df.to_string(float_format=format_floats(decimals), formatters={"p": format_p_value(decimals)}))
+        print(
+            df.to_string(
+                float_format=format_floats(decimals),
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+            )
+        )
 
         # Significance code explanation
         print("---")

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -602,7 +602,7 @@ class ParametericUnivariateFitter(UnivariateFitter):
         print(
             df.to_string(
                 float_format=format_floats(decimals),
-                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats(decimals)},
             )
         )
 
@@ -1248,16 +1248,16 @@ class ParametericRegressionFitter(BaseFitter):
 
     @property
     def _ll_null(self):
-        if hasattr(self, "__ll_null"):
-            return self.__ll_null
+        if hasattr(self, "_ll_null_"):
+            return self._ll_null_
 
         initial_point = np.zeros(len(self._fitted_parameter_names))
-        self.__ll_null = (
+        self._ll_null_ = (
             self.__class__()
             .fit(pd.DataFrame({"T": self.durations, "E": self.event_observed}), "T", "E", initial_point=initial_point)
             ._log_likelihood
         )
-        return self.__ll_null
+        return self._ll_null_
 
     def _compute_likelihood_ratio_test(self):
         """
@@ -1345,7 +1345,7 @@ class ParametericRegressionFitter(BaseFitter):
         print(
             df.to_string(
                 float_format=format_floats(decimals),
-                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats(decimals)},
             )
         )
 

--- a/lifelines/fitters/aalen_additive_fitter.py
+++ b/lifelines/fitters/aalen_additive_fitter.py
@@ -567,7 +567,7 @@ It's important to know that the naive variance estimates of the coefficients are
         print(
             df.to_string(
                 float_format=format_floats(decimals),
-                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats(decimals)},
             )
         )
 

--- a/lifelines/fitters/aalen_additive_fitter.py
+++ b/lifelines/fitters/aalen_additive_fitter.py
@@ -26,6 +26,7 @@ from lifelines.utils import (
     _to_list,
     format_floats,
     format_p_value,
+    format_exp_floats,
     survival_table_from_events,
     StatisticalWarning,
 )
@@ -563,7 +564,12 @@ It's important to know that the naive variance estimates of the coefficients are
         print("---")
 
         df = self.summary
-        print(df.to_string(float_format=format_floats(decimals), formatters={"p": format_p_value(decimals)}))
+        print(
+            df.to_string(
+                float_format=format_floats(decimals),
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+            )
+        )
 
         # Significance code explanation
         print("---")

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -36,6 +36,7 @@ from lifelines.utils import (
     check_nans_or_infs,
     string_justify,
     format_p_value,
+    format_exp_floats,
     format_floats,
     coalesce,
 )
@@ -644,7 +645,12 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
         df = self.summary
         # Significance codes last
-        print(df.to_string(float_format=format_floats(decimals), formatters={"p": format_p_value(decimals)}))
+        print(
+            df.to_string(
+                float_format=format_floats(decimals),
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+            )
+        )
 
         # Significance code explanation
         print("---")

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -192,7 +192,7 @@ class CoxTimeVaryingFitter(BaseFitter):
         weights = df.pop("__weights").astype(float)
 
         df = df.astype(float)
-        self._check_values(df, events, start, stop, self.event_col)
+        self._check_values(df, events, start, stop)
 
         self._norm_mean = df.mean(0)
         self._norm_std = df.std(0)
@@ -224,12 +224,11 @@ class CoxTimeVaryingFitter(BaseFitter):
         self._n_unique = df.index.unique().shape[0]
         return self
 
-    @staticmethod
-    def _check_values(df, events, start, stop, event_col):
+    def _check_values(self, df, events, start, stop):
         # check_for_overlapping_intervals(df) # this is currently too slow for production.
         check_nans_or_infs(df)
         check_low_var(df)
-        check_complete_separation_low_variance(df, events, event_col)
+        check_complete_separation_low_variance(df, events, self.event_col)
         check_for_numeric_dtypes_or_raise(df)
         check_for_immediate_deaths(events, start, stop)
         check_for_instantaneous_events(start, stop)

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -648,7 +648,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         print(
             df.to_string(
                 float_format=format_floats(decimals),
-                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats(decimals)},
             )
         )
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -38,6 +38,7 @@ from lifelines.utils import (
     string_justify,
     format_p_value,
     format_floats,
+    format_exp_floats,
     dataframe_interpolate_at_times,
 )
 
@@ -1257,7 +1258,12 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
         df = self.summary
         # Significance codes as last column
-        print(df.to_string(float_format=format_floats(decimals), formatters={"p": format_p_value(decimals)}))
+        print(
+            df.to_string(
+                float_format=format_floats(decimals),
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+            )
+        )
 
         # Significance code explanation
         print("---")

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1261,7 +1261,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         print(
             df.to_string(
                 float_format=format_floats(decimals),
-                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats()},
+                formatters={"p": format_p_value(decimals), "exp(coef)": format_exp_floats(decimals)},
             )
         )
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -334,6 +334,23 @@ class CoxPHFitter(BaseFitter):
             else pd.Series(np.ones((self._n_examples,)), index=df.index, name="weights")
         )
 
+        _clusters = df.pop(self.cluster_col).values if self.cluster_col else None
+
+        X = df.astype(float)
+        T = T.astype(float)
+        E = E.astype(bool)
+
+        self._check_values(X, T, E, W)
+
+        return X, T, E, W, original_index, _clusters
+
+    def _check_values(self, X, T, E, W):
+        check_for_numeric_dtypes_or_raise(X)
+        check_nans_or_infs(T)
+        check_nans_or_infs(E)
+        check_nans_or_infs(X)
+        check_low_var(X)
+        check_complete_separation(X, E, T, self.event_col)
         # check to make sure their weights are okay
         if self.weights_col:
             if (W.astype(int) != W).any() and not self.robust:
@@ -346,25 +363,6 @@ estimate the variances. See paper "Variance estimation when using inverse probab
                 )
             if (W <= 0).any():
                 raise ValueError("values in weight column %s must be positive." % self.weights_col)
-
-        _clusters = df.pop(self.cluster_col).values if self.cluster_col else None
-
-        X = df.astype(float)
-        T = T.astype(float)
-        E = E.astype(bool)
-
-        self._check_values(X, T, E, self.event_col)
-
-        return X, T, E, W, original_index, _clusters
-
-    @staticmethod
-    def _check_values(X, T, E, event_col):
-        check_for_numeric_dtypes_or_raise(X)
-        check_nans_or_infs(T)
-        check_nans_or_infs(E)
-        check_nans_or_infs(X)
-        check_low_var(X)
-        check_complete_separation(X, E, T, event_col)
 
     def _newton_rhaphson(
         self,

--- a/lifelines/fitters/exponential_fitter.py
+++ b/lifelines/fitters/exponential_fitter.py
@@ -23,15 +23,15 @@ class ExponentialFitter(KnownModelParametericUnivariateFitter):
     After calling the `.fit` method, you have access to properties like: ``survival_function_``, ``lambda_``, ``cumulative_hazard_``
     A summary of the fit is available with the method ``print_summary()``
 
+    Parameters
+    -----------
+    alpha: float, optional (default=0.05)
+        the level in the confidence intervals.
+
     Important
     ----------
     The parameterization of this model changed in lifelines 0.19.0. Previously, the cumulative hazard looked like
     :math:`\lambda t`. The parameterization is now the reciprocal of :math:`\lambda`.
-
-
-    Notes
-    -----
-    Reference: https://www4.stat.ncsu.edu/~dzhang2/st745/chap3.pdf
 
     Attributes
     ----------

--- a/lifelines/fitters/log_logistic_aft_fitter.py
+++ b/lifelines/fitters/log_logistic_aft_fitter.py
@@ -5,10 +5,10 @@ from autograd import numpy as np
 import pandas as pd
 
 from lifelines.utils import _get_index, coalesce
-from lifelines.fitters import ParametericRegressionFitter
+from lifelines.fitters import ParametericAFTRegressionFitter
 
 
-class LogLogisticAFTFitter(ParametericRegressionFitter):
+class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
     r"""
     This class implements a Log-Logistic AFT model. The model has parameterized
     form, with :math:`\alpha(x) = \exp\left(a_0 + a_1x_1 + ... + a_n x_n \right)`,

--- a/lifelines/fitters/log_logistic_fitter.py
+++ b/lifelines/fitters/log_logistic_fitter.py
@@ -23,6 +23,11 @@ class LogLogisticFitter(KnownModelParametericUnivariateFitter):
     After calling the `.fit` method, you have access to properties like: ``cumulative_hazard_``, ``plot``, ``survival_function_``, ``alpha_`` and ``beta_``.
     A summary of the fit is available with the method 'print_summary()'
 
+    Parameters
+    -----------
+    alpha: float, optional (default=0.05)
+        the level in the confidence intervals.
+
     Examples
     --------
 

--- a/lifelines/fitters/log_normal_aft_fitter.py
+++ b/lifelines/fitters/log_normal_aft_fitter.py
@@ -5,11 +5,11 @@ from scipy.special import erfinv
 import pandas as pd
 
 from lifelines.utils import _get_index, coalesce
-from lifelines.fitters import ParametericRegressionFitter
+from lifelines.fitters import ParametericAFTRegressionFitter
 from lifelines.utils.logsf import logsf
 
 
-class LogNormalAFTFitter(ParametericRegressionFitter):
+class LogNormalAFTFitter(ParametericAFTRegressionFitter):
     r"""
     This class implements a Log-Normal AFT model. The model has parameterized
     form, with :math:`\mu(x) = \exp\left(a_0 + a_1x_1 + ... + a_n x_n \right)`,

--- a/lifelines/fitters/log_normal_fitter.py
+++ b/lifelines/fitters/log_normal_fitter.py
@@ -22,6 +22,12 @@ class LogNormalFitter(KnownModelParametericUnivariateFitter):
     After calling the `.fit` method, you have access to properties like: ``survival_function_``, ``mu_``, ``sigma_``.
     A summary of the fit is available with the method ``print_summary()``
 
+    Parameters
+    -----------
+    alpha: float, optional (default=0.05)
+        the level in the confidence intervals.
+
+
     Attributes
     ----------
     cumulative_hazard_ : DataFrame

--- a/lifelines/fitters/piecewise_exponential_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_fitter.py
@@ -73,10 +73,10 @@ class PiecewiseExponentialFitter(KnownModelParametericUnivariateFitter):
 
     def __init__(self, breakpoints, *args, **kwargs):
         breakpoints = np.sort(breakpoints)
-        if len(breakpoints) > 0 and not (breakpoints[-1] < np.inf):
+        if breakpoints and not (breakpoints[-1] < np.inf):
             raise ValueError("Do not add inf to the breakpoints.")
 
-        if len(breakpoints) > 0 and breakpoints[0] < 0:
+        if breakpoints and breakpoints[0] <= 0:
             raise ValueError("First breakpoint must be greater than 0.")
 
         self.breakpoints = np.append(breakpoints, [np.inf])

--- a/lifelines/fitters/piecewise_exponential_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_fitter.py
@@ -22,6 +22,13 @@ class PiecewiseExponentialFitter(KnownModelParametericUnivariateFitter):
     After calling the `.fit` method, you have access to properties like: ``survival_function_``, ``plot``, ``cumulative_hazard_``
     A summary of the fit is available with the method ``print_summary()``
 
+    Parameters
+    -----------
+    breakpoints: list
+        a list of times when a new exponential model is constructed.
+    alpha: float, optional (default=0.05)
+        the level in the confidence intervals.
+
     Important
     ----------
     The parameterization of this model changed in lifelines 0.19.1. Previously, the cumulative hazard looked like
@@ -66,10 +73,10 @@ class PiecewiseExponentialFitter(KnownModelParametericUnivariateFitter):
 
     def __init__(self, breakpoints, *args, **kwargs):
         breakpoints = np.sort(breakpoints)
-        if not (breakpoints[-1] < np.inf):
+        if len(breakpoints) > 0 and not (breakpoints[-1] < np.inf):
             raise ValueError("Do not add inf to the breakpoints.")
 
-        if breakpoints[0] < 0:
+        if len(breakpoints) > 0 and breakpoints[0] < 0:
             raise ValueError("First breakpoint must be greater than 0.")
 
         self.breakpoints = np.append(breakpoints, [np.inf])
@@ -84,7 +91,6 @@ class PiecewiseExponentialFitter(KnownModelParametericUnivariateFitter):
 
         n = times.shape[0]
         times = times.reshape((n, 1))
-
         bp = self.breakpoints
         M = np.minimum(np.tile(bp, (n, 1)), times)
         M = np.hstack([M[:, tuple([0])], np.diff(M, axis=1)])

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -4,10 +4,10 @@ from scipy.special import gamma
 import pandas as pd
 
 from lifelines.utils import _get_index, coalesce
-from lifelines.fitters import ParametericRegressionFitter
+from lifelines.fitters import ParametericAFTRegressionFitter
 
 
-class WeibullAFTFitter(ParametericRegressionFitter):
+class WeibullAFTFitter(ParametericAFTRegressionFitter):
     r"""
     This class implements a Weibull AFT model. The model has parameterized
     form, with :math:`\lambda(x) = \exp\left(\beta_0 + \beta_1x_1 + ... + \beta_n x_n \right)`,

--- a/lifelines/fitters/weibull_fitter.py
+++ b/lifelines/fitters/weibull_fitter.py
@@ -24,6 +24,10 @@ class WeibullFitter(KnownModelParametericUnivariateFitter):
     After calling the `.fit` method, you have access to properties like: ``cumulative_hazard_``, ``survival_function_``, ``lambda_`` and ``rho_``.
     A summary of the fit is available with the method ``print_summary()``.
 
+    Parameters
+    -----------
+    alpha: float, optional (default=0.05)
+        the level in the confidence intervals.
 
     Important
     ----------

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -868,6 +868,13 @@ df.groupby(level=1).apply(lambda g: g.index.get_level_values(0).is_non_overlappi
         )
 
 
+def check_positivity(array):
+    if np.any(array <= 0):
+        raise ValueError(
+            "This model does not allow for non-positive durations. Suggestion: add a small positive value to zero elements."
+        )
+
+
 def _low_var(df):
     return df.var(0) < 1e-4
 

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1360,12 +1360,14 @@ def format_p_value(decimals):
     return lambda p: "<%s" % threshold if p < threshold else "{:4.{prec}f}".format(p, prec=decimals)
 
 
-def format_exp_floats():
+def format_exp_floats(decimals):
     """
     sometimes the exp. column can be too large
     """
     threshold = 10 ** 5
-    return lambda n: "{:.2e}".format(n) if n > threshold else str(n)
+    return (
+        lambda n: "{:.{prec}e}".format(n, prec=decimals) if n > threshold else "{:4.{prec}f}".format(n, prec=decimals)
+    )
 
 
 def format_floats(decimals):

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1360,6 +1360,14 @@ def format_p_value(decimals):
     return lambda p: "<%s" % threshold if p < threshold else "{:4.{prec}f}".format(p, prec=decimals)
 
 
+def format_exp_floats():
+    """
+    sometimes the exp. column can be too large
+    """
+    threshold = 10 ** 5
+    return lambda n: "{:.2e}".format(n) if n > threshold else str(n)
+
+
 def format_floats(decimals):
     return lambda f: "{:4.{prec}f}".format(f, prec=decimals)
 

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.20.3"
+__version__ = "0.20.4"

--- a/perf_tests/weibull_aft_perf.py
+++ b/perf_tests/weibull_aft_perf.py
@@ -5,16 +5,18 @@
 if __name__ == "__main__":
     import pandas as pd
     import time
+    import numpy as np
 
     from lifelines import WeibullAFTFitter
     from lifelines.datasets import load_rossi
 
     df = load_rossi()
     df = pd.concat([df] * 1)
+    df["start"] = np.random.randint(0, 3, size=df.shape[0])
     # df = df.reset_index()
     # df['week'] = np.random.exponential(1, size=df.shape[0])
     wp = WeibullAFTFitter()
     start_time = time.time()
-    wp.fit(df, duration_col="week", event_col="arrest")
+    wp.fit(df, duration_col="week", event_col="arrest", start_col="start")
     print("--- %s seconds ---" % (time.time() - start_time))
     wp.print_summary()

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ setup(
     install_requires=[
         "numpy>=1.6.0",
         "scipy>=1.0",
-        "pandas>=0.18",
-        """matplotlib>=3.0""",
+        "pandas>=0.23.0",
+        "matplotlib>=3.0",
         "bottleneck>=1.0",
         "autograd>=1.2",
     ],


### PR DESCRIPTION
#### 0.20.4

##### New features
 - left-truncation support in AFT models, using the `entry_col` kwarg in `fit()`
 - `generate_datasets.piecewise_exponential_survival_data` for generating piecewise exp. data
 - Faster `print_summary` for AFT models.

##### API changes
 - Pandas is now correctly pinned to >= 0.23.0. This was always the case, but not specified in setup.py correctly.

##### Bug fixes
 - Better handling for extremely large numbers in `print_summary`
 - `PiecewiseExponentialFitter` is available with `from lifelines import *`.

