### PR TITLE
V0.22.5

### DIFF
--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -919,7 +919,7 @@ class ParametericUnivariateFitter(UnivariateFitter):
 
         # estimation
         self._fitted_parameters_, self.log_likelihood_, self._hessian_ = self._fit_model(
-            Ts, self.event_observed.astype(bool), self.entry, self.weights, initial_point, show_progress=show_progress
+            Ts, self.event_observed.astype(bool), self.entry, self.weights, show_progress=show_progress
         )
 
         if not self._KNOWN_MODEL:

--- a/lifelines/fitters/log_normal_fitter.py
+++ b/lifelines/fitters/log_normal_fitter.py
@@ -65,7 +65,7 @@ class LogNormalFitter(KnownModelParametericUnivariateFitter):
         elif CensoringType.is_left_censoring(self):
             log_T = np.log(Ts[1])
         elif CensoringType.is_interval_censoring(self):
-            log_T = np.log(Ts[1] - Ts[0])
+            log_T = np.log(Ts[1])
         return np.array([np.median(log_T), 1.0])
 
     @property

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.22.4"
+__version__ = "0.22.5"

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -2486,16 +2486,6 @@ class TestCoxPHFitter:
         npt.assert_allclose(results.loc[1, "martingale"], 0.774216356429, rtol=1e-05)
         npt.assert_allclose(results.loc[199, "martingale"], 0.868510420157, rtol=1e-05)
 
-    def test_error_is_raised_if_using_non_numeric_data_in_prediction(self, cph):
-        df = pd.DataFrame({"t": [1.0, 2.0, 3.0, 4.0], "int_": [1, -1, 0, 0], "float_": [1.2, -0.5, 0.0, 0.1]})
-
-        cph.fit(df, duration_col="t")
-
-        df_predict_on = pd.DataFrame({"int_": ["1", "-1", "0"], "float_": [1.2, -0.5, 0.0]})
-
-        with pytest.raises(TypeError):
-            cph.predict_partial_hazard(df_predict_on)
-
     def test_strata_will_work_with_matched_pairs(self, rossi, cph):
         rossi["matched_pairs"] = np.floor(rossi.index / 2.0).astype(int)
         cph.fit(rossi, duration_col="week", event_col="arrest", strata=["matched_pairs"], show_progress=True)


### PR DESCRIPTION
##### New features
 - Improvements to the __repr__ of models that takes into accounts weights.
 - Better support for predicting on Pandas Series

##### Bug fixes
 - Fixed issue where `fit_interval_censoring` wouldn't accept lists.
 - Fixed an issue with `AalenJohansenFitter` failing to plot confidence intervals.

##### API Changes
 - `_get_initial_value` in parametric univariate models is renamed `_create_initial_point`


closes #823 
closes #830