### PR TITLE
v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 ### Changelog
 
+#### 0.21.1 - 2019-04-26
 
-#### 0.21.0
+##### New features
+ - users can provided their own start and stop column names in `add_covariate_to_timeline`
+ - PiecewiseExponentialFitter now allows numpy arrays as breakpoints
+
+##### API changes
+ - output of `survival_table_from_events` when collapsing rows to intervals now removes the "aggregate" column multi-index.
+
+##### Bug fixes
+ - fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
+
+#### 0.21.0 - 2019-04-12
 
 ##### New features
  - `weights` is now a optional kwarg for parametric univariate models.

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,8 +1,33 @@
 Changelog
 ~~~~~~~~~
 
-0.21.0
-^^^^^^
+0.21.1 - 2019-04-26
+^^^^^^^^^^^^^^^^^^^
+
+New features
+''''''''''''
+
+-  users can provided their own start and stop column names in
+   ``add_covariate_to_timeline``
+-  PiecewiseExponentialFitter now allows numpy arrays as breakpoints
+
+API changes
+'''''''''''
+
+-  output of ``survival_table_from_events`` when collapsing rows to
+   intervals now removes the “aggregate” column multi-index.
+
+Bug fixes
+'''''''''
+
+-  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
+
+.. _section-1:
+
+0.21.0 - 2019-04-12
+^^^^^^^^^^^^^^^^^^^
+
+.. _new-features-1:
 
 New features
 ''''''''''''
@@ -16,6 +41,8 @@ New features
 -  a new interval censored dataset is available under
    ``lifelines.datasets.load_diabetes``
 
+.. _api-changes-1:
+
 API changes
 '''''''''''
 
@@ -25,6 +52,8 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
+.. _bug-fixes-1:
+
 Bug fixes
 '''''''''
 
@@ -33,19 +62,19 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-1:
+.. _section-2:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ''''''''''''
 
 -  performance improvements for ``print_summary``.
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API changes
 '''''''''''
@@ -55,7 +84,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -64,12 +93,12 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-2:
+.. _section-3:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ''''''''''''
@@ -80,7 +109,7 @@ New features
    generating piecewise exp. data
 -  Faster ``print_summary`` for AFT models.
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API changes
 '''''''''''
@@ -88,7 +117,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
@@ -97,12 +126,12 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-3:
+.. _section-4:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ''''''''''''
@@ -115,12 +144,12 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-4:
+.. _section-5:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ''''''''''''
@@ -135,7 +164,7 @@ New features
 -  add a ``lifelines.plotting.qq_plot`` for univariate parametric models
    that handles censored data.
 
-.. _api-changes-3:
+.. _api-changes-4:
 
 API changes
 '''''''''''
@@ -144,7 +173,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -160,7 +189,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-5:
+.. _section-6:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -174,7 +203,7 @@ Bug fixes
    decades of development.
 -  suppressed unimportant warnings
 
-.. _api-changes-4:
+.. _api-changes-5:
 
 API changes
 '''''''''''
@@ -184,7 +213,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-6:
+.. _section-7:
 
 0.20.0 - 2019-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -193,7 +222,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ''''''''''''
@@ -201,7 +230,7 @@ New features
 -  smarter initialization for AFT models which should improve
    convergence.
 
-.. _api-changes-5:
+.. _api-changes-6:
 
 API changes
 '''''''''''
@@ -213,19 +242,19 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-7:
+.. _section-8:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ''''''''''''
@@ -235,24 +264,24 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-8:
+.. _section-9:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-9:
+.. _section-10:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ''''''''''''
@@ -264,12 +293,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-10:
+.. _section-11:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-8:
+.. _new-features-9:
 
 New features
 ''''''''''''
@@ -277,7 +306,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -287,12 +316,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-11:
+.. _section-12:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-9:
+.. _new-features-10:
 
 New features
 ''''''''''''
@@ -300,7 +329,7 @@ New features
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-6:
+.. _api-changes-7:
 
 API changes
 '''''''''''
@@ -309,12 +338,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-12:
+.. _section-13:
 
 0.19.0 - 2019-02-20
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-10:
+.. _new-features-11:
 
 New features
 ''''''''''''
@@ -327,7 +356,7 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-7:
+.. _api-changes-8:
 
 API changes
 '''''''''''
@@ -353,7 +382,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug Fixes
 '''''''''
@@ -370,7 +399,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-13:
+.. _section-14:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -380,7 +409,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-14:
+.. _section-15:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -401,7 +430,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-15:
+.. _section-16:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -411,7 +440,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-16:
+.. _section-17:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -421,7 +450,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-17:
+.. _section-18:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -437,7 +466,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-18:
+.. _section-19:
 
 0.18.1 2019-02-02
 ^^^^^^^^^^^^^^^^^
@@ -448,7 +477,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-19:
+.. _section-20:
 
 0.18.0 - 2019-01-31
 ^^^^^^^^^^^^^^^^^^^
@@ -485,7 +514,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-20:
+.. _section-21:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -493,7 +522,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-21:
+.. _section-22:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -505,7 +534,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-22:
+.. _section-23:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -513,7 +542,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-23:
+.. _section-24:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -524,7 +553,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-24:
+.. _section-25:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -541,7 +570,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-25:
+.. _section-26:
 
 0.17.0 - 2019-01-11
 ^^^^^^^^^^^^^^^^^^^
@@ -562,7 +591,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-26:
+.. _section-27:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -570,7 +599,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-27:
+.. _section-28:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -581,14 +610,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-28:
+.. _section-29:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-29:
+.. _section-30:
 
 0.16.0 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
@@ -624,7 +653,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-30:
+.. _section-31:
 
 0.15.4
 ^^^^^^
@@ -632,14 +661,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-31:
+.. _section-32:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-32:
+.. _section-33:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -650,7 +679,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-33:
+.. _section-34:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -659,7 +688,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-34:
+.. _section-35:
 
 0.15.0 - 2018-11-22
 ^^^^^^^^^^^^^^^^^^^
@@ -730,7 +759,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-35:
+.. _section-36:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -738,7 +767,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-36:
+.. _section-37:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -746,7 +775,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-37:
+.. _section-38:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -763,7 +792,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-38:
+.. _section-39:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -775,7 +804,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-39:
+.. _section-40:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -783,7 +812,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-40:
+.. _section-41:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -801,7 +830,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-41:
+.. _section-42:
 
 0.14.0 - 2018-03-03
 ^^^^^^^^^^^^^^^^^^^
@@ -823,7 +852,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-42:
+.. _section-43:
 
 0.13.0 - 2017-12-22
 ^^^^^^^^^^^^^^^^^^^
@@ -852,7 +881,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-43:
+.. _section-44:
 
 0.12.0
 ^^^^^^
@@ -869,7 +898,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-44:
+.. _section-45:
 
 0.11.3
 ^^^^^^
@@ -881,7 +910,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-45:
+.. _section-46:
 
 0.11.2
 ^^^^^^
@@ -889,14 +918,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-46:
+.. _section-47:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-47:
+.. _section-48:
 
 0.11.0 - 2017-06-21
 ^^^^^^^^^^^^^^^^^^^
@@ -910,14 +939,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-48:
+.. _section-49:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-49:
+.. _section-50:
 
 0.10.0
 ^^^^^^
@@ -932,7 +961,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-50:
+.. _section-51:
 
 0.9.4
 ^^^^^
@@ -955,7 +984,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-51:
+.. _section-52:
 
 0.9.2
 ^^^^^
@@ -964,7 +993,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-52:
+.. _section-53:
 
 0.9.1
 ^^^^^
@@ -972,7 +1001,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-53:
+.. _section-54:
 
 0.9.0
 ^^^^^
@@ -988,7 +1017,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-54:
+.. _section-55:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -1005,7 +1034,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-55:
+.. _section-56:
 
 0.8.0
 ^^^^^
@@ -1024,7 +1053,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-56:
+.. _section-57:
 
 0.7.1
 ^^^^^
@@ -1043,7 +1072,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-57:
+.. _section-58:
 
 0.7.0 - 2015-03-01
 ^^^^^^^^^^^^^^^^^^
@@ -1062,7 +1091,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-58:
+.. _section-59:
 
 0.6.1
 ^^^^^
@@ -1074,7 +1103,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-59:
+.. _section-60:
 
 0.6.0 - 2015-02-04
 ^^^^^^^^^^^^^^^^^^
@@ -1097,7 +1126,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-60:
+.. _section-61:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1118,7 +1147,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-61:
+.. _section-62:
 
 0.5.0 - 2014-12-07
 ^^^^^^^^^^^^^^^^^^
@@ -1131,7 +1160,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-62:
+.. _section-63:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1143,7 +1172,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-63:
+.. _section-64:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -1164,7 +1193,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-64:
+.. _section-65:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -1184,7 +1213,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-65:
+.. _section-66:
 
 0.4.1.1
 ^^^^^^^
@@ -1197,7 +1226,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-66:
+.. _section-67:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -1216,7 +1245,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-67:
+.. _section-68:
 
 0.4.0 - 2014-06-08
 ^^^^^^^^^^^^^^^^^^

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ copyright = "2014-{},  Cam Davidson-Pilon".format(date.today().year)
 #
 # The short X.Y version.
 
-version = "0.21.0"
+version = "0.21.1"
 # The full version, including dev info
 release = version
 

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1246,7 +1246,7 @@ def add_covariate_to_timeline(
         raise ValueError("delay parameter must be equal to or greater than 0")
 
     if any(col not in long_form_df for col in (id_col, event_col, start_col, stop_col)):
-        raise ValueError("Missing column in long_form_df")
+        raise IndexError("Missing column in long_form_df")
 
     cv[duration_col] += delay
     cv = cv.dropna()

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"


### PR DESCRIPTION

#### 0.21.1 - 2019-04-26

##### New features
 - users can provided their own start and stop column names in `add_covariate_to_timeline`
 - PiecewiseExponentialFitter now allows numpy arrays as breakpoints

##### API changes
 - output of `survival_table_from_events` when collapsing rows to intervals now removes the "aggregate" column multi-index.

##### Bug fixes
 - fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
