### PR TITLE
Fixed scipy version to <=1.2.1

### DIFF
--- a/reqs/base-requirements.txt
+++ b/reqs/base-requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.14.0
-scipy>=1.0
+scipy>=1.0,<=1.2.1
 pandas>=0.23.0
 matplotlib>=3.0
 bottleneck>=1.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ],
     install_requires=[
         "numpy>=1.6.0",
-        "scipy>=1.0",
+        "scipy<=1.2.1",
         "pandas>=0.23.0",
         "matplotlib>=3.0",
         "bottleneck>=1.0",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ],
     install_requires=[
         "numpy>=1.6.0",
-        "scipy<=1.2.1",
+        "scipy>=1.0,<=1.2.1",
         "pandas>=0.23.0",
         "matplotlib>=3.0",
         "bottleneck>=1.0",


### PR DESCRIPTION
Fixed scipy version to <= 1.2.1 until autograd HIPS/autograd#490 is released. After that we could fix autograd to >= whatever version they release with that specific PR and return scipy to >=1.0.

In scipy >= 1.3.0 some functions that autograd uses are moved to a different namespace. Due to this change lifelines currently will not work when installed trough a package manager like pypi.