### PR TITLE
v0.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Changelog
 
+#### 0.22.4
+
+
+##### New features
+ - model's now expose a `log_likelihood_` property.
+
+
 #### 0.22.3
 
 ##### API changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ##### New features
  - model's now expose a `log_likelihood_` property.
+ - new `conditional_after` argument on `predict_*` methods that make prediction on censored subjects easier.
+
+##### Bug fixes
+ - convergence is improved for most models, and many overflow warnings have been eliminated.
+ - Fixed an error in the `predict_percentile` of `LogLogisticAFTFitter`. New tests have been added around this.
 
 
 #### 0.22.3

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -114,7 +114,7 @@ Convergence
 
 Fitting the Cox model to the data involves using iterative methods. *lifelines* takes extra effort to help with convergence, so please be attentive to any warnings that appear. Fixing any warnings will generally help convergence and decrease the number of iterative steps required. If you wish to see the fitting, there is a ``show_progress`` parameter in :meth:`~lifelines.fitters.coxph_fitter.CoxPHFitter.fit` function. For further help, see :ref:`Problems with convergence in the Cox Proportional Hazard Model`.
 
-After fitting, the value of the maximum log-likelihood this available using :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter._log_likelihood`. The variance matrix of the coefficients is available under :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter.variance_matrix_`.
+After fitting, the value of the maximum log-likelihood this available using :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter.log_likelihood`. The variance matrix of the coefficients is available under :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter.variance_matrix_`.
 
 
 Goodness of fit
@@ -669,9 +669,9 @@ Often, you don't know *a priori* which AFT model to use. Each model has some ass
     lnf = LogNormalAFTFitter().fit(rossi, 'week', 'arrest')
     wf = WeibullAFTFitter().fit(rossi, 'week', 'arrest')
 
-    print(llf._log_likelihood)  # -679.938
-    print(lnf._log_likelihood)  # -683.234
-    print(wf._log_likelihood)   # -679.916, slightly the best model.
+    print(llf.log_likelihood_)  # -679.938
+    print(lnf.log_likelihood_)  # -683.234
+    print(wf.log_likelihood_)   # -679.916, slightly the best model.
 
 
     # with some heterogeneity in the ancillary parameters
@@ -680,9 +680,9 @@ Often, you don't know *a priori* which AFT model to use. Each model has some ass
     lnf = LogNormalAFTFitter().fit(rossi, 'week', 'arrest', ancillary_df=ancillary_df)
     wf = WeibullAFTFitter().fit(rossi, 'week', 'arrest', ancillary_df=ancillary_df)
 
-    print(llf._log_likelihood) # -678.94, slightly the best model.
-    print(lnf._log_likelihood) # -680.39
-    print(wf._log_likelihood)  # -679.60
+    print(llf.log_likelihood_) # -678.94, slightly the best model.
+    print(lnf.log_likelihood_) # -680.39
+    print(wf.log_likelihood_)  # -679.60
 
 
 Left, right and interval censored data

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -135,7 +135,7 @@ After fitting, you can use use the suite of prediction methods: :meth:`~lifeline
 
 .. code:: python
 
-    X = rossi_dataset.drop(["week", "arrest"], axis=1)
+    X = rossi_dataset
 
     cph.predict_partial_hazard(X)
 
@@ -156,54 +156,20 @@ A common use case is to predict the event time of censored subjects. This is eas
 
 Thus we scale the original survival function by the survival function at time :math:`s` (everything prior to :math:`s` should be mapped to 1.0 as well, since we are working with probabilities and we know that the subject was alive before :math:`s`).
 
-Back to our original problem of predicting the event time of censored individuals, we do the same thing:
+Back to our original problem of predicting the event time of censored individuals, *lifelines* has all this math and logic built in when using the `conditional_after` kwarg.
 
-.. code:: python
-
-    from lifelines import CoxPHFitter
-    from lifelines.datasets import load_regression_dataset
-
-    df = load_regression_dataset()
-
-    cph = CoxPHFitter().fit(df, 'T', 'E')
-
-    censored_subjects = df.loc[df['E'] == 0]
-
-    unconditioned_sf = cph.predict_survival_function(censored_subjects)
-
-    conditioned_sf = unconditioned_sf.apply(lambda c: (c / c.loc[df.loc[c.name, 'T']]).clip_upper(1))
-
-    # let's focus on a single subject
-    subject = 13
-    unconditioned_sf[subject].plot(ls="--", color="#A60628", label="unconditioned")
-    conditioned_sf[subject].plot(color="#A60628", label="conditioned on $T>10$")
-    plt.legend()
+.. code::
 
 
-.. image:: images/survival_regression_conditioning.png
+    censored_subjects = rossi.loc[~rossi['arrest'].astype(bool)]
+    censored_subjects_last_obs = censored_subjects['week']
 
+    cph.predict_partial_hazard(censored_subjects, conditional_after=censored_subjects_last_obs)
 
-From here, you can pick a median or percentile as a best guess as to the subject's event time:
+    cph.predict_survival_function(censored_subjects, times=[5., 25., 50.], conditional_after=censored_subjects_last_obs)
 
-.. code:: python
+    cph.predict_median(censored_subjects, conditional_after=censored_subjects_last_obs)
 
-
-    from lifelines.utils import median_survival_times, qth_survival_times
-
-    predictions_50 = median_survival_times(conditioned_sf)
-    predictions_75 = qth_survival_times(0.75, conditioned_sf)
-
-
-    # plotting subject 13 again
-    plt.hlines([0.5, 0.75], 0, 23, alpha=0.5, label="percentiles")
-
-    plt.scatter(median_survival_times(conditioned_sf[subject]), 0.5,  color="#E24A33", label="median prediction", zorder=20)
-    plt.scatter(qth_survival_times(0.75, conditioned_sf[subject]), 0.75,  color="#467821", label="q=75 prediction", zorder=20)
-
-    plt.legend()
-
-
-.. image:: images/survival_regression_conditioning_with_median.png
 
 
 Plotting the coefficients
@@ -592,14 +558,26 @@ Given a new subject, we ask questions about their future survival? When are they
 
     X = rossi.loc[:10]
 
-    aft.predict_cumulative_hazard(X, ancillary_X=X)
-    aft.predict_survival_function(X, ancillary_X=X)
-    aft.predict_median(X, ancillary_X=X)
-    aft.predict_percentile(X, ancillary_X=X)
-    aft.predict_expectation(X, ancillary_X=X)
+    aft.predict_cumulative_hazard(X, ancillary_df=X)
+    aft.predict_survival_function(X, ancillary_df=X)
+    aft.predict_median(X, ancillary_df=X)
+    aft.predict_percentile(X, p=0.9, ancillary_df=X)
+    aft.predict_expectation(X, ancillary_df=X)
 
 
-There are two tunable parameters that can be used to to achieve a better test score. These are ``penalizer`` and ``l1_ratio`` in the call to :class:`~lifelines.fitters.weibull_aft_fitter.WeibullAFTFitter`. The penalizer is similar to scikit-learn's ``ElasticNet`` model, see their `docs <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html>`_.
+When predicting time remaining for uncensored individuals, you can use the `conditional_after` kwarg:
+
+
+    censored_X = rossi.loc[~rossi['arrest'].astype(bool)]
+    censored_subjects_last_obs = censored_X['week']
+
+    aft.predict_cumulative_hazard(censored_X, ancillary_df=censored_X, conditional_after=censored_subjects_last_obs)
+    aft.predict_survival_function(censored_X, ancillary_df=censored_X, conditional_after=censored_subjects_last_obs)
+    aft.predict_median(censored_X, ancillary_df=censored_X, conditional_after=censored_subjects_last_obs)
+    aft.predict_percentile(X, p=0.9, ancillary_df=censored_X, conditional_after=censored_subjects_last_obs)
+
+
+There are two hyper-parameters that can be used to to achieve a better test score. These are ``penalizer`` and ``l1_ratio`` in the call to :class:`~lifelines.fitters.weibull_aft_fitter.WeibullAFTFitter`. The penalizer is similar to scikit-learn's ``ElasticNet`` model, see their `docs <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html>`_.
 
 .. code:: python
 

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -967,7 +967,7 @@ Fitted survival models typically have a concordance index between 0.55 and 0.75 
     from lifelines.utils import concordance_index
     print(concordance_index(rossi['week'], -cph.predict_partial_hazard(rossi), rossi['arrest']))
 
-.. note:: Remember, the concordance score evaluates the relative rankings of subject's event times. Thus, it is scale invariant (i.e. you can multiple by a positive constant, or add a constant, and the rankings won't change). A model maximized for concordance-index does not necessarily give good predicted *times*, but will give good predicted *rankings*.
+.. note:: Remember, the concordance score evaluates the relative rankings of subject's event times. Thus, it is scale and shift invariant (i.e. you can multiple by a positive constant, or add a constant, and the rankings won't change). A model maximized for concordance-index does not necessarily give good predicted *times*, but will give good predicted *rankings*.
 
 
 However, there are other, arguably better, methods to measure the fit of a model. Included in ``print_summary`` is the log-likelihood, which can be used in an `AIC calculation <https://en.wikipedia.org/wiki/Akaike_information_criterion>`_, and the `log-likelihood ratio statistic <https://en.wikipedia.org/wiki/Likelihood-ratio_test>`_. Generally, I personally loved this article by Frank Harrell, `"Statistically Efficient Ways to Quantify Added Predictive Value of New Measurements" <http://www.fharrell.com/post/addvalue/>`_.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,8 @@
-### Examples
+## Examples
 
 In this folder are some examples of lifelines usage, some with and some without comments and context. You can see some common patterns using lifelines and survival analysis.
+
+
 
 
 #### Other examples

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -2179,9 +2179,17 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             regressors = {self._primary_parameter_name: primary_columns, self._ancillary_parameter_name: []}
 
         if self.fit_intercept:
-            assert "_intercept" not in df
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
             df["_intercept"] = 1.0
             regressors[self._primary_parameter_name].append("_intercept")
+            regressors[self._ancillary_parameter_name].append("_intercept")
+        elif not self.fit_intercept and ((ancillary_df is None) or (ancillary_df == False) or not self.model_ancillary):
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
+            df["_intercept"] = 1.0
             regressors[self._ancillary_parameter_name].append("_intercept")
 
         super(ParametericAFTRegressionFitter, self)._fit(
@@ -2333,9 +2341,17 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             regressors = {self._primary_parameter_name: primary_columns, self._ancillary_parameter_name: []}
 
         if self.fit_intercept:
-            assert "_intercept" not in df
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
             df["_intercept"] = 1.0
             regressors[self._primary_parameter_name].append("_intercept")
+            regressors[self._ancillary_parameter_name].append("_intercept")
+        elif not self.fit_intercept and ((ancillary_df is None) or (ancillary_df == False) or not self.model_ancillary):
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
+            df["_intercept"] = 1.0
             regressors[self._ancillary_parameter_name].append("_intercept")
 
         super(ParametericAFTRegressionFitter, self)._fit(
@@ -2465,9 +2481,17 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             regressors = {self._primary_parameter_name: primary_columns, self._ancillary_parameter_name: []}
 
         if self.fit_intercept:
-            assert "_intercept" not in df
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
             df["_intercept"] = 1.0
             regressors[self._primary_parameter_name].append("_intercept")
+            regressors[self._ancillary_parameter_name].append("_intercept")
+        elif not self.fit_intercept and ((ancillary_df is None) or (ancillary_df == False) or not self.model_ancillary):
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
+            df["_intercept"] = 1.0
             regressors[self._ancillary_parameter_name].append("_intercept")
 
         super(ParametericAFTRegressionFitter, self)._fit(
@@ -2691,9 +2715,8 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         X = X.copy()
 
         if isinstance(X, pd.DataFrame):
-            if self.fit_intercept:
-                X["_intercept"] = 1.0
-            X = X[self.params_.loc[self._primary_parameter_name].index]
+            X["_intercept"] = 1.0
+            primary_X = X[self.params_.loc[self._primary_parameter_name].index]
         else:
             # provided numpy array
             assert X.shape[1] == self.params_.loc[self._primary_parameter_name].shape[0]
@@ -2714,7 +2737,7 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         primary_params = self.params_[self._primary_parameter_name]
         ancillary_params = self.params_[self._ancillary_parameter_name]
 
-        primary_scores = np.exp(np.dot(X, primary_params))
+        primary_scores = np.exp(np.dot(primary_X, primary_params))
         ancillary_scores = np.exp(np.dot(ancillary_X, ancillary_params))
 
         return primary_scores, ancillary_scores

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1498,7 +1498,7 @@ class ParametricRegressionFitter(BaseFitter):
             method=self._scipy_fit_method,
             jac=True,
             args=(Ts, E, weights, entries, Xs),
-            options={**{"disp": show_progress, "gtol": 1e-6}, **self._scipy_fit_options},
+            options={**{"disp": show_progress}, **self._scipy_fit_options},
         )
         if show_progress or not results.success:
             print(results)

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1498,7 +1498,7 @@ class ParametricRegressionFitter(BaseFitter):
             method=self._scipy_fit_method,
             jac=True,
             args=(Ts, E, weights, entries, Xs),
-            options={**{"disp": show_progress}, **self._scipy_fit_options},
+            options={**{"disp": show_progress, "gtol": 1e-6}, **self._scipy_fit_options},
         )
         if show_progress or not results.success:
             print(results)

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -454,7 +454,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
         self._hessian_ = hessian
         self._score_ = gradient
-        self._log_likelihood = ll
+        self.log_likelihood_ = ll
 
         if show_progress and completed:
             print("Convergence completed after %d iterations." % (i))
@@ -472,6 +472,14 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             warnings.warn("Newton-Rhapson failed to converge sufficiently in %d steps." % max_steps, ConvergenceWarning)
 
         return beta
+
+    @property
+    def _log_likelihood(self):
+        warnings.warn(
+            "Please use `log_likelihood` property instead. `_log_likelihood` will be removed in a future version of lifelines",
+            DeprecationWarning,
+        )
+        return self.log_likelihood_
 
     def _get_gradients(self, X, events, start, stop, weights, beta):  # pylint: disable=too-many-locals
         """
@@ -729,10 +737,10 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
                     weights_col="__weights",
                     strata=self.strata,
                 )
-                ._log_likelihood
+                .log_likelihood_
             )
 
-        ll_alt = self._log_likelihood
+        ll_alt = self.log_likelihood_
         test_stat = 2 * (ll_alt - ll_null)
         degrees_freedom = self.params_.shape[0]
         p_value = chisq_test(test_stat, degrees_freedom=degrees_freedom)

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -554,7 +554,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
         self._hessian_ = hessian
         self._score_ = gradient
-        self._log_likelihood = ll
+        self.log_likelihood_ = ll
 
         if show_progress and completed:
             print("Convergence completed after %d iterations." % (i))
@@ -574,6 +574,14 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             )
 
         return beta
+
+    @property
+    def _log_likelihood(self):
+        warnings.warn(
+            "Please use `log_likelihood` property instead. `_log_likelihood` will be removed in a future version of lifelines",
+            DeprecationWarning,
+        )
+        return self.log_likelihood_
 
     def _get_efron_values_single(self, X, T, E, weights, beta):
         """
@@ -1349,7 +1357,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
                 ll_null = self._trivial_log_likelihood_single(
                     self.durations.values, self.event_observed.values, self.weights.values
                 )
-        ll_alt = self._log_likelihood
+        ll_alt = self.log_likelihood_
         test_stat = 2 * ll_alt - 2 * ll_null
         degrees_freedom = self.params_.shape[0]
         p_value = chisq_test(test_stat, degrees_freedom=degrees_freedom)

--- a/lifelines/fitters/generalized_gamma_aft_fitter.py
+++ b/lifelines/fitters/generalized_gamma_aft_fitter.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+import autograd.numpy as np
+import warnings
+from autograd.numpy import exp, abs, log
+from scipy.special import gammainccinv, gammaincinv
+from autograd_gamma import gammaincc, gammainc, gammaln, gammainccln, gammaincln
+from lifelines.fitters import ParametricRegressionFitter
+from lifelines.utils import coalesce, CensoringType
+from lifelines.utils.safe_exp import safe_exp
+from lifelines import utils
+
+
+class GeneralizedGammaAFTFitter(ParametricRegressionFitter):
+    r"""
+
+    This class implements a Generalized Gamma model for univariate data. The model has parameterized
+    form:
+
+    The survival function is:
+
+    .. math::
+        S(t)=\left\{ \begin{array}{}
+           1-{{\Gamma}_{RL}}\left( \tfrac{1}{{{\lambda }^{2}}};\tfrac{{{e}^{\lambda \left( \tfrac{\text{ln}(t)-\mu }{\sigma } \right)}}}{{{\lambda }^{2}}} \right)\text{ if }\lambda >0  \\
+           {{\Gamma}_{RL}}\left( \tfrac{1}{{{\lambda }^{2}}};\tfrac{{{e}^{\lambda \left( \tfrac{\text{ln}(t)-\mu }{\sigma } \right)}}}{{{\lambda }^{2}}} \right)\text{       if }\lambda < 0  \\
+        \end{array} \right.\,\!
+
+    where :math:`\Gamma_{RL}` is the regularized lower incomplete Gamma function.
+
+    This model has the Exponential, Weibull, Gamma and Log-Normal as sub-models, and thus can be used as a way to test which
+    model to use:
+
+    1. When :math:`\lambda = 1` and :math:`\sigma = 1`, then the data is Exponential.
+    2. When :math:`\lambda = 1` then the data is Weibull.
+    3. When :math:`\sigma = \lambda` then the data is Gamma.
+    4. When :math:`\lambda = 0` then the data is  Log-Normal.
+    5. When :math:`\lambda = -1` then the data is Inverse-Weibull.
+    6. When :math:`-\sigma = \lambda` then the data is Inverse-Gamma.
+
+
+    After calling the `.fit` method, you have access to properties like: ``cumulative_hazard_``, ``survival_function_``,
+    A summary of the fit is available with the method ``print_summary()``.
+
+
+    Important
+    -------------
+    The parameterization implemented has :math:`\log\sigma`, thus there is a `ln_sigma_` in the output. Exponentiate this parameter
+    to recover :math:`\sigma`.
+
+
+    Important
+    -------------
+    This model is experimental. It's API may change in the future. Also, it's convergence is not very stable.
+
+
+    Parameters
+    -----------
+    alpha: float, optional (default=0.05)
+        the level in the confidence intervals.
+
+
+    Examples
+    --------
+
+    >>> from lifelines import GeneralizedGammaFitter
+    >>> from lifelines.datasets import load_waltons
+    >>> waltons = load_waltons()
+    >>> ggf = GeneralizedGammaFitter()
+    >>> ggf.fit(waltons['T'], waltons['E'])
+    >>> ggf.plot()
+    >>> ggf.summary
+
+    Attributes
+    ----------
+    cumulative_hazard_ : DataFrame
+        The estimated cumulative hazard (with custom timeline if provided)
+    hazard_ : DataFrame
+        The estimated hazard (with custom timeline if provided)
+    survival_function_ : DataFrame
+        The estimated survival function (with custom timeline if provided)
+    cumumlative_density_ : DataFrame
+        The estimated cumulative density function (with custom timeline if provided)
+    variance_matrix_ : numpy array
+        The variance matrix of the coefficients
+    median_: float
+        The median time to event
+    lambda_: float
+        The fitted parameter in the model
+    rho_: float
+        The fitted parameter in the model
+    alpha_: float
+        The fitted parameter in the model
+    durations: array
+        The durations provided
+    event_observed: array
+        The event_observed variable provided
+    timeline: array
+        The time line to use for plotting and indexing
+    entry: array or None
+        The entry array provided, or None
+    """
+    _fitted_parameter_names = ["sigma_", "mu_", "lambda_"]
+    _scipy_fit_method = "trust-exact"
+
+    def _create_initial_point(self, Ts, E, entries, weights, Xs):
+        import lifelines
+
+        uni_model = lifelines.GeneralizedGammaFitter()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            if utils.CensoringType.is_right_censoring(self):
+                uni_model.fit_right_censoring(Ts[0], event_observed=E, entry=entries, weights=weights)
+            elif utils.CensoringType.is_interval_censoring(self):
+                uni_model.fit_interval_censoring(Ts[0], Ts[1], event_observed=E, entry=entries, weights=weights)
+            elif utils.CensoringType.is_left_censoring(self):
+                uni_model.fit_left_censoring(Ts[1], event_observed=E, entry=entries, weights=weights)
+
+            # we may use this later in print_summary
+            self._ll_null_ = uni_model.log_likelihood_
+
+            return {
+                # tack on as the intercept
+                "mu_": np.array([0] * (Xs["mu_"].shape[1] - 1) + [uni_model.mu_]),
+                "sigma_": np.array([0] * (Xs["sigma_"].shape[1] - 1) + [uni_model.ln_sigma_]),
+                "lambda_": np.array([0] * (Xs["lambda_"].shape[1] - 1) + [uni_model.lambda_]),
+            }
+
+    def _survival_function(self, params, T, Xs):
+        lambda_ = Xs["lambda_"] @ params["lambda_"]
+        sigma_ = safe_exp(Xs["sigma_"] @ params["sigma_"])
+        mu_ = Xs["mu_"] @ params["mu_"]
+
+        Z = (log(T) - mu_) / sigma_
+        ilambda_2 = 1 / lambda_ ** 2
+        exp_term = safe_exp(lambda_ * Z - 2 * log(np.abs(lambda_)))
+
+        return np.where(lambda_ > 0, gammaincc(ilambda_2, exp_term), gammainc(ilambda_2, exp_term))
+
+    def _cumulative_hazard(self, params, T, Xs):
+        lambda_ = Xs["lambda_"] @ params["lambda_"]
+        sigma_ = safe_exp(Xs["sigma_"] @ params["sigma_"])
+        mu_ = Xs["mu_"] @ params["mu_"]
+
+        ilambda_2 = 1 / lambda_ ** 2
+        Z = (log(T) - mu_) / sigma_
+        exp_term = np.clip(safe_exp(lambda_ * Z - 2 * log(np.abs(lambda_))), 1e-300, np.inf)
+
+        return -np.where(lambda_ > 0, gammainccln(ilambda_2, exp_term), gammaincln(ilambda_2, exp_term))
+
+    def _log_hazard(self, params, T, Xs):
+        lambda_ = Xs["lambda_"] @ params["lambda_"]
+        ln_sigma_ = Xs["sigma_"] @ params["sigma_"]
+        mu_ = Xs["mu_"] @ params["mu_"]
+
+        ilambda_2 = 1 / lambda_ ** 2
+        Z = (log(T) - mu_) / safe_exp(ln_sigma_)
+        exp_term = np.clip(safe_exp(lambda_ * Z - 2 * log(np.abs(lambda_))), 1e-300, np.inf)
+
+        return (
+            log(np.abs(lambda_))
+            - log(T)
+            - ln_sigma_
+            - gammaln(ilambda_2)
+            + (lambda_ * Z - 2 * log(np.abs(lambda_))) * ilambda_2
+            - exp_term
+            - np.where(lambda_ > 0, gammainccln(ilambda_2, exp_term), gammaincln(ilambda_2, exp_term))
+        )

--- a/lifelines/fitters/generalized_gamma_aft_fitter.py
+++ b/lifelines/fitters/generalized_gamma_aft_fitter.py
@@ -99,7 +99,7 @@ class GeneralizedGammaAFTFitter(ParametricRegressionFitter):
         The entry array provided, or None
     """
     _fitted_parameter_names = ["sigma_", "mu_", "lambda_"]
-    _scipy_fit_method = "trust-exact"
+    _scipy_fit_method = "SLSQP"
 
     def _create_initial_point(self, Ts, E, entries, weights, Xs):
         import lifelines

--- a/lifelines/fitters/generalized_gamma_fitter.py
+++ b/lifelines/fitters/generalized_gamma_fitter.py
@@ -100,7 +100,6 @@ class GeneralizedGammaFitter(KnownModelParametericUnivariateFitter):
     _fitted_parameter_names = ["mu_", "ln_sigma_", "lambda_"]
     _bounds = [(None, None), (None, None), (None, None)]
     _compare_to_values = np.array([0, 0, 1])
-    _scipy_fit_method = "SLSQP"
 
     def _get_initial_values(self, Ts, E, *args):
         if CensoringType.is_right_censoring(self):

--- a/lifelines/fitters/generalized_gamma_fitter.py
+++ b/lifelines/fitters/generalized_gamma_fitter.py
@@ -100,6 +100,7 @@ class GeneralizedGammaFitter(KnownModelParametericUnivariateFitter):
     _fitted_parameter_names = ["mu_", "ln_sigma_", "lambda_"]
     _bounds = [(None, None), (None, None), (None, None)]
     _compare_to_values = np.array([0, 0, 1])
+    _scipy_fit_method = "SLSQP"
 
     def _get_initial_values(self, Ts, E, *args):
         if CensoringType.is_right_censoring(self):

--- a/lifelines/fitters/log_logistic_aft_fitter.py
+++ b/lifelines/fitters/log_logistic_aft_fitter.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from lifelines.utils import _get_index, coalesce
 from lifelines.fitters import ParametericAFTRegressionFitter
+from lifelines.utils.safe_exp import safe_exp
 
 
 class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
@@ -68,7 +69,7 @@ class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
 
     def _cumulative_hazard(self, params, T, Xs):
         alpha_params = params["alpha_"]
-        alpha_ = np.exp(np.dot(Xs["alpha_"], alpha_params))
+        alpha_ = safe_exp(np.dot(Xs["alpha_"], alpha_params))
 
         beta_params = params["beta_"]
         beta_ = np.exp(np.dot(Xs["beta_"], beta_params))
@@ -77,11 +78,11 @@ class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
     def _log_hazard(self, params, T, Xs):
         alpha_params = params["alpha_"]
         log_alpha_ = np.dot(Xs["alpha_"], alpha_params)
-        alpha_ = np.exp(log_alpha_)
+        alpha_ = safe_exp(log_alpha_)
 
         beta_params = params["beta_"]
         log_beta_ = np.dot(Xs["beta_"], beta_params)
-        beta_ = np.exp(log_beta_)
+        beta_ = safe_exp(log_beta_)
 
         return (
             log_beta_
@@ -93,11 +94,11 @@ class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
     def _log_1m_sf(self, params, T, Xs):
         alpha_params = params["alpha_"]
         log_alpha_ = np.dot(Xs["alpha_"], alpha_params)
-        alpha_ = np.exp(log_alpha_)
+        alpha_ = safe_exp(log_alpha_)
 
         beta_params = params["beta_"]
         log_beta_ = np.dot(Xs["beta_"], beta_params)
-        beta_ = np.exp(log_beta_)
+        beta_ = safe_exp(log_beta_)
         return -np.logaddexp(-beta_ * (np.log(T) - np.log(alpha_)), 0)
 
     def predict_percentile(self, df, ancillary_df=None, p=0.5):

--- a/lifelines/fitters/log_normal_aft_fitter.py
+++ b/lifelines/fitters/log_normal_aft_fitter.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from lifelines.utils import _get_index
 from lifelines.fitters import ParametericAFTRegressionFitter
+from lifelines.utils.safe_exp import safe_exp
 
 
 class LogNormalAFTFitter(ParametericAFTRegressionFitter):
@@ -71,7 +72,7 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
         mu_ = np.dot(Xs["mu_"], mu_params)
 
         sigma_params = params["sigma_"]
-        sigma_ = np.exp(np.dot(Xs["sigma_"], sigma_params))
+        sigma_ = safe_exp(np.dot(Xs["sigma_"], sigma_params))
         Z = (np.log(T) - mu_) / sigma_
         return -norm.logsf(Z)
 
@@ -82,7 +83,7 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
         sigma_params = params["sigma_"]
 
         log_sigma_ = np.dot(Xs["sigma_"], sigma_params)
-        sigma_ = np.exp(log_sigma_)
+        sigma_ = safe_exp(log_sigma_)
         Z = (np.log(T) - mu_) / sigma_
 
         return norm.logpdf(Z) - log_sigma_ - np.log(T) - norm.logsf(Z)
@@ -94,7 +95,7 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
         sigma_params = params["sigma_"]
 
         log_sigma_ = np.dot(Xs["sigma_"], sigma_params)
-        sigma_ = np.exp(log_sigma_)
+        sigma_ = safe_exp(log_sigma_)
         Z = (np.log(T) - mu_) / sigma_
         return norm.logcdf(Z)
 

--- a/lifelines/fitters/piecewise_exponential_regression_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_regression_fitter.py
@@ -115,5 +115,5 @@ class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
         if CensoringType.is_left_censoring(self):
             raise NotImplementedError()
 
-        self._ll_null_ = model._log_likelihood
+        self._ll_null_ = model.log_likelihood_
         return self._ll_null_

--- a/lifelines/fitters/piecewise_exponential_regression_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_regression_fitter.py
@@ -3,6 +3,7 @@ import autograd.numpy as np
 from lifelines.utils import coalesce, _get_index, CensoringType
 from lifelines.fitters import ParametricRegressionFitter
 import pandas as pd
+from lifelines.utils.safe_exp import safe_exp
 
 
 class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
@@ -37,7 +38,7 @@ class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
         T = T.reshape((n, 1))
         M = np.minimum(np.tile(self.breakpoints, (n, 1)), T)
         M = np.hstack([M[:, tuple([0])], np.diff(M, axis=1)])
-        lambdas_ = np.array([np.exp(-np.dot(Xs[param], params[param])) for param in self._fitted_parameter_names])
+        lambdas_ = np.array([safe_exp(-np.dot(Xs[param], params[param])) for param in self._fitted_parameter_names])
         return (M * lambdas_.T).sum(1)
 
     def _log_hazard(self, params, T, X):

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from lifelines.utils import _get_index, coalesce
 from lifelines.fitters import ParametericAFTRegressionFitter
+from lifelines.utils.safe_exp import safe_exp
 
 
 class WeibullAFTFitter(ParametericAFTRegressionFitter):
@@ -72,9 +73,9 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter):
         log_lambda_ = Xs["lambda_"] @ lambda_params
 
         rho_params = params["rho_"]
-        rho_ = np.exp(Xs["rho_"] @ rho_params)
+        rho_ = safe_exp(Xs["rho_"] @ rho_params)
 
-        return np.exp(rho_ * (np.log(np.clip(T, 1e-25, np.inf)) - log_lambda_))
+        return safe_exp(rho_ * (np.log(np.clip(T, 1e-25, np.inf)) - log_lambda_))
 
     def _log_hazard(self, params, T, Xs):
         lambda_params = params["lambda_"]

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -86,7 +86,7 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter):
 
         return log_rho_ - log_lambda_ + np.expm1(log_rho_) * (np.log(T) - log_lambda_)
 
-    def predict_percentile(self, df, ancillary_df=None, p=0.5):
+    def predict_percentile(self, df, ancillary_df=None, p=0.5, conditional_after=None):
         """
         Returns the median lifetimes for the individuals, by default. If the survival curve of an
         individual does not cross 0.5, then the result is infinity.
@@ -116,7 +116,12 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter):
         """
         lambda_, rho_ = self._prep_inputs_for_prediction_and_return_scores(df, ancillary_df)
 
-        return pd.DataFrame(lambda_ * np.power(-np.log(p), 1 / rho_), index=_get_index(df))
+        if conditional_after is None:
+            conditional_after = np.zeros(df.shape[0])
+        return pd.DataFrame(
+            lambda_ * np.power(-np.log(p) + (conditional_after / lambda_) ** rho_, 1 / rho_) - conditional_after,
+            index=_get_index(df),
+        )
 
     def predict_expectation(self, df, ancillary_df=None):
         """

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -69,19 +69,19 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter):
 
     def _cumulative_hazard(self, params, T, Xs):
         lambda_params = params["lambda_"]
-        log_lambda_ = np.dot(Xs["lambda_"], lambda_params)
+        log_lambda_ = Xs["lambda_"] @ lambda_params
 
         rho_params = params["rho_"]
-        rho_ = np.exp(np.dot(Xs["rho_"], rho_params))
+        rho_ = np.exp(Xs["rho_"] @ rho_params)
 
         return np.exp(rho_ * (np.log(np.clip(T, 1e-25, np.inf)) - log_lambda_))
 
     def _log_hazard(self, params, T, Xs):
         lambda_params = params["lambda_"]
-        log_lambda_ = np.dot(Xs["lambda_"], lambda_params)
+        log_lambda_ = Xs["lambda_"] @ lambda_params
 
         rho_params = params["rho_"]
-        log_rho_ = np.dot(Xs["rho_"], rho_params)
+        log_rho_ = Xs["rho_"] @ rho_params
 
         return log_rho_ - log_lambda_ + np.expm1(log_rho_) * (np.log(T) - log_lambda_)
 

--- a/lifelines/fitters/weibull_fitter.py
+++ b/lifelines/fitters/weibull_fitter.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import autograd.numpy as np
 from lifelines.fitters import KnownModelParametericUnivariateFitter
+from lifelines.utils.safe_exp import safe_exp
 
 
 class WeibullFitter(KnownModelParametericUnivariateFitter):
@@ -80,7 +81,7 @@ class WeibullFitter(KnownModelParametericUnivariateFitter):
 
     def _cumulative_hazard(self, params, times):
         lambda_, rho_ = params
-        return np.exp(rho_ * (np.log(np.clip(times, 1e-25, np.inf)) - np.log(lambda_)))
+        return safe_exp(rho_ * (np.log(np.clip(times, 1e-25, np.inf)) - np.log(lambda_)))
 
     def percentile(self, p):
         return self.lambda_ * (np.log(1 / p) ** (1.0 / self.rho_))

--- a/lifelines/utils/safe_exp.py
+++ b/lifelines/utils/safe_exp.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+import sys
+from autograd.extend import primitive, defvjp
+from autograd import numpy as np
+
+MAX = np.log(sys.float_info.max) - 50
+
+
+def safe_exp_vjp(ans, x):
+    return lambda g: g * ans
+
+
+@primitive
+def safe_exp(x):
+    return np.exp(np.clip(x, -np.inf, MAX))
+
+
+defvjp(safe_exp, safe_exp_vjp)

--- a/lifelines/utils/safe_exp.py
+++ b/lifelines/utils/safe_exp.py
@@ -3,7 +3,7 @@ import sys
 from autograd.extend import primitive, defvjp
 from autograd import numpy as np
 
-MAX = np.log(sys.float_info.max) - 50
+MAX = np.log(sys.float_info.max) - 75
 
 
 def safe_exp_vjp(ans, x):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1684,8 +1684,8 @@ class TestAFTFitters:
         lnf = LogNormalAFTFitter().fit(df, "T")
         llf = LogLogisticAFTFitter().fit(df, "T")
 
-        assert wf._log_likelihood > lnf._log_likelihood
-        assert wf._log_likelihood > llf._log_likelihood
+        assert wf.log_likelihood_ > lnf.log_likelihood_
+        assert wf.log_likelihood_ > llf.log_likelihood_
 
         # lognormal should have the best fit -> largest ll
         W = norm.rvs(scale=1, loc=0, size=N)
@@ -1699,8 +1699,8 @@ class TestAFTFitters:
         lnf = LogNormalAFTFitter().fit(df, "T")
         llf = LogLogisticAFTFitter().fit(df, "T")
 
-        assert lnf._log_likelihood > wf._log_likelihood
-        assert lnf._log_likelihood > llf._log_likelihood
+        assert lnf.log_likelihood_ > wf.log_likelihood_
+        assert lnf.log_likelihood_ > llf.log_likelihood_
 
         # loglogistic should have the best fit -> largest ll
         W = logistic.rvs(scale=1, loc=0, size=N)
@@ -1714,8 +1714,8 @@ class TestAFTFitters:
         lnf = LogNormalAFTFitter().fit(df, "T")
         llf = LogLogisticAFTFitter().fit(df, "T")
 
-        assert llf._log_likelihood > wf._log_likelihood
-        assert llf._log_likelihood > lnf._log_likelihood
+        assert llf.log_likelihood_ > wf.log_likelihood_
+        assert llf.log_likelihood_ > lnf.log_likelihood_
 
     def test_aft_median_behaviour(self, models, rossi):
         for aft in models:
@@ -3396,7 +3396,7 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
         cp_with_strata_in_fit.fit(rossi, "week", "arrest", strata=strata)
         assert cp_with_strata_in_fit.strata == strata
 
-        assert cp_with_strata_in_init._log_likelihood == cp_with_strata_in_fit._log_likelihood
+        assert cp_with_strata_in_init.log_likelihood_ == cp_with_strata_in_fit.log_likelihood_
 
     def test_baseline_survival_is_the_same_indp_of_location(self, regression_dataset):
         df = regression_dataset.copy()

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1626,7 +1626,24 @@ class TestAFTFitters:
     def models(self):
         return [WeibullAFTFitter(), LogNormalAFTFitter(), LogLogisticAFTFitter()]
 
-    def test_fit_intercept_can_be_false(self, rossi):
+    def test_fit_intercept_can_be_false_and_not_provided(self, rossi):
+        # nonsensical data
+        interval_rossi = rossi.copy()
+        interval_rossi["start"] = 0
+        interval_rossi["end"] = rossi["week"]
+        interval_rossi["arrest"] = False
+        interval_rossi = interval_rossi.drop("week", axis=1)
+
+        # nonsensical data
+        left_rossi = rossi.copy()
+        left_rossi["week"] = 1 / rossi["week"] + 1
+
+        for fitter in [WeibullAFTFitter(fit_intercept=False)]:
+            fitter.fit_right_censoring(rossi, "week", "arrest")
+            fitter.fit_left_censoring(left_rossi, "week", "arrest")
+            fitter.fit_interval_censoring(interval_rossi, "start", "end", "arrest")
+
+    def test_fit_intercept_can_be_false_but_provided(self, rossi):
         rossi["intercept"] = 1.0
         for fitter in [
             WeibullAFTFitter(fit_intercept=False),


### PR DESCRIPTION
#### 0.22.3

##### New features
 - model's now expose a `log_likelihood_` property.
 - new `conditional_after` argument on `predict_*` methods that make prediction on censored subjects easier.

##### API changes
 - removed `lifelines.utils.gamma` - use `autograd_gamma` library instead.

##### Bug fixes
 - AFT log-likelihood ratio test was not using weights correctly.
 - corrected (by bumping) scipy and autograd dependencies
 - convergence is improved for most models, and many overflow warnings have been eliminated.
 - Fixed an error in the `predict_percentile` of `LogLogisticAFTFitter`. New tests have been added around this.
