### PR TITLE
kaplan_meier: Change lambda -> functools.partial()

### DIFF
--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import functools
 import warnings
 import numpy as np
 import pandas as pd
@@ -264,7 +265,7 @@ class KaplanMeierFitter(UnivariateFitter):
         self.__estimate = getattr(self, primary_estimate_name)
         self.confidence_interval_ = self._bounds(cumulative_sq_[:, None], alpha, ci_labels)
         self._median = median_survival_times(self.__estimate, left_censorship=is_left_censoring)
-        self.percentile = lambda p: qth_survival_time(p, self.__estimate, cdf=is_left_censoring)
+        self.percentile = functools.partial(qth_survival_time, survival_function=self.__estimate, cdf=is_left_censoring)
         self._cumulative_sq_ = cumulative_sq_
 
         setattr(self, "confidence_interval_" + primary_estimate_name, self.confidence_interval_)


### PR DESCRIPTION
Lambda is slightly less performant and is also not picklable.
use the functools.partial instead that is the more robust way to
manage partial functions and functions using default arguments.

