### PR TITLE
v0.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,11 @@
 ### Changelog
 
-#### 0.22.4
 
+#### 0.22.3
 
 ##### New features
  - model's now expose a `log_likelihood_` property.
  - new `conditional_after` argument on `predict_*` methods that make prediction on censored subjects easier.
-
-##### Bug fixes
- - convergence is improved for most models, and many overflow warnings have been eliminated.
- - Fixed an error in the `predict_percentile` of `LogLogisticAFTFitter`. New tests have been added around this.
-
-
-#### 0.22.3
 
 ##### API changes
  - removed `lifelines.utils.gamma` - use `autograd_gamma` library instead.
@@ -20,9 +13,11 @@
 ##### Bug fixes
  - AFT log-likelihood ratio test was not using weights correctly.
  - corrected (by bumping) scipy and autograd dependencies
+ - convergence is improved for most models, and many `exp` overflow warnings have been eliminated.
+ - Fixed an error in the `predict_percentile` of `LogLogisticAFTFitter`. New tests have been added around this.
 
 
-#### 0.22.2
+#### 0.22.2 - 2019-07-25
 
 ##### New features
  - lifelines is now compatible with scipy>=1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - new `conditional_after` argument on `predict_*` methods that make prediction on censored subjects easier.
  - new `lifelines.utils.safe_exp` to make `exp` overflows easier to handle.
  - smarter initial conditions for parametric regression models.
+ - New regression model: `GeneralizedGammaRegressionFitter`
 
 ##### API changes
  - removed `lifelines.utils.gamma` - use `autograd_gamma` library instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ##### API changes
  - removed `lifelines.utils.gamma` - use `autograd_gamma` library instead.
+ - removed bottleneck as a dependency. It offered slight performance gains only in Cox models, and only a small fraction of the API was being used.
 
 ##### Bug fixes
  - AFT log-likelihood ratio test was not using weights correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - model's now expose a `log_likelihood_` property.
  - new `conditional_after` argument on `predict_*` methods that make prediction on censored subjects easier.
  - new `lifelines.utils.safe_exp` to make `exp` overflows easier to handle.
+ - smarter initial conditions for parametric regression models.
 
 ##### API changes
  - removed `lifelines.utils.gamma` - use `autograd_gamma` library instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Changelog
 
+#### 0.22.4
+
+
+##### New features
+ - model's now expose a `log_likelihood_` property.
+
+
 #### 0.22.3
 
 ##### API changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ##### New features
  - model's now expose a `log_likelihood_` property.
+ - new `conditional_after` argument on `predict_*` methods that make prediction on censored subjects easier.
+
+##### Bug fixes
+ - convergence is improved for most models, and many overflow warnings have been eliminated.
+ - Fixed an error in the `predict_percentile` of `LogLogisticAFTFitter`. New tests have been added around this.
 
 
 #### 0.22.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ##### New features
  - model's now expose a `log_likelihood_` property.
  - new `conditional_after` argument on `predict_*` methods that make prediction on censored subjects easier.
+ - new `lifelines.utils.safe_exp` to make `exp` overflows easier to handle.
 
 ##### API changes
  - removed `lifelines.utils.gamma` - use `autograd_gamma` library instead.

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,13 +1,48 @@
 Changelog
 ~~~~~~~~~
 
-0.22.2
+0.22.3
 ^^^^^^
 
 New features
 ''''''''''''
 
+-  model’s now expose a ``log_likelihood_`` property.
+-  new ``conditional_after`` argument on ``predict_*`` methods that make
+   prediction on censored subjects easier.
+-  new ``lifelines.utils.safe_exp`` to make ``exp`` overflows easier to
+   handle.
+-  smarter initial conditions for parametric regression models.
+
+API changes
+'''''''''''
+
+-  removed ``lifelines.utils.gamma`` - use ``autograd_gamma`` library
+   instead.
+
+Bug fixes
+'''''''''
+
+-  AFT log-likelihood ratio test was not using weights correctly.
+-  corrected (by bumping) scipy and autograd dependencies
+-  convergence is improved for most models, and many ``exp`` overflow
+   warnings have been eliminated.
+-  Fixed an error in the ``predict_percentile`` of
+   ``LogLogisticAFTFitter``. New tests have been added around this.
+
+.. _section-1:
+
+0.22.2 - 2019-07-25
+^^^^^^^^^^^^^^^^^^^
+
+.. _new-features-1:
+
+New features
+''''''''''''
+
 -  lifelines is now compatible with scipy>=1.3.0
+
+.. _bug-fixes-1:
 
 Bug fixes
 '''''''''
@@ -15,15 +50,15 @@ Bug fixes
 -  fixed printing error when using robust=True in regression models
 -  ``GeneralizedGammaFitter`` is more stable, maybe.
 -  lifelines was allowing old version of numpy (1.6), but this caused
-   errors when using the library. The correctly numpy has been pinned (to
-   1.14.0+)
+   errors when using the library. The correctly numpy has been pinned
+   (to 1.14.0+)
 
-.. _section-1:
+.. _section-2:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ''''''''''''
@@ -38,6 +73,8 @@ New features
    right censoring)
 -  improvements to ``lifelines.utils.gamma``
 
+.. _api-changes-1:
+
 API changes
 '''''''''''
 
@@ -49,7 +86,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -59,12 +96,12 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-2:
+.. _section-3:
 
 0.22.0 - 2019-07-03
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ''''''''''''
@@ -76,7 +113,7 @@ New features
 -  for parametric univariate models, the ``conditional_time_to_event_``
    is now exact instead of an approximation.
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API changes
 '''''''''''
@@ -98,7 +135,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
@@ -107,21 +144,21 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-3:
+.. _section-4:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 I’m skipping 0.21.4 version because of deployment issues.
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ''''''''''''
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -131,12 +168,12 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-4:
+.. _section-5:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ''''''''''''
@@ -150,19 +187,19 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-5:
+.. _section-6:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ''''''''''''
@@ -174,7 +211,7 @@ New features
    that computes, you guessed it, the log-likelihood ratio test.
    Previously this was an internal API that is being exposed.
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API changes
 '''''''''''
@@ -186,17 +223,17 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
 
-.. _section-6:
+.. _section-7:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ''''''''''''
@@ -205,7 +242,7 @@ New features
    ``add_covariate_to_timeline``
 -  PiecewiseExponentialFitter now allows numpy arrays as breakpoints
 
-.. _api-changes-3:
+.. _api-changes-4:
 
 API changes
 '''''''''''
@@ -213,19 +250,19 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-7:
+.. _section-8:
 
 0.21.0 - 2019-04-12
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ''''''''''''
@@ -239,7 +276,7 @@ New features
 -  a new interval censored dataset is available under
    ``lifelines.datasets.load_diabetes``
 
-.. _api-changes-4:
+.. _api-changes-5:
 
 API changes
 '''''''''''
@@ -250,7 +287,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
@@ -260,19 +297,19 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-8:
+.. _section-9:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-8:
+.. _new-features-9:
 
 New features
 ''''''''''''
 
 -  performance improvements for ``print_summary``.
 
-.. _api-changes-5:
+.. _api-changes-6:
 
 API changes
 '''''''''''
@@ -282,7 +319,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
@@ -291,12 +328,12 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-9:
+.. _section-10:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-9:
+.. _new-features-10:
 
 New features
 ''''''''''''
@@ -307,7 +344,7 @@ New features
    generating piecewise exp. data
 -  Faster ``print_summary`` for AFT models.
 
-.. _api-changes-6:
+.. _api-changes-7:
 
 API changes
 '''''''''''
@@ -315,7 +352,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
@@ -324,12 +361,12 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-10:
+.. _section-11:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-10:
+.. _new-features-11:
 
 New features
 ''''''''''''
@@ -342,12 +379,12 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-11:
+.. _section-12:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-11:
+.. _new-features-12:
 
 New features
 ''''''''''''
@@ -362,7 +399,7 @@ New features
 -  add a ``lifelines.plotting.qq_plot`` for univariate parametric models
    that handles censored data.
 
-.. _api-changes-7:
+.. _api-changes-8:
 
 API changes
 '''''''''''
@@ -371,7 +408,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
@@ -387,7 +424,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-12:
+.. _section-13:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -401,7 +438,7 @@ Bug fixes
    decades of development.
 -  suppressed unimportant warnings
 
-.. _api-changes-8:
+.. _api-changes-9:
 
 API changes
 '''''''''''
@@ -411,7 +448,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-13:
+.. _section-14:
 
 0.20.0 - 2019-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -420,7 +457,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-12:
+.. _new-features-13:
 
 New features
 ''''''''''''
@@ -428,7 +465,7 @@ New features
 -  smarter initialization for AFT models which should improve
    convergence.
 
-.. _api-changes-9:
+.. _api-changes-10:
 
 API changes
 '''''''''''
@@ -440,19 +477,19 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-14:
+.. _section-15:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-13:
+.. _new-features-14:
 
 New features
 ''''''''''''
@@ -462,24 +499,24 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-15:
+.. _section-16:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-16:
+.. _section-17:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-14:
+.. _new-features-15:
 
 New features
 ''''''''''''
@@ -491,12 +528,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-17:
+.. _section-18:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-15:
+.. _new-features-16:
 
 New features
 ''''''''''''
@@ -504,7 +541,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
@@ -514,12 +551,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-18:
+.. _section-19:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-16:
+.. _new-features-17:
 
 New features
 ''''''''''''
@@ -527,7 +564,7 @@ New features
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-10:
+.. _api-changes-11:
 
 API changes
 '''''''''''
@@ -536,12 +573,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-19:
+.. _section-20:
 
 0.19.0 - 2019-02-20
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-17:
+.. _new-features-18:
 
 New features
 ''''''''''''
@@ -554,7 +591,7 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-11:
+.. _api-changes-12:
 
 API changes
 '''''''''''
@@ -580,7 +617,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug Fixes
 '''''''''
@@ -597,7 +634,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-20:
+.. _section-21:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -607,7 +644,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-21:
+.. _section-22:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -628,7 +665,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-22:
+.. _section-23:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -638,7 +675,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-23:
+.. _section-24:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -648,7 +685,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-24:
+.. _section-25:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -664,7 +701,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-25:
+.. _section-26:
 
 0.18.1 2019-02-02
 ^^^^^^^^^^^^^^^^^
@@ -675,7 +712,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-26:
+.. _section-27:
 
 0.18.0 - 2019-01-31
 ^^^^^^^^^^^^^^^^^^^
@@ -712,7 +749,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-27:
+.. _section-28:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -720,7 +757,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-28:
+.. _section-29:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -732,7 +769,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-29:
+.. _section-30:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -740,7 +777,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-30:
+.. _section-31:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -751,7 +788,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-31:
+.. _section-32:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -768,7 +805,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-32:
+.. _section-33:
 
 0.17.0 - 2019-01-11
 ^^^^^^^^^^^^^^^^^^^
@@ -789,7 +826,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-33:
+.. _section-34:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -797,7 +834,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-34:
+.. _section-35:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -808,14 +845,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-35:
+.. _section-36:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-36:
+.. _section-37:
 
 0.16.0 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
@@ -851,7 +888,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-37:
+.. _section-38:
 
 0.15.4
 ^^^^^^
@@ -859,14 +896,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-38:
+.. _section-39:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-39:
+.. _section-40:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -877,7 +914,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-40:
+.. _section-41:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -886,7 +923,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-41:
+.. _section-42:
 
 0.15.0 - 2018-11-22
 ^^^^^^^^^^^^^^^^^^^
@@ -957,7 +994,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-42:
+.. _section-43:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -965,7 +1002,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-43:
+.. _section-44:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -973,7 +1010,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-44:
+.. _section-45:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -990,7 +1027,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-45:
+.. _section-46:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1002,7 +1039,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-46:
+.. _section-47:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1010,7 +1047,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-47:
+.. _section-48:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1028,7 +1065,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-48:
+.. _section-49:
 
 0.14.0 - 2018-03-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1050,7 +1087,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-49:
+.. _section-50:
 
 0.13.0 - 2017-12-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1079,7 +1116,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-50:
+.. _section-51:
 
 0.12.0
 ^^^^^^
@@ -1096,7 +1133,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-51:
+.. _section-52:
 
 0.11.3
 ^^^^^^
@@ -1108,7 +1145,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-52:
+.. _section-53:
 
 0.11.2
 ^^^^^^
@@ -1116,14 +1153,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-53:
+.. _section-54:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-54:
+.. _section-55:
 
 0.11.0 - 2017-06-21
 ^^^^^^^^^^^^^^^^^^^
@@ -1137,14 +1174,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-55:
+.. _section-56:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-56:
+.. _section-57:
 
 0.10.0
 ^^^^^^
@@ -1159,7 +1196,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-57:
+.. _section-58:
 
 0.9.4
 ^^^^^
@@ -1182,7 +1219,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-58:
+.. _section-59:
 
 0.9.2
 ^^^^^
@@ -1191,7 +1228,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-59:
+.. _section-60:
 
 0.9.1
 ^^^^^
@@ -1199,7 +1236,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-60:
+.. _section-61:
 
 0.9.0
 ^^^^^
@@ -1215,7 +1252,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-61:
+.. _section-62:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -1232,7 +1269,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-62:
+.. _section-63:
 
 0.8.0
 ^^^^^
@@ -1251,7 +1288,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-63:
+.. _section-64:
 
 0.7.1
 ^^^^^
@@ -1270,7 +1307,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-64:
+.. _section-65:
 
 0.7.0 - 2015-03-01
 ^^^^^^^^^^^^^^^^^^
@@ -1289,7 +1326,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-65:
+.. _section-66:
 
 0.6.1
 ^^^^^
@@ -1301,7 +1338,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-66:
+.. _section-67:
 
 0.6.0 - 2015-02-04
 ^^^^^^^^^^^^^^^^^^
@@ -1324,7 +1361,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-67:
+.. _section-68:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1345,7 +1382,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-68:
+.. _section-69:
 
 0.5.0 - 2014-12-07
 ^^^^^^^^^^^^^^^^^^
@@ -1358,7 +1395,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-69:
+.. _section-70:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1370,7 +1407,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-70:
+.. _section-71:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -1391,7 +1428,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-71:
+.. _section-72:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -1411,7 +1448,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-72:
+.. _section-73:
 
 0.4.1.1
 ^^^^^^^
@@ -1424,7 +1461,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-73:
+.. _section-74:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -1443,7 +1480,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-74:
+.. _section-75:
 
 0.4.0 - 2014-06-08
 ^^^^^^^^^^^^^^^^^^

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -114,7 +114,7 @@ Convergence
 
 Fitting the Cox model to the data involves using iterative methods. *lifelines* takes extra effort to help with convergence, so please be attentive to any warnings that appear. Fixing any warnings will generally help convergence and decrease the number of iterative steps required. If you wish to see the fitting, there is a ``show_progress`` parameter in :meth:`~lifelines.fitters.coxph_fitter.CoxPHFitter.fit` function. For further help, see :ref:`Problems with convergence in the Cox Proportional Hazard Model`.
 
-After fitting, the value of the maximum log-likelihood this available using :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter._log_likelihood`. The variance matrix of the coefficients is available under :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter.variance_matrix_`.
+After fitting, the value of the maximum log-likelihood this available using :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter.log_likelihood`. The variance matrix of the coefficients is available under :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter.variance_matrix_`.
 
 
 Goodness of fit
@@ -669,9 +669,9 @@ Often, you don't know *a priori* which AFT model to use. Each model has some ass
     lnf = LogNormalAFTFitter().fit(rossi, 'week', 'arrest')
     wf = WeibullAFTFitter().fit(rossi, 'week', 'arrest')
 
-    print(llf._log_likelihood)  # -679.938
-    print(lnf._log_likelihood)  # -683.234
-    print(wf._log_likelihood)   # -679.916, slightly the best model.
+    print(llf.log_likelihood_)  # -679.938
+    print(lnf.log_likelihood_)  # -683.234
+    print(wf.log_likelihood_)   # -679.916, slightly the best model.
 
 
     # with some heterogeneity in the ancillary parameters
@@ -680,9 +680,9 @@ Often, you don't know *a priori* which AFT model to use. Each model has some ass
     lnf = LogNormalAFTFitter().fit(rossi, 'week', 'arrest', ancillary_df=ancillary_df)
     wf = WeibullAFTFitter().fit(rossi, 'week', 'arrest', ancillary_df=ancillary_df)
 
-    print(llf._log_likelihood) # -678.94, slightly the best model.
-    print(lnf._log_likelihood) # -680.39
-    print(wf._log_likelihood)  # -679.60
+    print(llf.log_likelihood_) # -678.94, slightly the best model.
+    print(lnf.log_likelihood_) # -680.39
+    print(wf.log_likelihood_)  # -679.60
 
 
 Left, right and interval censored data

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -135,7 +135,7 @@ After fitting, you can use use the suite of prediction methods: :meth:`~lifeline
 
 .. code:: python
 
-    X = rossi_dataset.drop(["week", "arrest"], axis=1)
+    X = rossi_dataset
 
     cph.predict_partial_hazard(X)
 
@@ -156,54 +156,20 @@ A common use case is to predict the event time of censored subjects. This is eas
 
 Thus we scale the original survival function by the survival function at time :math:`s` (everything prior to :math:`s` should be mapped to 1.0 as well, since we are working with probabilities and we know that the subject was alive before :math:`s`).
 
-Back to our original problem of predicting the event time of censored individuals, we do the same thing:
+Back to our original problem of predicting the event time of censored individuals, *lifelines* has all this math and logic built in when using the `conditional_after` kwarg.
 
-.. code:: python
-
-    from lifelines import CoxPHFitter
-    from lifelines.datasets import load_regression_dataset
-
-    df = load_regression_dataset()
-
-    cph = CoxPHFitter().fit(df, 'T', 'E')
-
-    censored_subjects = df.loc[df['E'] == 0]
-
-    unconditioned_sf = cph.predict_survival_function(censored_subjects)
-
-    conditioned_sf = unconditioned_sf.apply(lambda c: (c / c.loc[df.loc[c.name, 'T']]).clip_upper(1))
-
-    # let's focus on a single subject
-    subject = 13
-    unconditioned_sf[subject].plot(ls="--", color="#A60628", label="unconditioned")
-    conditioned_sf[subject].plot(color="#A60628", label="conditioned on $T>10$")
-    plt.legend()
+.. code::
 
 
-.. image:: images/survival_regression_conditioning.png
+    censored_subjects = rossi.loc[~rossi['arrest'].astype(bool)]
+    censored_subjects_last_obs = censored_subjects['week']
 
+    cph.predict_partial_hazard(censored_subjects, conditional_after=censored_subjects_last_obs)
 
-From here, you can pick a median or percentile as a best guess as to the subject's event time:
+    cph.predict_survival_function(censored_subjects, times=[5., 25., 50.], conditional_after=censored_subjects_last_obs)
 
-.. code:: python
+    cph.predict_median(censored_subjects, conditional_after=censored_subjects_last_obs)
 
-
-    from lifelines.utils import median_survival_times, qth_survival_times
-
-    predictions_50 = median_survival_times(conditioned_sf)
-    predictions_75 = qth_survival_times(0.75, conditioned_sf)
-
-
-    # plotting subject 13 again
-    plt.hlines([0.5, 0.75], 0, 23, alpha=0.5, label="percentiles")
-
-    plt.scatter(median_survival_times(conditioned_sf[subject]), 0.5,  color="#E24A33", label="median prediction", zorder=20)
-    plt.scatter(qth_survival_times(0.75, conditioned_sf[subject]), 0.75,  color="#467821", label="q=75 prediction", zorder=20)
-
-    plt.legend()
-
-
-.. image:: images/survival_regression_conditioning_with_median.png
 
 
 Plotting the coefficients
@@ -592,14 +558,26 @@ Given a new subject, we ask questions about their future survival? When are they
 
     X = rossi.loc[:10]
 
-    aft.predict_cumulative_hazard(X, ancillary_X=X)
-    aft.predict_survival_function(X, ancillary_X=X)
-    aft.predict_median(X, ancillary_X=X)
-    aft.predict_percentile(X, ancillary_X=X)
-    aft.predict_expectation(X, ancillary_X=X)
+    aft.predict_cumulative_hazard(X, ancillary_df=X)
+    aft.predict_survival_function(X, ancillary_df=X)
+    aft.predict_median(X, ancillary_df=X)
+    aft.predict_percentile(X, p=0.9, ancillary_df=X)
+    aft.predict_expectation(X, ancillary_df=X)
 
 
-There are two tunable parameters that can be used to to achieve a better test score. These are ``penalizer`` and ``l1_ratio`` in the call to :class:`~lifelines.fitters.weibull_aft_fitter.WeibullAFTFitter`. The penalizer is similar to scikit-learn's ``ElasticNet`` model, see their `docs <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html>`_.
+When predicting time remaining for uncensored individuals, you can use the `conditional_after` kwarg:
+
+
+    censored_X = rossi.loc[~rossi['arrest'].astype(bool)]
+    censored_subjects_last_obs = censored_X['week']
+
+    aft.predict_cumulative_hazard(censored_X, ancillary_df=censored_X, conditional_after=censored_subjects_last_obs)
+    aft.predict_survival_function(censored_X, ancillary_df=censored_X, conditional_after=censored_subjects_last_obs)
+    aft.predict_median(censored_X, ancillary_df=censored_X, conditional_after=censored_subjects_last_obs)
+    aft.predict_percentile(X, p=0.9, ancillary_df=censored_X, conditional_after=censored_subjects_last_obs)
+
+
+There are two hyper-parameters that can be used to to achieve a better test score. These are ``penalizer`` and ``l1_ratio`` in the call to :class:`~lifelines.fitters.weibull_aft_fitter.WeibullAFTFitter`. The penalizer is similar to scikit-learn's ``ElasticNet`` model, see their `docs <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html>`_.
 
 .. code:: python
 

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -967,7 +967,7 @@ Fitted survival models typically have a concordance index between 0.55 and 0.75 
     from lifelines.utils import concordance_index
     print(concordance_index(rossi['week'], -cph.predict_partial_hazard(rossi), rossi['arrest']))
 
-.. note:: Remember, the concordance score evaluates the relative rankings of subject's event times. Thus, it is scale invariant (i.e. you can multiple by a positive constant, or add a constant, and the rankings won't change). A model maximized for concordance-index does not necessarily give good predicted *times*, but will give good predicted *rankings*.
+.. note:: Remember, the concordance score evaluates the relative rankings of subject's event times. Thus, it is scale and shift invariant (i.e. you can multiple by a positive constant, or add a constant, and the rankings won't change). A model maximized for concordance-index does not necessarily give good predicted *times*, but will give good predicted *rankings*.
 
 
 However, there are other, arguably better, methods to measure the fit of a model. Included in ``print_summary`` is the log-likelihood, which can be used in an `AIC calculation <https://en.wikipedia.org/wiki/Akaike_information_criterion>`_, and the `log-likelihood ratio statistic <https://en.wikipedia.org/wiki/Likelihood-ratio_test>`_. Generally, I personally loved this article by Frank Harrell, `"Statistically Efficient Ways to Quantify Added Predictive Value of New Measurements" <http://www.fharrell.com/post/addvalue/>`_.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,8 @@
-### Examples
+## Examples
 
 In this folder are some examples of lifelines usage, some with and some without comments and context. You can see some common patterns using lifelines and survival analysis.
+
+
 
 
 #### Other examples

--- a/lifelines/__init__.py
+++ b/lifelines/__init__.py
@@ -18,7 +18,7 @@ from lifelines.fitters.log_logistic_aft_fitter import LogLogisticAFTFitter
 from lifelines.fitters.log_normal_aft_fitter import LogNormalAFTFitter
 from lifelines.fitters.piecewise_exponential_regression_fitter import PiecewiseExponentialRegressionFitter
 from lifelines.fitters.generalized_gamma_fitter import GeneralizedGammaFitter
-from lifelines.fitters.generalized_gamma_aft_fitter import GeneralizedGammaAFTFitter
+from lifelines.fitters.generalized_gamma_regression_fitter import GeneralizedGammaRegressionFitter
 
 
 from lifelines.version import __version__
@@ -40,7 +40,7 @@ __all__ = [
     "WeibullAFTFitter",
     "LogLogisticAFTFitter",
     "LogNormalAFTFitter",
-    "GeneralizedGammaAFTFitter",
+    "GeneralizedGammaRegressionFitter",
     "PiecewiseExponentialFitter",
     "PiecewiseExponentialRegressionFitter",
 ]

--- a/lifelines/__init__.py
+++ b/lifelines/__init__.py
@@ -18,6 +18,7 @@ from lifelines.fitters.log_logistic_aft_fitter import LogLogisticAFTFitter
 from lifelines.fitters.log_normal_aft_fitter import LogNormalAFTFitter
 from lifelines.fitters.piecewise_exponential_regression_fitter import PiecewiseExponentialRegressionFitter
 from lifelines.fitters.generalized_gamma_fitter import GeneralizedGammaFitter
+from lifelines.fitters.generalized_gamma_aft_fitter import GeneralizedGammaAFTFitter
 
 
 from lifelines.version import __version__
@@ -39,6 +40,7 @@ __all__ = [
     "WeibullAFTFitter",
     "LogLogisticAFTFitter",
     "LogNormalAFTFitter",
+    "GeneralizedGammaAFTFitter",
     "PiecewiseExponentialFitter",
     "PiecewiseExponentialRegressionFitter",
 ]

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -2179,9 +2179,17 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             regressors = {self._primary_parameter_name: primary_columns, self._ancillary_parameter_name: []}
 
         if self.fit_intercept:
-            assert "_intercept" not in df
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
             df["_intercept"] = 1.0
             regressors[self._primary_parameter_name].append("_intercept")
+            regressors[self._ancillary_parameter_name].append("_intercept")
+        elif not self.fit_intercept and ((ancillary_df is None) or (ancillary_df == False) or not self.model_ancillary):
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
+            df["_intercept"] = 1.0
             regressors[self._ancillary_parameter_name].append("_intercept")
 
         super(ParametericAFTRegressionFitter, self)._fit(
@@ -2333,9 +2341,17 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             regressors = {self._primary_parameter_name: primary_columns, self._ancillary_parameter_name: []}
 
         if self.fit_intercept:
-            assert "_intercept" not in df
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
             df["_intercept"] = 1.0
             regressors[self._primary_parameter_name].append("_intercept")
+            regressors[self._ancillary_parameter_name].append("_intercept")
+        elif not self.fit_intercept and ((ancillary_df is None) or (ancillary_df == False) or not self.model_ancillary):
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
+            df["_intercept"] = 1.0
             regressors[self._ancillary_parameter_name].append("_intercept")
 
         super(ParametericAFTRegressionFitter, self)._fit(
@@ -2465,9 +2481,17 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             regressors = {self._primary_parameter_name: primary_columns, self._ancillary_parameter_name: []}
 
         if self.fit_intercept:
-            assert "_intercept" not in df
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
             df["_intercept"] = 1.0
             regressors[self._primary_parameter_name].append("_intercept")
+            regressors[self._ancillary_parameter_name].append("_intercept")
+        elif not self.fit_intercept and ((ancillary_df is None) or (ancillary_df == False) or not self.model_ancillary):
+            assert (
+                "_intercept" not in df
+            ), "lifelines is trying to overwrite _intercept. Please rename _intercept to something else."
+            df["_intercept"] = 1.0
             regressors[self._ancillary_parameter_name].append("_intercept")
 
         super(ParametericAFTRegressionFitter, self)._fit(
@@ -2691,9 +2715,8 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         X = X.copy()
 
         if isinstance(X, pd.DataFrame):
-            if self.fit_intercept:
-                X["_intercept"] = 1.0
-            X = X[self.params_.loc[self._primary_parameter_name].index]
+            X["_intercept"] = 1.0
+            primary_X = X[self.params_.loc[self._primary_parameter_name].index]
         else:
             # provided numpy array
             assert X.shape[1] == self.params_.loc[self._primary_parameter_name].shape[0]
@@ -2714,7 +2737,7 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         primary_params = self.params_[self._primary_parameter_name]
         ancillary_params = self.params_[self._ancillary_parameter_name]
 
-        primary_scores = np.exp(np.dot(X, primary_params))
+        primary_scores = np.exp(np.dot(primary_X, primary_params))
         ancillary_scores = np.exp(np.dot(ancillary_X, ancillary_params))
 
         return primary_scores, ancillary_scores

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1498,7 +1498,7 @@ class ParametricRegressionFitter(BaseFitter):
             method=self._scipy_fit_method,
             jac=True,
             args=(Ts, E, weights, entries, Xs),
-            options={**{"disp": show_progress, "gtol": 1e-6}, **self._scipy_fit_options},
+            options={**{"disp": show_progress}, **self._scipy_fit_options},
         )
         if show_progress or not results.success:
             print(results)

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -2922,7 +2922,7 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         Xs = self._create_Xs_dict(df)
 
         params_dict = {
-            parameter_name: self.params_.loc[parameter_name] for parameter_name in self._fitted_parameter_names
+            parameter_name: self.params_.loc[parameter_name].values for parameter_name in self._fitted_parameter_names
         }
 
         if conditional_after is None:

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1498,7 +1498,7 @@ class ParametricRegressionFitter(BaseFitter):
             method=self._scipy_fit_method,
             jac=True,
             args=(Ts, E, weights, entries, Xs),
-            options={**{"disp": show_progress}, **self._scipy_fit_options},
+            options={**{"disp": show_progress, "gtol": 1e-6}, **self._scipy_fit_options},
         )
         if show_progress or not results.success:
             print(results)

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -500,6 +500,8 @@ class ParametericUnivariateFitter(UnivariateFitter):
             if results.success:
                 # pylint: disable=no-value-for-parameter
                 hessian_ = hessian(negative_log_likelihood)(results.x, Ts, E, entry, weights)
+                # see issue https://github.com/CamDavidsonPilon/lifelines/issues/801
+                hessian_ = (hessian_ + hessian_.T) / 2
                 return results.x, -results.fun * weights.sum(), hessian_ * weights.sum()
 
             # convergence failed.
@@ -1508,6 +1510,8 @@ class ParametricRegressionFitter(BaseFitter):
             sum_weights = weights.sum()
             # pylint: disable=no-value-for-parameter
             hessian_ = hessian(self._neg_likelihood_with_penalty_function)(results.x, Ts, E, weights, entries, Xs)
+            # See issue https://github.com/CamDavidsonPilon/lifelines/issues/801
+            hessian_ = (hessian_ + hessian_.T) / 2
             return results.x, -sum_weights * results.fun, sum_weights * hessian_
 
         raise utils.ConvergenceError(

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -361,7 +361,7 @@ class ParametericUnivariateFitter(UnivariateFitter):
                 yield (lb + self._MIN_PARAMETER_VALUE, ub - self._MIN_PARAMETER_VALUE)
 
     def _cumulative_hazard(self, params, times):
-        raise NotImplementedError("Subclass implements this.")
+        return -anp.log(self._survival_function(params, times))
 
     def _survival_function(self, params, times):
         return anp.exp(-self._cumulative_hazard(params, times))
@@ -371,13 +371,12 @@ class ParametericUnivariateFitter(UnivariateFitter):
 
     def _log_hazard(self, params, times):
         hz = self._hazard(params, times)
-        hz = anp.clip(hz, 1e-18, np.inf)
+        hz = anp.clip(hz, 1e-50, np.inf)
         return anp.log(hz)
 
     def _log_1m_sf(self, params, times):
         # equal to log(cdf), but often easier to express with sf.
-        cum_haz = self._cumulative_hazard(params, times)
-        return anp.log1p(-anp.exp(-cum_haz))
+        return anp.log1p(-self._survival_function(params, times))
 
     def _negative_log_likelihood_left_censoring(self, params, Ts, E, entry, W):
         T = Ts[1]

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -454,7 +454,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
         self._hessian_ = hessian
         self._score_ = gradient
-        self._log_likelihood = ll
+        self.log_likelihood_ = ll
 
         if show_progress and completed:
             print("Convergence completed after %d iterations." % (i))
@@ -472,6 +472,14 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             warnings.warn("Newton-Rhapson failed to converge sufficiently in %d steps." % max_steps, ConvergenceWarning)
 
         return beta
+
+    @property
+    def _log_likelihood(self):
+        warnings.warn(
+            "Please use `log_likelihood` property instead. `_log_likelihood` will be removed in a future version of lifelines",
+            DeprecationWarning,
+        )
+        return self.log_likelihood_
 
     def _get_gradients(self, X, events, start, stop, weights, beta):  # pylint: disable=too-many-locals
         """
@@ -729,10 +737,10 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
                     weights_col="__weights",
                     strata=self.strata,
                 )
-                ._log_likelihood
+                .log_likelihood_
             )
 
-        ll_alt = self._log_likelihood
+        ll_alt = self.log_likelihood_
         test_stat = 2 * (ll_alt - ll_null)
         degrees_freedom = self.params_.shape[0]
         p_value = chisq_test(test_stat, degrees_freedom=degrees_freedom)

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -13,7 +13,7 @@ from numpy.linalg import norm, inv
 from scipy.linalg import solve as spsolve, LinAlgError
 
 
-from bottleneck import nansum as array_sum_to_scalar
+from numpy import sum as array_sum_to_scalar
 
 from lifelines.fitters import BaseFitter
 from lifelines.statistics import chisq_test, StatisticalResult
@@ -661,7 +661,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         print("{} = {}".format(justify("number of subjects"), self._n_unique))
         print("{} = {}".format(justify("number of periods"), self._n_examples))
         print("{} = {}".format(justify("number of events"), self.event_observed.sum()))
-        print("{} = {:.{prec}f}".format(justify("log-likelihood"), self._log_likelihood, prec=decimals))
+        print("{} = {:.{prec}f}".format(justify("log-likelihood"), self.log_likelihood_, prec=decimals))
         print("{} = {} UTC".format(justify("time fit was run"), self._time_fit_was_called))
 
         for k, v in kwargs.items():

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -2087,7 +2087,7 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
                 # https://stats.stackexchange.com/questions/133817/stratified-concordance-index-survivalsurvconcordance
                 num_correct, num_tied, num_pairs = 0, 0, 0
                 for _, _df in self._predicted_partial_hazards_.groupby(self.strata):
-                    if _X.shape[0] == 1:
+                    if _df.shape[0] == 1:
                         continue
                     _num_correct, _num_tied, _num_pairs = _concordance_summary_statistics(
                         _df["T"].values, -_df["P"].values, _df["E"].values

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1464,19 +1464,14 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         cumulative_hazard_ : DataFrame
             the cumulative hazard of individuals over the timeline
         """
-        if conditional_after is None:
-            conditional_after = np.zeros(X.shape[0])
-        else:
-            conditional_after = np.asarray(conditional_after)
+        if conditional_after is not None:
+            raise NotImplementedError("Sorry, conditional_after for Cox is tricky to do. It's not implemented yet.")
 
         if self.strata:
             cumulative_hazard_ = pd.DataFrame()
             for stratum, stratified_X in X.groupby(self.strata):
                 try:
-                    c_0 = self.baseline_cumulative_hazard_[[stratum]] - dataframe_interpolate_at_times(
-                        self.baseline_cumulative_hazard_[[stratum]], conditional_after
-                    )
-                    c_0 = np.clip(c_0, 0, np.inf)
+                    c_0 = self.baseline_cumulative_hazard_[[stratum]]
                 except KeyError:
                     raise StatError(
                         """The stratum %s was not found in the original training data. For example, try
@@ -1493,14 +1488,10 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
                     left_index=True,
                 )
         else:
-            # TODO this needs to be shifted by conditional_after
-            c_0 = self.baseline_cumulative_hazard_ - dataframe_interpolate_at_times(
-                self.baseline_cumulative_hazard_, conditional_after
-            )
-            c_0 = np.clip(c_0, 0, np.inf)
-
+            c_0 = self.baseline_cumulative_hazard_
             v = self.predict_partial_hazard(X)
             col = _get_index(v)
+
             cumulative_hazard_ = pd.DataFrame(np.dot(c_0, v.T), columns=col, index=c_0.index)
 
         if times is not None:

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -554,7 +554,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
         self._hessian_ = hessian
         self._score_ = gradient
-        self._log_likelihood = ll
+        self.log_likelihood_ = ll
 
         if show_progress and completed:
             print("Convergence completed after %d iterations." % (i))
@@ -574,6 +574,14 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             )
 
         return beta
+
+    @property
+    def _log_likelihood(self):
+        warnings.warn(
+            "Please use `log_likelihood` property instead. `_log_likelihood` will be removed in a future version of lifelines",
+            DeprecationWarning,
+        )
+        return self.log_likelihood_
 
     def _get_efron_values_single(self, X, T, E, weights, beta):
         """
@@ -1349,7 +1357,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
                 ll_null = self._trivial_log_likelihood_single(
                     self.durations.values, self.event_observed.values, self.weights.values
                 )
-        ll_alt = self._log_likelihood
+        ll_alt = self.log_likelihood_
         test_stat = 2 * ll_alt - 2 * ll_null
         degrees_freedom = self.params_.shape[0]
         p_value = chisq_test(test_stat, degrees_freedom=degrees_freedom)

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -10,7 +10,6 @@ from numpy.linalg import norm, inv
 from scipy.linalg import solve as spsolve, LinAlgError
 from scipy.integrate import trapz
 from scipy import stats
-from bottleneck import nansum as array_sum_to_scalar
 from numpy import sum as array_sum_to_scalar
 
 from lifelines.fitters import BaseFitter
@@ -1290,7 +1289,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
         print("{} = {}".format(justify("number of subjects"), self._n_examples))
         print("{} = {}".format(justify("number of events"), self.event_observed.sum()))
-        print("{} = {:.{prec}f}".format(justify("partial log-likelihood"), self._log_likelihood, prec=decimals))
+        print("{} = {:.{prec}f}".format(justify("partial log-likelihood"), self.log_likelihood_, prec=decimals))
         print("{} = {}".format(justify("time fit was run"), self._time_fit_was_called))
 
         for k, v in kwargs.items():

--- a/lifelines/fitters/generalized_gamma_aft_fitter.py
+++ b/lifelines/fitters/generalized_gamma_aft_fitter.py
@@ -100,6 +100,7 @@ class GeneralizedGammaAFTFitter(ParametricRegressionFitter):
     """
     _fitted_parameter_names = ["sigma_", "mu_", "lambda_"]
     _scipy_fit_method = "SLSQP"
+    _scipy_fit_options = {"disp": True, "ftol": 1e-8, "maxiter": 200}
 
     def _create_initial_point(self, Ts, E, entries, weights, Xs):
         import lifelines

--- a/lifelines/fitters/generalized_gamma_aft_fitter.py
+++ b/lifelines/fitters/generalized_gamma_aft_fitter.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+import autograd.numpy as np
+import warnings
+from autograd.numpy import exp, abs, log
+from scipy.special import gammainccinv, gammaincinv
+from autograd_gamma import gammaincc, gammainc, gammaln, gammainccln, gammaincln
+from lifelines.fitters import ParametricRegressionFitter
+from lifelines.utils import coalesce, CensoringType
+from lifelines.utils.safe_exp import safe_exp
+from lifelines import utils
+
+
+class GeneralizedGammaAFTFitter(ParametricRegressionFitter):
+    r"""
+
+    This class implements a Generalized Gamma model for univariate data. The model has parameterized
+    form:
+
+    The survival function is:
+
+    .. math::
+        S(t)=\left\{ \begin{array}{}
+           1-{{\Gamma}_{RL}}\left( \tfrac{1}{{{\lambda }^{2}}};\tfrac{{{e}^{\lambda \left( \tfrac{\text{ln}(t)-\mu }{\sigma } \right)}}}{{{\lambda }^{2}}} \right)\text{ if }\lambda >0  \\
+           {{\Gamma}_{RL}}\left( \tfrac{1}{{{\lambda }^{2}}};\tfrac{{{e}^{\lambda \left( \tfrac{\text{ln}(t)-\mu }{\sigma } \right)}}}{{{\lambda }^{2}}} \right)\text{       if }\lambda < 0  \\
+        \end{array} \right.\,\!
+
+    where :math:`\Gamma_{RL}` is the regularized lower incomplete Gamma function.
+
+    This model has the Exponential, Weibull, Gamma and Log-Normal as sub-models, and thus can be used as a way to test which
+    model to use:
+
+    1. When :math:`\lambda = 1` and :math:`\sigma = 1`, then the data is Exponential.
+    2. When :math:`\lambda = 1` then the data is Weibull.
+    3. When :math:`\sigma = \lambda` then the data is Gamma.
+    4. When :math:`\lambda = 0` then the data is  Log-Normal.
+    5. When :math:`\lambda = -1` then the data is Inverse-Weibull.
+    6. When :math:`-\sigma = \lambda` then the data is Inverse-Gamma.
+
+
+    After calling the `.fit` method, you have access to properties like: ``cumulative_hazard_``, ``survival_function_``,
+    A summary of the fit is available with the method ``print_summary()``.
+
+
+    Important
+    -------------
+    The parameterization implemented has :math:`\log\sigma`, thus there is a `ln_sigma_` in the output. Exponentiate this parameter
+    to recover :math:`\sigma`.
+
+
+    Important
+    -------------
+    This model is experimental. It's API may change in the future. Also, it's convergence is not very stable.
+
+
+    Parameters
+    -----------
+    alpha: float, optional (default=0.05)
+        the level in the confidence intervals.
+
+
+    Examples
+    --------
+
+    >>> from lifelines import GeneralizedGammaFitter
+    >>> from lifelines.datasets import load_waltons
+    >>> waltons = load_waltons()
+    >>> ggf = GeneralizedGammaFitter()
+    >>> ggf.fit(waltons['T'], waltons['E'])
+    >>> ggf.plot()
+    >>> ggf.summary
+
+    Attributes
+    ----------
+    cumulative_hazard_ : DataFrame
+        The estimated cumulative hazard (with custom timeline if provided)
+    hazard_ : DataFrame
+        The estimated hazard (with custom timeline if provided)
+    survival_function_ : DataFrame
+        The estimated survival function (with custom timeline if provided)
+    cumumlative_density_ : DataFrame
+        The estimated cumulative density function (with custom timeline if provided)
+    variance_matrix_ : numpy array
+        The variance matrix of the coefficients
+    median_: float
+        The median time to event
+    lambda_: float
+        The fitted parameter in the model
+    rho_: float
+        The fitted parameter in the model
+    alpha_: float
+        The fitted parameter in the model
+    durations: array
+        The durations provided
+    event_observed: array
+        The event_observed variable provided
+    timeline: array
+        The time line to use for plotting and indexing
+    entry: array or None
+        The entry array provided, or None
+    """
+    _fitted_parameter_names = ["sigma_", "mu_", "lambda_"]
+    _scipy_fit_method = "trust-exact"
+
+    def _create_initial_point(self, Ts, E, entries, weights, Xs):
+        import lifelines
+
+        uni_model = lifelines.GeneralizedGammaFitter()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            if utils.CensoringType.is_right_censoring(self):
+                uni_model.fit_right_censoring(Ts[0], event_observed=E, entry=entries, weights=weights)
+            elif utils.CensoringType.is_interval_censoring(self):
+                uni_model.fit_interval_censoring(Ts[0], Ts[1], event_observed=E, entry=entries, weights=weights)
+            elif utils.CensoringType.is_left_censoring(self):
+                uni_model.fit_left_censoring(Ts[1], event_observed=E, entry=entries, weights=weights)
+
+            # we may use this later in print_summary
+            self._ll_null_ = uni_model.log_likelihood_
+
+            return {
+                # tack on as the intercept
+                "mu_": np.array([0] * (Xs["mu_"].shape[1] - 1) + [uni_model.mu_]),
+                "sigma_": np.array([0] * (Xs["sigma_"].shape[1] - 1) + [uni_model.ln_sigma_]),
+                "lambda_": np.array([0] * (Xs["lambda_"].shape[1] - 1) + [uni_model.lambda_]),
+            }
+
+    def _survival_function(self, params, T, Xs):
+        lambda_ = Xs["lambda_"] @ params["lambda_"]
+        sigma_ = safe_exp(Xs["sigma_"] @ params["sigma_"])
+        mu_ = Xs["mu_"] @ params["mu_"]
+
+        Z = (log(T) - mu_) / sigma_
+        ilambda_2 = 1 / lambda_ ** 2
+        exp_term = safe_exp(lambda_ * Z - 2 * log(np.abs(lambda_)))
+
+        return np.where(lambda_ > 0, gammaincc(ilambda_2, exp_term), gammainc(ilambda_2, exp_term))
+
+    def _cumulative_hazard(self, params, T, Xs):
+        lambda_ = Xs["lambda_"] @ params["lambda_"]
+        sigma_ = safe_exp(Xs["sigma_"] @ params["sigma_"])
+        mu_ = Xs["mu_"] @ params["mu_"]
+
+        ilambda_2 = 1 / lambda_ ** 2
+        Z = (log(T) - mu_) / sigma_
+        exp_term = np.clip(safe_exp(lambda_ * Z - 2 * log(np.abs(lambda_))), 1e-300, np.inf)
+
+        return -np.where(lambda_ > 0, gammainccln(ilambda_2, exp_term), gammaincln(ilambda_2, exp_term))
+
+    def _log_hazard(self, params, T, Xs):
+        lambda_ = Xs["lambda_"] @ params["lambda_"]
+        ln_sigma_ = Xs["sigma_"] @ params["sigma_"]
+        mu_ = Xs["mu_"] @ params["mu_"]
+
+        ilambda_2 = 1 / lambda_ ** 2
+        Z = (log(T) - mu_) / safe_exp(ln_sigma_)
+        exp_term = np.clip(safe_exp(lambda_ * Z - 2 * log(np.abs(lambda_))), 1e-300, np.inf)
+
+        return (
+            log(np.abs(lambda_))
+            - log(T)
+            - ln_sigma_
+            - gammaln(ilambda_2)
+            + (lambda_ * Z - 2 * log(np.abs(lambda_))) * ilambda_2
+            - exp_term
+            - np.where(lambda_ > 0, gammainccln(ilambda_2, exp_term), gammaincln(ilambda_2, exp_term))
+        )

--- a/lifelines/fitters/generalized_gamma_aft_fitter.py
+++ b/lifelines/fitters/generalized_gamma_aft_fitter.py
@@ -99,7 +99,7 @@ class GeneralizedGammaAFTFitter(ParametricRegressionFitter):
         The entry array provided, or None
     """
     _fitted_parameter_names = ["sigma_", "mu_", "lambda_"]
-    _scipy_fit_method = "trust-exact"
+    _scipy_fit_method = "SLSQP"
 
     def _create_initial_point(self, Ts, E, entries, weights, Xs):
         import lifelines

--- a/lifelines/fitters/generalized_gamma_fitter.py
+++ b/lifelines/fitters/generalized_gamma_fitter.py
@@ -100,7 +100,6 @@ class GeneralizedGammaFitter(KnownModelParametericUnivariateFitter):
     _fitted_parameter_names = ["mu_", "ln_sigma_", "lambda_"]
     _bounds = [(None, None), (None, None), (None, None)]
     _compare_to_values = np.array([0, 0, 1])
-    _scipy_fit_method = "SLSQP"
 
     def _get_initial_values(self, Ts, E, *args):
         if CensoringType.is_right_censoring(self):

--- a/lifelines/fitters/generalized_gamma_fitter.py
+++ b/lifelines/fitters/generalized_gamma_fitter.py
@@ -100,6 +100,7 @@ class GeneralizedGammaFitter(KnownModelParametericUnivariateFitter):
     _fitted_parameter_names = ["mu_", "ln_sigma_", "lambda_"]
     _bounds = [(None, None), (None, None), (None, None)]
     _compare_to_values = np.array([0, 0, 1])
+    _scipy_fit_method = "SLSQP"
 
     def _get_initial_values(self, Ts, E, *args):
         if CensoringType.is_right_censoring(self):

--- a/lifelines/fitters/generalized_gamma_regression_fitter.py
+++ b/lifelines/fitters/generalized_gamma_regression_fitter.py
@@ -10,21 +10,21 @@ from lifelines.utils.safe_exp import safe_exp
 from lifelines import utils
 
 
-class GeneralizedGammaAFTFitter(ParametricRegressionFitter):
+class GeneralizedGammaRegressionFitter(ParametricRegressionFitter):
     r"""
 
-    This class implements a Generalized Gamma model for univariate data. The model has parameterized
+    This class implements a Generalized Gamma model for regression data. The model has parameterized
     form:
 
     The survival function is:
 
     .. math::
-        S(t)=\left\{ \begin{array}{}
+        S(t \;|\; x)=\left\{ \begin{array}{}
            1-{{\Gamma}_{RL}}\left( \tfrac{1}{{{\lambda }^{2}}};\tfrac{{{e}^{\lambda \left( \tfrac{\text{ln}(t)-\mu }{\sigma } \right)}}}{{{\lambda }^{2}}} \right)\text{ if }\lambda >0  \\
            {{\Gamma}_{RL}}\left( \tfrac{1}{{{\lambda }^{2}}};\tfrac{{{e}^{\lambda \left( \tfrac{\text{ln}(t)-\mu }{\sigma } \right)}}}{{{\lambda }^{2}}} \right)\text{       if }\lambda < 0  \\
         \end{array} \right.\,\!
 
-    where :math:`\Gamma_{RL}` is the regularized lower incomplete Gamma function.
+    where :math:`\Gamma_{RL}` is the regularized lower incomplete Gamma function, and :math:`\sigma = \exp(\alpha x^T), \lambda = \beta x^T, \mu = \gamma x^T`.
 
     This model has the Exponential, Weibull, Gamma and Log-Normal as sub-models, and thus can be used as a way to test which
     model to use:

--- a/lifelines/fitters/log_logistic_aft_fitter.py
+++ b/lifelines/fitters/log_logistic_aft_fitter.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from lifelines.utils import _get_index, coalesce
 from lifelines.fitters import ParametericAFTRegressionFitter
+from lifelines.utils.safe_exp import safe_exp
 
 
 class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
@@ -68,7 +69,7 @@ class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
 
     def _cumulative_hazard(self, params, T, Xs):
         alpha_params = params["alpha_"]
-        alpha_ = np.exp(np.dot(Xs["alpha_"], alpha_params))
+        alpha_ = safe_exp(np.dot(Xs["alpha_"], alpha_params))
 
         beta_params = params["beta_"]
         beta_ = np.exp(np.dot(Xs["beta_"], beta_params))
@@ -77,11 +78,11 @@ class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
     def _log_hazard(self, params, T, Xs):
         alpha_params = params["alpha_"]
         log_alpha_ = np.dot(Xs["alpha_"], alpha_params)
-        alpha_ = np.exp(log_alpha_)
+        alpha_ = safe_exp(log_alpha_)
 
         beta_params = params["beta_"]
         log_beta_ = np.dot(Xs["beta_"], beta_params)
-        beta_ = np.exp(log_beta_)
+        beta_ = safe_exp(log_beta_)
 
         return (
             log_beta_
@@ -93,11 +94,11 @@ class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
     def _log_1m_sf(self, params, T, Xs):
         alpha_params = params["alpha_"]
         log_alpha_ = np.dot(Xs["alpha_"], alpha_params)
-        alpha_ = np.exp(log_alpha_)
+        alpha_ = safe_exp(log_alpha_)
 
         beta_params = params["beta_"]
         log_beta_ = np.dot(Xs["beta_"], beta_params)
-        beta_ = np.exp(log_beta_)
+        beta_ = safe_exp(log_beta_)
         return -np.logaddexp(-beta_ * (np.log(T) - np.log(alpha_)), 0)
 
     def predict_percentile(self, df, ancillary_df=None, p=0.5):

--- a/lifelines/fitters/log_normal_aft_fitter.py
+++ b/lifelines/fitters/log_normal_aft_fitter.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from lifelines.utils import _get_index
 from lifelines.fitters import ParametericAFTRegressionFitter
+from lifelines.utils.safe_exp import safe_exp
 
 
 class LogNormalAFTFitter(ParametericAFTRegressionFitter):
@@ -71,7 +72,7 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
         mu_ = np.dot(Xs["mu_"], mu_params)
 
         sigma_params = params["sigma_"]
-        sigma_ = np.exp(np.dot(Xs["sigma_"], sigma_params))
+        sigma_ = safe_exp(np.dot(Xs["sigma_"], sigma_params))
         Z = (np.log(T) - mu_) / sigma_
         return -norm.logsf(Z)
 
@@ -82,7 +83,7 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
         sigma_params = params["sigma_"]
 
         log_sigma_ = np.dot(Xs["sigma_"], sigma_params)
-        sigma_ = np.exp(log_sigma_)
+        sigma_ = safe_exp(log_sigma_)
         Z = (np.log(T) - mu_) / sigma_
 
         return norm.logpdf(Z) - log_sigma_ - np.log(T) - norm.logsf(Z)
@@ -94,7 +95,7 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
         sigma_params = params["sigma_"]
 
         log_sigma_ = np.dot(Xs["sigma_"], sigma_params)
-        sigma_ = np.exp(log_sigma_)
+        sigma_ = safe_exp(log_sigma_)
         Z = (np.log(T) - mu_) / sigma_
         return norm.logcdf(Z)
 

--- a/lifelines/fitters/piecewise_exponential_regression_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_regression_fitter.py
@@ -54,7 +54,7 @@ class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
 
         return np.array([np.exp(np.dot(X, self.params_["lambda_%d_" % i])) for i in range(self.n_breakpoints)])
 
-    def predict_cumulative_hazard(self, df, times=None):
+    def predict_cumulative_hazard(self, df, times=None, conditional_after=None):
         """
         Return the cumulative hazard rate of subjects in X at time points.
 
@@ -74,6 +74,10 @@ class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
         cumulative_hazard_ : DataFrame
             the cumulative hazard of individuals over the timeline
         """
+
+        if conditional_after is not None:
+            raise NotImplementedError()
+
         times = np.asarray(coalesce(times, self.timeline, np.unique(self.durations)))
         n = times.shape[0]
         times = times.reshape((n, 1))

--- a/lifelines/fitters/piecewise_exponential_regression_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_regression_fitter.py
@@ -115,5 +115,5 @@ class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
         if CensoringType.is_left_censoring(self):
             raise NotImplementedError()
 
-        self._ll_null_ = model._log_likelihood
+        self._ll_null_ = model.log_likelihood_
         return self._ll_null_

--- a/lifelines/fitters/piecewise_exponential_regression_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_regression_fitter.py
@@ -3,6 +3,7 @@ import autograd.numpy as np
 from lifelines.utils import coalesce, _get_index, CensoringType
 from lifelines.fitters import ParametricRegressionFitter
 import pandas as pd
+from lifelines.utils.safe_exp import safe_exp
 
 
 class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
@@ -37,7 +38,7 @@ class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
         T = T.reshape((n, 1))
         M = np.minimum(np.tile(self.breakpoints, (n, 1)), T)
         M = np.hstack([M[:, tuple([0])], np.diff(M, axis=1)])
-        lambdas_ = np.array([np.exp(-np.dot(Xs[param], params[param])) for param in self._fitted_parameter_names])
+        lambdas_ = np.array([safe_exp(-np.dot(Xs[param], params[param])) for param in self._fitted_parameter_names])
         return (M * lambdas_.T).sum(1)
 
     def _log_hazard(self, params, T, X):

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from lifelines.utils import _get_index, coalesce
 from lifelines.fitters import ParametericAFTRegressionFitter
+from lifelines.utils.safe_exp import safe_exp
 
 
 class WeibullAFTFitter(ParametericAFTRegressionFitter):
@@ -72,9 +73,9 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter):
         log_lambda_ = Xs["lambda_"] @ lambda_params
 
         rho_params = params["rho_"]
-        rho_ = np.exp(Xs["rho_"] @ rho_params)
+        rho_ = safe_exp(Xs["rho_"] @ rho_params)
 
-        return np.exp(rho_ * (np.log(np.clip(T, 1e-25, np.inf)) - log_lambda_))
+        return safe_exp(rho_ * (np.log(np.clip(T, 1e-25, np.inf)) - log_lambda_))
 
     def _log_hazard(self, params, T, Xs):
         lambda_params = params["lambda_"]

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -86,7 +86,7 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter):
 
         return log_rho_ - log_lambda_ + np.expm1(log_rho_) * (np.log(T) - log_lambda_)
 
-    def predict_percentile(self, df, ancillary_df=None, p=0.5):
+    def predict_percentile(self, df, ancillary_df=None, p=0.5, conditional_after=None):
         """
         Returns the median lifetimes for the individuals, by default. If the survival curve of an
         individual does not cross 0.5, then the result is infinity.
@@ -116,7 +116,12 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter):
         """
         lambda_, rho_ = self._prep_inputs_for_prediction_and_return_scores(df, ancillary_df)
 
-        return pd.DataFrame(lambda_ * np.power(-np.log(p), 1 / rho_), index=_get_index(df))
+        if conditional_after is None:
+            conditional_after = np.zeros(df.shape[0])
+        return pd.DataFrame(
+            lambda_ * np.power(-np.log(p) + (conditional_after / lambda_) ** rho_, 1 / rho_) - conditional_after,
+            index=_get_index(df),
+        )
 
     def predict_expectation(self, df, ancillary_df=None):
         """

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -69,19 +69,19 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter):
 
     def _cumulative_hazard(self, params, T, Xs):
         lambda_params = params["lambda_"]
-        log_lambda_ = np.dot(Xs["lambda_"], lambda_params)
+        log_lambda_ = Xs["lambda_"] @ lambda_params
 
         rho_params = params["rho_"]
-        rho_ = np.exp(np.dot(Xs["rho_"], rho_params))
+        rho_ = np.exp(Xs["rho_"] @ rho_params)
 
         return np.exp(rho_ * (np.log(np.clip(T, 1e-25, np.inf)) - log_lambda_))
 
     def _log_hazard(self, params, T, Xs):
         lambda_params = params["lambda_"]
-        log_lambda_ = np.dot(Xs["lambda_"], lambda_params)
+        log_lambda_ = Xs["lambda_"] @ lambda_params
 
         rho_params = params["rho_"]
-        log_rho_ = np.dot(Xs["rho_"], rho_params)
+        log_rho_ = Xs["rho_"] @ rho_params
 
         return log_rho_ - log_lambda_ + np.expm1(log_rho_) * (np.log(T) - log_lambda_)
 

--- a/lifelines/fitters/weibull_fitter.py
+++ b/lifelines/fitters/weibull_fitter.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import autograd.numpy as np
 from lifelines.fitters import KnownModelParametericUnivariateFitter
+from lifelines.utils.safe_exp import safe_exp
 
 
 class WeibullFitter(KnownModelParametericUnivariateFitter):
@@ -80,7 +81,7 @@ class WeibullFitter(KnownModelParametericUnivariateFitter):
 
     def _cumulative_hazard(self, params, times):
         lambda_, rho_ = params
-        return np.exp(rho_ * (np.log(np.clip(times, 1e-25, np.inf)) - np.log(lambda_)))
+        return safe_exp(rho_ * (np.log(np.clip(times, 1e-25, np.inf)) - np.log(lambda_)))
 
     def percentile(self, p):
         return self.lambda_ * (np.log(1 / p) ** (1.0 / self.rho_))

--- a/lifelines/utils/safe_exp.py
+++ b/lifelines/utils/safe_exp.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+import sys
+from autograd.extend import primitive, defvjp
+from autograd import numpy as np
+
+MAX = np.log(sys.float_info.max) - 50
+
+
+def safe_exp_vjp(ans, x):
+    return lambda g: g * ans
+
+
+@primitive
+def safe_exp(x):
+    return np.exp(np.clip(x, -np.inf, MAX))
+
+
+defvjp(safe_exp, safe_exp_vjp)

--- a/lifelines/utils/safe_exp.py
+++ b/lifelines/utils/safe_exp.py
@@ -1,9 +1,93 @@
 # -*- coding: utf-8 -*-
-import sys
+"""
+One interesting idea in autograd is the ability to "hijack"
+derivatives if they start misbehaving. In this example, it's
+possible for exponentials to get very large with even modestly
+large arguments, and their derivatives can be arbitrarily larger.
+
+One solution is to limit the `exp` to never be above
+some very large limit. That's what `np.clip(x, -np.inf, MAX)`
+is doing. The function looks like this:
+
+                           exp capped
++--------------------------------------------------------+
+|                                                        |
+|                                                        |
+|                                        X+--------------+
+|                                        X               |
+|                                        X               |
+|                                        X               |
+|                                        X               |
+|                                       X                |
+|                                       X                |
+|                                      X                 |
+|                                     X                  |
+|                                   XX                   |
+|                                 XX                     |
+|                              XX                        |
+|                       X X XX                           |
+| x x    x  X   X  X XX                                  |
++--------------------------------------------------------+
+                      0                  M
+
+
+However, the `clip` function has derivative 0 after it's reached it's
+max, M. That will mess up any derivatives:
+
+                           exp capped'
++--------------------------------------------------------+
+|                                                        |
+|                                                        |
+|                                        X               |
+|                                        X               |
+|                                        X               |
+|                                        X               |
+|                                        X               |
+|                                       X                |
+|                                       X                |
+|                                      X                 |
+|                                     X                  |
+|                                   XX                   |
+|                                 XX                     |
+|                              XX                        |
+|                       X X XX                           |
+| x x    x  X   X  X XX                   +--------------+               |
++--------------------------------------------------------+
+                      0                  M
+
+
+
+
+So we make the derivative _the same_ as the original function:
+
+                         exp capped'
++--------------------------------------------------------+
+|                                                        |
+|                                                        |
+|                                        X+--------------+
+|                                        X               |
+|                                        X               |
+|                                        X               |
+|                                        X               |
+|                                       X                |
+|                                       X                |
+|                                      X                 |
+|                                     X                  |
+|                                   XX                   |
+|                                 XX                     |
+|                              XX                        |
+|                       X X XX                           |
+| x x    x  X   X  X XX                                  |
++--------------------------------------------------------+
+                      0                  M
+
+
+
+"""
 from autograd.extend import primitive, defvjp
 from autograd import numpy as np
 
-MAX = np.log(sys.float_info.max) - 75
+MAX = np.log(np.finfo(float).max) - 75
 
 
 def safe_exp_vjp(ans, x):

--- a/lifelines/utils/safe_exp.py
+++ b/lifelines/utils/safe_exp.py
@@ -3,7 +3,7 @@ import sys
 from autograd.extend import primitive, defvjp
 from autograd import numpy as np
 
-MAX = np.log(sys.float_info.max) - 50
+MAX = np.log(sys.float_info.max) - 75
 
 
 def safe_exp_vjp(ans, x):

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.22.2"
+__version__ = "0.22.3"

--- a/reqs/base-requirements.txt
+++ b/reqs/base-requirements.txt
@@ -2,6 +2,5 @@ numpy>=1.14.0
 scipy>=1.0
 pandas>=0.23.0
 matplotlib>=3.0
-bottleneck>=1.0
 autograd>=1.3
 autograd-gamma>=0.3

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1684,8 +1684,8 @@ class TestAFTFitters:
         lnf = LogNormalAFTFitter().fit(df, "T")
         llf = LogLogisticAFTFitter().fit(df, "T")
 
-        assert wf._log_likelihood > lnf._log_likelihood
-        assert wf._log_likelihood > llf._log_likelihood
+        assert wf.log_likelihood_ > lnf.log_likelihood_
+        assert wf.log_likelihood_ > llf.log_likelihood_
 
         # lognormal should have the best fit -> largest ll
         W = norm.rvs(scale=1, loc=0, size=N)
@@ -1699,8 +1699,8 @@ class TestAFTFitters:
         lnf = LogNormalAFTFitter().fit(df, "T")
         llf = LogLogisticAFTFitter().fit(df, "T")
 
-        assert lnf._log_likelihood > wf._log_likelihood
-        assert lnf._log_likelihood > llf._log_likelihood
+        assert lnf.log_likelihood_ > wf.log_likelihood_
+        assert lnf.log_likelihood_ > llf.log_likelihood_
 
         # loglogistic should have the best fit -> largest ll
         W = logistic.rvs(scale=1, loc=0, size=N)
@@ -1714,8 +1714,8 @@ class TestAFTFitters:
         lnf = LogNormalAFTFitter().fit(df, "T")
         llf = LogLogisticAFTFitter().fit(df, "T")
 
-        assert llf._log_likelihood > wf._log_likelihood
-        assert llf._log_likelihood > lnf._log_likelihood
+        assert llf.log_likelihood_ > wf.log_likelihood_
+        assert llf.log_likelihood_ > lnf.log_likelihood_
 
     def test_aft_median_behaviour(self, models, rossi):
         for aft in models:
@@ -3396,7 +3396,7 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
         cp_with_strata_in_fit.fit(rossi, "week", "arrest", strata=strata)
         assert cp_with_strata_in_fit.strata == strata
 
-        assert cp_with_strata_in_init._log_likelihood == cp_with_strata_in_fit._log_likelihood
+        assert cp_with_strata_in_init.log_likelihood_ == cp_with_strata_in_fit.log_likelihood_
 
     def test_baseline_survival_is_the_same_indp_of_location(self, regression_dataset):
         df = regression_dataset.copy()

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -952,6 +952,39 @@ class TestGeneralizedGammaFitter:
         gg.print_summary(4)
         assert abs(gg.summary.loc["lambda_", "coef"] - -np.exp(gg.summary.loc["ln_sigma_", "coef"])) < 0.15
 
+    def test_against_reliability_software(self):
+        # From http://reliawiki.org/index.php/The_Generalized_Gamma_Distribution
+        T = [
+            17.88,
+            28.92,
+            33,
+            41.52,
+            42.12,
+            45.6,
+            48.4,
+            51.84,
+            51.96,
+            54.12,
+            55.56,
+            67.8,
+            68.64,
+            68.64,
+            68.88,
+            84.12,
+            93.12,
+            98.64,
+            105.12,
+            105.84,
+            127.92,
+            128.04,
+            173.4,
+        ]
+
+        gg = GeneralizedGammaFitter().fit(T)
+        npt.assert_allclose(gg.summary.loc["mu_", "coef"], 4.23064, rtol=0.001)
+        npt.assert_allclose(gg.summary.loc["lambda_", "coef"], 0.307639, rtol=1e-5)
+        npt.assert_allclose(np.exp(gg.summary.loc["ln_sigma_", "coef"]), 0.509982, rtol=1e-6)
+
 
 class TestExponentialFitter:
     def test_fit_computes_correct_lambda_(self):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -2012,7 +2012,7 @@ class TestWeibullAFTFitter:
     def test_fitted_log_likelihood_match_with_flexsurv_has(self, aft, rossi):
         # survreg(Surv(week, arrest) ~ fin + age + race + wexp + mar + paro + prio, data=df, dist='weibull')
         aft.fit(rossi, "week", "arrest")
-        npt.assert_allclose(aft._log_likelihood, -679.9166)
+        npt.assert_allclose(aft.log_likelihood_, -679.9166)
 
     def test_fitted_log_likelihood_ratio_test_match_with_flexsurv_has(self, aft, rossi):
         # survreg(Surv(week, arrest) ~ fin + age + race + wexp + mar + paro + prio, data=df, dist='weibull')
@@ -2143,7 +2143,7 @@ class TestWeibullAFTFitter:
         npt.assert_allclose(aft.summary.loc[("lambda_", "_intercept"), "coef"], np.log(18.31971), rtol=1e-4)
         npt.assert_allclose(aft.summary.loc[("rho_", "_intercept"), "coef"], np.log(2.82628), rtol=1e-4)
 
-        npt.assert_allclose(aft._log_likelihood, -2027.196, rtol=1e-3)
+        npt.assert_allclose(aft.log_likelihood_, -2027.196, rtol=1e-3)
 
         npt.assert_allclose(aft.summary.loc[("lambda_", "gender"), "se(coef)"], 0.02823, rtol=1e-1)
         # npt.assert_allclose(aft.summary.loc[("lambda_", "_intercept"), "se(coef)"], 0.42273, rtol=1e-1)
@@ -2151,7 +2151,7 @@ class TestWeibullAFTFitter:
 
         aft.fit_interval_censoring(df, "left", "right", "E", ancillary_df=True)
 
-        npt.assert_allclose(aft._log_likelihood, -2025.813, rtol=1e-3)
+        npt.assert_allclose(aft.log_likelihood_, -2025.813, rtol=1e-3)
         # npt.assert_allclose(aft.summary.loc[("rho_", "gender"), "coef"], 0.1670, rtol=1e-4)
 
     def test_aft_weibull_with_weights(self, rossi, aft):
@@ -2517,7 +2517,7 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
 
     def test_log_likelihood(self, data_nus, cph):
         cph.fit(data_nus, duration_col="t", event_col="E")
-        assert abs(cph._log_likelihood - -12.7601409152) < 0.001
+        assert abs(cph.log_likelihood_ - -12.7601409152) < 0.001
 
     def test_single_efron_computed_by_hand_examples(self, data_nus, cph):
 
@@ -3181,7 +3181,7 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
             assert_series_equal(cph.summary["se(coef)"], expected_std, check_less_precise=2, check_names=False)
 
             expected_ll = -1.142397
-            assert abs(cph._log_likelihood - expected_ll) < 0.001
+            assert abs(cph.log_likelihood_ - expected_ll) < 0.001
 
     def test_less_trival_float_weights_with_no_ties_is_the_same_as_R(self, regression_dataset):
         """
@@ -3431,7 +3431,7 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
         cp.fit(rossi, "week", "arrest", strata=["race", "paro", "mar", "wexp"])
 
         npt.assert_almost_equal(cp.summary["coef"].values, [-0.335, -0.059, 0.100], decimal=3)
-        assert abs(cp._log_likelihood - -436.9339) / 436.9339 < 0.01
+        assert abs(cp.log_likelihood_ - -436.9339) / 436.9339 < 0.01
 
     def test_baseline_hazard_works_with_strata_against_R_output(self, rossi):
         """
@@ -4309,11 +4309,11 @@ Likelihood ratio test = 15.11 on 4 df, -log2(p)=7.80
         npt.assert_allclose(summary["coef"].tolist(), [0.0293, -0.6176, -0.1527], atol=0.001)
         npt.assert_allclose(summary["se(coef)"].tolist(), [0.0139, 0.3707, 0.0710], atol=0.001)
         npt.assert_allclose(summary["z"].tolist(), [2.11, -1.67, -2.15], atol=0.01)
-        npt.assert_allclose(ctv._log_likelihood, -254.7144, atol=0.01)
+        npt.assert_allclose(ctv.log_likelihood_, -254.7144, atol=0.01)
 
     def test_ctv_with_multiple_strata(self, ctv, heart):
         ctv.fit(heart, id_col="id", event_col="event", strata=["transplant", "surgery"])
-        npt.assert_allclose(ctv._log_likelihood, -230.6726, atol=0.01)
+        npt.assert_allclose(ctv.log_likelihood_, -230.6726, atol=0.01)
 
     def test_ctv_ratio_test_with_strata(self, ctv, heart):
         ctv.fit(heart, id_col="id", event_col="event", strata=["transplant"])

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1626,7 +1626,24 @@ class TestAFTFitters:
     def models(self):
         return [WeibullAFTFitter(), LogNormalAFTFitter(), LogLogisticAFTFitter()]
 
-    def test_fit_intercept_can_be_false(self, rossi):
+    def test_fit_intercept_can_be_false_and_not_provided(self, rossi):
+        # nonsensical data
+        interval_rossi = rossi.copy()
+        interval_rossi["start"] = 0
+        interval_rossi["end"] = rossi["week"]
+        interval_rossi["arrest"] = False
+        interval_rossi = interval_rossi.drop("week", axis=1)
+
+        # nonsensical data
+        left_rossi = rossi.copy()
+        left_rossi["week"] = 1 / rossi["week"] + 1
+
+        for fitter in [WeibullAFTFitter(fit_intercept=False)]:
+            fitter.fit_right_censoring(rossi, "week", "arrest")
+            fitter.fit_left_censoring(left_rossi, "week", "arrest")
+            fitter.fit_interval_censoring(interval_rossi, "start", "end", "arrest")
+
+    def test_fit_intercept_can_be_false_but_provided(self, rossi):
         rossi["intercept"] = 1.0
         for fitter in [
             WeibullAFTFitter(fit_intercept=False),

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -57,7 +57,7 @@ from lifelines import (
     LogLogisticAFTFitter,
     PiecewiseExponentialRegressionFitter,
     GeneralizedGammaFitter,
-    GeneralizedGammaAFTFitter,
+    GeneralizedGammaRegressionFitter,
 )
 
 from lifelines.datasets import (
@@ -1409,7 +1409,7 @@ class TestRegressionFitters:
             LogLogisticAFTFitter(fit_intercept=True),
             PiecewiseExponentialRegressionFitter(breakpoints=[25.0]),
             CustomRegressionModelTesting(penalizer=1.0),
-            GeneralizedGammaAFTFitter(penalizer=0),
+            GeneralizedGammaRegressionFitter(penalizer=0),
         ]
 
     def test_dill_serialization(self, rossi, regression_models):
@@ -1506,7 +1506,7 @@ class TestRegressionFitters:
             if (
                 isinstance(fitter, PiecewiseExponentialRegressionFitter)
                 or isinstance(fitter, CustomRegressionModelTesting)
-                or isinstance(fitter, GeneralizedGammaAFTFitter)
+                or isinstance(fitter, GeneralizedGammaRegressionFitter)
             ):
                 continue
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -4066,8 +4066,7 @@ class TestCoxTimeVaryingFitter:
         )
 
         with pytest.warns(ConvergenceWarning, match="with start and stop equal and a death event") as w:
-            with pytest.raises(ZeroDivisionError):
-                ctv.fit(df, id_col="id", start_col="start", stop_col="stop", event_col="event")
+            ctv.fit(df, id_col="id", start_col="start", stop_col="stop", event_col="event")
 
     def test_summary_output_versus_Rs_against_standford_heart_transplant(self, ctv, heart):
         """


### PR DESCRIPTION
#### 0.22.3

##### New features
 - model's now expose a `log_likelihood_` property.
 - new `conditional_after` argument on `predict_*` methods that make prediction on censored subjects easier.
 - new `lifelines.utils.safe_exp` to make `exp` overflows easier to handle.
 - smarter initial conditions for parametric regression models.
 - New regression model: `GeneralizedGammaRegressionFitter`

##### API changes
 - removed `lifelines.utils.gamma` - use `autograd_gamma` library instead.

##### Bug fixes
 - AFT log-likelihood ratio test was not using weights correctly.
 - corrected (by bumping) scipy and autograd dependencies
 - convergence is improved for most models, and many `exp` overflow warnings have been eliminated.
 - Fixed an error in the `predict_percentile` of `LogLogisticAFTFitter`. New tests have been added around this.

closes #798,
closes #792
closes #785,
closes #799
closes #801