### PR TITLE
Fix typo in smoothing hazard curve docs

### DIFF
--- a/docs/Survival analysis with lifelines.rst
+++ b/docs/Survival analysis with lifelines.rst
@@ -414,8 +414,8 @@ there is a catch. The derivation involves a kernel smoother (to smooth
 out the differences of the cumulative hazard curve) , and this requires
 us to specify a bandwidth parameter that controls the amount of
 smoothing. This functionality is in the ``smoothed_hazard_``
-and ``hazard_confidence_intervals_`` methods. Why methods? They require
-an argument representing the bandwidth.
+and ``smoothed_hazard_confidence_intervals_`` methods. Why methods?
+They require an argument representing the bandwidth.
 
 
 There is also a ``plot_hazard`` function (that also requires a


### PR DESCRIPTION
There is no such method `hazard_confidence_intervals_`,
but there is a `smoothed_hazard_confidence_intervals_`.