### PR TITLE
v0.20.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 ### Changelog
 
-#### 0.20.4
+#### 0.20.5 - 2019-04-08
+
+##### New features
+ - performance improvements for `print_summary`.
+
+##### API changes
+ - `utils.survival_events_from_table` returns an integer weight vector as well as durations and censoring vector.
+ - in `AalenJohansenFitter`, the `variance` parameter is renamed to `variance_` to align with the usual lifelines convention.
+
+##### Bug fixes
+ - Fixed an error in the `CoxTimeVaryingFitter`'s likelihood ratio test when using strata.
+ - Fixed some plotting bugs with `AalenJohansenFitter`
+
+
+#### 0.20.4 - 2019-03-27
 
 ##### New features
  - left-truncation support in AFT models, using the `entry_col` kwarg in `fit()`

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,8 +1,35 @@
 Changelog
 ~~~~~~~~~
 
-0.20.4
-^^^^^^
+0.20.5 - 2019-04-08
+^^^^^^^^^^^^^^^^^^^
+
+New features
+''''''''''''
+
+-  performance improvements for ``print_summary``.
+
+API changes
+'''''''''''
+
+-  ``utils.survival_events_from_table`` returns an integer weight vector
+   as well as durations and censoring vector.
+-  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
+   ``variance_`` to align with the usual lifelines convention.
+
+Bug fixes
+'''''''''
+
+-  Fixed an error in the ``CoxTimeVaryingFitter``\ ’s likelihood ratio
+   test when using strata.
+-  Fixed some plotting bugs with ``AalenJohansenFitter``
+
+.. _section-1:
+
+0.20.4 - 2019-03-27
+^^^^^^^^^^^^^^^^^^^
+
+.. _new-features-1:
 
 New features
 ''''''''''''
@@ -13,11 +40,15 @@ New features
    generating piecewise exp. data
 -  Faster ``print_summary`` for AFT models.
 
+.. _api-changes-1:
+
 API changes
 '''''''''''
 
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
+
+.. _bug-fixes-1:
 
 Bug fixes
 '''''''''
@@ -26,12 +57,12 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-1:
+.. _section-2:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ''''''''''''
@@ -44,12 +75,12 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-2:
+.. _section-3:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ''''''''''''
@@ -64,7 +95,7 @@ New features
 -  add a ``lifelines.plotting.qq_plot`` for univariate parametric models
    that handles censored data.
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API changes
 '''''''''''
@@ -73,7 +104,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -89,7 +120,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-3:
+.. _section-4:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -103,7 +134,7 @@ Bug fixes
    decades of development.
 -  suppressed unimportant warnings
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API changes
 '''''''''''
@@ -113,7 +144,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-4:
+.. _section-5:
 
 0.20.0 - 2019-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -122,7 +153,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ''''''''''''
@@ -130,7 +161,7 @@ New features
 -  smarter initialization for AFT models which should improve
    convergence.
 
-.. _api-changes-3:
+.. _api-changes-4:
 
 API changes
 '''''''''''
@@ -142,19 +173,19 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-5:
+.. _section-6:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ''''''''''''
@@ -164,24 +195,24 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-6:
+.. _section-7:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-7:
+.. _section-8:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ''''''''''''
@@ -193,12 +224,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-8:
+.. _section-9:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ''''''''''''
@@ -206,7 +237,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -216,12 +247,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-9:
+.. _section-10:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ''''''''''''
@@ -229,7 +260,7 @@ New features
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-4:
+.. _api-changes-5:
 
 API changes
 '''''''''''
@@ -238,12 +269,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-10:
+.. _section-11:
 
 0.19.0 - 2019-02-20
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-8:
+.. _new-features-9:
 
 New features
 ''''''''''''
@@ -256,7 +287,7 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-5:
+.. _api-changes-6:
 
 API changes
 '''''''''''
@@ -282,7 +313,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug Fixes
 '''''''''
@@ -299,7 +330,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-11:
+.. _section-12:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -309,7 +340,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-12:
+.. _section-13:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -330,7 +361,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-13:
+.. _section-14:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -340,7 +371,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-14:
+.. _section-15:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -350,7 +381,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-15:
+.. _section-16:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -366,7 +397,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-16:
+.. _section-17:
 
 0.18.1 2019-02-02
 ^^^^^^^^^^^^^^^^^
@@ -377,7 +408,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-17:
+.. _section-18:
 
 0.18.0 - 2019-01-31
 ^^^^^^^^^^^^^^^^^^^
@@ -414,7 +445,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-18:
+.. _section-19:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -422,7 +453,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-19:
+.. _section-20:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -434,7 +465,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-20:
+.. _section-21:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -442,7 +473,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-21:
+.. _section-22:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -453,7 +484,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-22:
+.. _section-23:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -470,7 +501,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-23:
+.. _section-24:
 
 0.17.0 - 2019-01-11
 ^^^^^^^^^^^^^^^^^^^
@@ -491,7 +522,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-24:
+.. _section-25:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -499,7 +530,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-25:
+.. _section-26:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -510,14 +541,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-26:
+.. _section-27:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-27:
+.. _section-28:
 
 0.16.0 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
@@ -553,7 +584,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-28:
+.. _section-29:
 
 0.15.4
 ^^^^^^
@@ -561,14 +592,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-29:
+.. _section-30:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-30:
+.. _section-31:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -579,7 +610,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-31:
+.. _section-32:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -588,7 +619,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-32:
+.. _section-33:
 
 0.15.0 - 2018-11-22
 ^^^^^^^^^^^^^^^^^^^
@@ -659,7 +690,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-33:
+.. _section-34:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -667,7 +698,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-34:
+.. _section-35:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -675,7 +706,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-35:
+.. _section-36:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -692,7 +723,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-36:
+.. _section-37:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -704,7 +735,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-37:
+.. _section-38:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -712,7 +743,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-38:
+.. _section-39:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -730,7 +761,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-39:
+.. _section-40:
 
 0.14.0 - 2018-03-03
 ^^^^^^^^^^^^^^^^^^^
@@ -752,7 +783,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-40:
+.. _section-41:
 
 0.13.0 - 2017-12-22
 ^^^^^^^^^^^^^^^^^^^
@@ -781,7 +812,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-41:
+.. _section-42:
 
 0.12.0
 ^^^^^^
@@ -798,7 +829,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-42:
+.. _section-43:
 
 0.11.3
 ^^^^^^
@@ -810,7 +841,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-43:
+.. _section-44:
 
 0.11.2
 ^^^^^^
@@ -818,14 +849,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-44:
+.. _section-45:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-45:
+.. _section-46:
 
 0.11.0 - 2017-06-21
 ^^^^^^^^^^^^^^^^^^^
@@ -839,14 +870,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-46:
+.. _section-47:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-47:
+.. _section-48:
 
 0.10.0
 ^^^^^^
@@ -861,7 +892,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-48:
+.. _section-49:
 
 0.9.4
 ^^^^^
@@ -884,7 +915,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-49:
+.. _section-50:
 
 0.9.2
 ^^^^^
@@ -893,7 +924,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-50:
+.. _section-51:
 
 0.9.1
 ^^^^^
@@ -901,7 +932,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-51:
+.. _section-52:
 
 0.9.0
 ^^^^^
@@ -917,7 +948,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-52:
+.. _section-53:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -934,7 +965,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-53:
+.. _section-54:
 
 0.8.0
 ^^^^^
@@ -953,7 +984,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-54:
+.. _section-55:
 
 0.7.1
 ^^^^^
@@ -972,7 +1003,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-55:
+.. _section-56:
 
 0.7.0 - 2015-03-01
 ^^^^^^^^^^^^^^^^^^
@@ -991,7 +1022,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-56:
+.. _section-57:
 
 0.6.1
 ^^^^^
@@ -1003,7 +1034,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-57:
+.. _section-58:
 
 0.6.0 - 2015-02-04
 ^^^^^^^^^^^^^^^^^^
@@ -1026,7 +1057,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-58:
+.. _section-59:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1047,7 +1078,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-59:
+.. _section-60:
 
 0.5.0 - 2014-12-07
 ^^^^^^^^^^^^^^^^^^
@@ -1060,7 +1091,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-60:
+.. _section-61:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1072,7 +1103,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-61:
+.. _section-62:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -1093,7 +1124,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-62:
+.. _section-63:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -1113,7 +1144,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-63:
+.. _section-64:
 
 0.4.1.1
 ^^^^^^^
@@ -1126,7 +1157,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-64:
+.. _section-65:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -1145,7 +1176,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-65:
+.. _section-66:
 
 0.4.0 - 2014-06-08
 ^^^^^^^^^^^^^^^^^^

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ copyright = "2014-{},  Cam Davidson-Pilon".format(date.today().year)
 #
 # The short X.Y version.
 
-version = "0.20.4"
+version = "0.20.5"
 # The full version, including dev info
 release = version
 

--- a/docs/lifelines.fitters.rst
+++ b/docs/lifelines.fitters.rst
@@ -112,7 +112,6 @@ lifelines.fitters.log\_logistic\_aft\_fitter module
 
 
 
-
 .. automodule:: lifelines.fitters
     :members:
     :undoc-members:

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -16,7 +16,6 @@ from scipy.linalg import solve as spsolve, LinAlgError
 from bottleneck import nansum as array_sum_to_scalar
 
 from lifelines.fitters import BaseFitter
-from lifelines import CoxPHFitter
 from lifelines.statistics import chisq_test
 from lifelines.utils import (
     _get_index,

--- a/lifelines/fitters/piecewise_exponential_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_fitter.py
@@ -72,13 +72,16 @@ class PiecewiseExponentialFitter(KnownModelParametericUnivariateFitter):
     """
 
     def __init__(self, breakpoints, *args, **kwargs):
-        breakpoints = np.sort(breakpoints)
-        if breakpoints and not (breakpoints[-1] < np.inf):
+        if not breakpoints:
+            raise ValueError("Breakpoints must be provided.")
+
+        if not (max(breakpoints) < np.inf):
             raise ValueError("Do not add inf to the breakpoints.")
 
-        if breakpoints and breakpoints[0] <= 0:
+        if min(breakpoints) <= 0:
             raise ValueError("First breakpoint must be greater than 0.")
 
+        breakpoints = np.sort(breakpoints)
         self.breakpoints = np.append(breakpoints, [np.inf])
         n_breakpoints = len(self.breakpoints)
 

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -416,8 +416,6 @@ def survival_events_from_table(survival_table, observed_deaths_col="observed", c
     >>> W = np.array([ 1,  1,  1,  1,  1,  1])
 
     """
-    columns = [observed_deaths_col, censored_col]
-
     T_ = []
     E_ = []
     W_ = []

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.20.4"
+__version__ = "0.20.5"

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -552,10 +552,11 @@ class TestPiecewiseExponentialFitter:
         with pytest.raises(ValueError):
             pwf = PiecewiseExponentialFitter([1, 2, 3, np.inf])
 
+    @flaky(max_runs=3, min_passes=2)
     def test_fit_on_simulated_data(self):
         bp = [1, 2]
         lambdas = [0.5, 0.1, 1.0]
-        N = int(5 * 1e5)
+        N = int(1e6)
         T_actual = piecewise_exponential_survival_data(N, bp, lambdas)
         T_censor = piecewise_exponential_survival_data(N, bp, lambdas)
         T = np.minimum(T_actual, T_censor)


### PR DESCRIPTION
#### 0.20.5 - 2019-04-08

##### New features
 - performance improvements for `print_summary`.

##### API changes
 - `utils.survival_events_from_table` returns an integer weight vector as well as durations and censoring vector.
 - in `AalenJohansenFitter`, the `variance` parameter is renamed to `variance_` to align with the usual lifelines convention.

##### Bug fixes
 - Fixed an error in the `CoxTimeVaryingFitter`'s likelihood ratio test when using strata.
 - Fixed some plotting bugs with `AalenJohansenFitter`

closes #694 too