### PR TITLE
V0.22.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 #### 0.22.6
 
 ##### New features
+ - `conditional_after` works for `CoxPHFitter` models 😅
 
 ##### Bug fixes
 
 ##### API Changes
  - `CoxPHFitter.baseline_cumulative_hazard_`'s column is renamed `"baseline cumulative hazard"` - previously it was `"baseline hazard"`. (Only applies if the model has no strata.)
-
+ - `utils.dataframe_interpolate_at_times` renamed to `utils.interpolate_at_times_and_return_pandas`.
 
 
 #### 0.22.5 - 2019-09-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### 0.22.6
 
 ##### New features
- - `conditional_after` works for `CoxPHFitter` models 😅
+ - `conditional_after` works for `CoxPHFitter` prediction models 😅
 
 ##### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Changelog
 
+#### 0.22.6
+
+##### New features
+
+##### Bug fixes
+
+##### API Changes
+ - `CoxPHFitter.baseline_cumulative_hazard_`'s column is renamed `"baseline cumulative hazard"` - previously it was `"baseline hazard"`. (Only applies if the model has no strata.)
+
+
+
 #### 0.22.5 - 2019-09-20
 
 ##### New features

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,8 +1,32 @@
 Changelog
 ---------
 
+0.22.6
+^^^^^^
+
+New features
+''''''''''''
+
+-  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
+
+Bug fixes
+'''''''''
+
+API Changes
+'''''''''''
+
+-  ``CoxPHFitter.baseline_cumulative_hazard_``\ ’s column is renamed
+   ``"baseline cumulative hazard"`` - previously it was
+   ``"baseline hazard"``. (Only applies if the model has no strata.)
+-  ``utils.dataframe_interpolate_at_times`` renamed to
+   ``utils.interpolate_at_times_and_return_pandas``.
+
+.. _section-1:
+
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
+
+.. _new-features-1:
 
 New features
 ''''''''''''
@@ -11,6 +35,8 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
+.. _bug-fixes-1:
+
 Bug fixes
 '''''''''
 
@@ -18,18 +44,20 @@ Bug fixes
 -  Fixed an issue with ``AalenJohansenFitter`` failing to plot
    confidence intervals.
 
+.. _api-changes-1:
+
 API Changes
 '''''''''''
 
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-1:
+.. _section-2:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ''''''''''''
@@ -40,7 +68,7 @@ New features
 -  new ``utils.restricted_mean_survival_time`` that approximates the
    RMST using numerical integration against survival functions.
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API changes
 '''''''''''
@@ -48,7 +76,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -56,12 +84,12 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-2:
+.. _section-3:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ''''''''''''
@@ -74,7 +102,7 @@ New features
 -  smarter initial conditions for parametric regression models.
 -  New regression model: ``GeneralizedGammaRegressionFitter``
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API changes
 '''''''''''
@@ -85,7 +113,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
@@ -97,19 +125,19 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-3:
+.. _section-4:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ''''''''''''
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -120,12 +148,12 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-4:
+.. _section-5:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ''''''''''''
@@ -140,7 +168,7 @@ New features
    right censoring)
 -  improvements to ``lifelines.utils.gamma``
 
-.. _api-changes-3:
+.. _api-changes-4:
 
 API changes
 '''''''''''
@@ -153,7 +181,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -163,12 +191,12 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-5:
+.. _section-6:
 
 0.22.0 - 2019-07-03
 ~~~~~~~~~~~~~~~~~~~
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ''''''''''''
@@ -180,7 +208,7 @@ New features
 -  for parametric univariate models, the ``conditional_time_to_event_``
    is now exact instead of an approximation.
 
-.. _api-changes-4:
+.. _api-changes-5:
 
 API changes
 '''''''''''
@@ -202,7 +230,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
@@ -211,21 +239,21 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-6:
+.. _section-7:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 I’m skipping 0.21.4 version because of deployment issues.
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ''''''''''''
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -235,12 +263,12 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-7:
+.. _section-8:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ''''''''''''
@@ -254,19 +282,19 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-8:
+.. _section-9:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-8:
+.. _new-features-9:
 
 New features
 ''''''''''''
@@ -278,7 +306,7 @@ New features
    that computes, you guessed it, the log-likelihood ratio test.
    Previously this was an internal API that is being exposed.
 
-.. _api-changes-5:
+.. _api-changes-6:
 
 API changes
 '''''''''''
@@ -290,17 +318,17 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
 
-.. _section-9:
+.. _section-10:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-9:
+.. _new-features-10:
 
 New features
 ''''''''''''
@@ -309,7 +337,7 @@ New features
    ``add_covariate_to_timeline``
 -  PiecewiseExponentialFitter now allows numpy arrays as breakpoints
 
-.. _api-changes-6:
+.. _api-changes-7:
 
 API changes
 '''''''''''
@@ -317,19 +345,19 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-10:
+.. _section-11:
 
 0.21.0 - 2019-04-12
 ~~~~~~~~~~~~~~~~~~~
 
-.. _new-features-10:
+.. _new-features-11:
 
 New features
 ''''''''''''
@@ -343,7 +371,7 @@ New features
 -  a new interval censored dataset is available under
    ``lifelines.datasets.load_diabetes``
 
-.. _api-changes-7:
+.. _api-changes-8:
 
 API changes
 '''''''''''
@@ -354,7 +382,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
@@ -364,19 +392,19 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-11:
+.. _section-12:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-11:
+.. _new-features-12:
 
 New features
 ''''''''''''
 
 -  performance improvements for ``print_summary``.
 
-.. _api-changes-8:
+.. _api-changes-9:
 
 API changes
 '''''''''''
@@ -386,7 +414,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
@@ -395,12 +423,12 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-12:
+.. _section-13:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-12:
+.. _new-features-13:
 
 New features
 ''''''''''''
@@ -411,7 +439,7 @@ New features
    generating piecewise exp. data
 -  Faster ``print_summary`` for AFT models.
 
-.. _api-changes-9:
+.. _api-changes-10:
 
 API changes
 '''''''''''
@@ -419,7 +447,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
@@ -428,12 +456,12 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-13:
+.. _section-14:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-13:
+.. _new-features-14:
 
 New features
 ''''''''''''
@@ -446,12 +474,12 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-14:
+.. _section-15:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-14:
+.. _new-features-15:
 
 New features
 ''''''''''''
@@ -466,7 +494,7 @@ New features
 -  add a ``lifelines.plotting.qq_plot`` for univariate parametric models
    that handles censored data.
 
-.. _api-changes-10:
+.. _api-changes-11:
 
 API changes
 '''''''''''
@@ -475,7 +503,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
@@ -491,7 +519,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-15:
+.. _section-16:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -505,7 +533,7 @@ Bug fixes
    decades of development.
 -  suppressed unimportant warnings
 
-.. _api-changes-11:
+.. _api-changes-12:
 
 API changes
 '''''''''''
@@ -515,7 +543,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-16:
+.. _section-17:
 
 0.20.0 - 2019-03-05
 ~~~~~~~~~~~~~~~~~~~
@@ -524,7 +552,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-15:
+.. _new-features-16:
 
 New features
 ''''''''''''
@@ -532,7 +560,7 @@ New features
 -  smarter initialization for AFT models which should improve
    convergence.
 
-.. _api-changes-12:
+.. _api-changes-13:
 
 API changes
 '''''''''''
@@ -544,19 +572,19 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-17:
+.. _section-18:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-16:
+.. _new-features-17:
 
 New features
 ''''''''''''
@@ -566,24 +594,24 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-18:
+.. _section-19:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-19:
+.. _section-20:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-17:
+.. _new-features-18:
 
 New features
 ''''''''''''
@@ -595,12 +623,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-20:
+.. _section-21:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-18:
+.. _new-features-19:
 
 New features
 ''''''''''''
@@ -608,7 +636,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 '''''''''
@@ -618,12 +646,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-21:
+.. _section-22:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-19:
+.. _new-features-20:
 
 New features
 ''''''''''''
@@ -631,7 +659,7 @@ New features
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-13:
+.. _api-changes-14:
 
 API changes
 '''''''''''
@@ -640,12 +668,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-22:
+.. _section-23:
 
 0.19.0 - 2019-02-20
 ~~~~~~~~~~~~~~~~~~~
 
-.. _new-features-20:
+.. _new-features-21:
 
 New features
 ''''''''''''
@@ -658,7 +686,7 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-14:
+.. _api-changes-15:
 
 API changes
 '''''''''''
@@ -684,7 +712,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug Fixes
 '''''''''
@@ -701,7 +729,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-23:
+.. _section-24:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -711,7 +739,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-24:
+.. _section-25:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -732,7 +760,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-25:
+.. _section-26:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -742,7 +770,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-26:
+.. _section-27:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -752,7 +780,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-27:
+.. _section-28:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -768,7 +796,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-28:
+.. _section-29:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -779,7 +807,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-29:
+.. _section-30:
 
 0.18.0 - 2019-01-31
 ~~~~~~~~~~~~~~~~~~~
@@ -816,7 +844,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-30:
+.. _section-31:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -824,7 +852,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-31:
+.. _section-32:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -836,7 +864,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-32:
+.. _section-33:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -844,7 +872,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-33:
+.. _section-34:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -855,7 +883,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-34:
+.. _section-35:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -872,7 +900,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-35:
+.. _section-36:
 
 0.17.0 - 2019-01-11
 ~~~~~~~~~~~~~~~~~~~
@@ -893,7 +921,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-36:
+.. _section-37:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -901,7 +929,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-37:
+.. _section-38:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -912,14 +940,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-38:
+.. _section-39:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-39:
+.. _section-40:
 
 0.16.0 - 2019-01-01
 ~~~~~~~~~~~~~~~~~~~
@@ -955,7 +983,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-40:
+.. _section-41:
 
 0.15.4
 ^^^^^^
@@ -963,14 +991,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-41:
+.. _section-42:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-42:
+.. _section-43:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -981,7 +1009,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-43:
+.. _section-44:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -990,7 +1018,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-44:
+.. _section-45:
 
 0.15.0 - 2018-11-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1061,7 +1089,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-45:
+.. _section-46:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1069,7 +1097,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-46:
+.. _section-47:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1077,7 +1105,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-47:
+.. _section-48:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1094,7 +1122,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-48:
+.. _section-49:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1106,7 +1134,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-49:
+.. _section-50:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1114,7 +1142,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-50:
+.. _section-51:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1132,7 +1160,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-51:
+.. _section-52:
 
 0.14.0 - 2018-03-03
 ~~~~~~~~~~~~~~~~~~~
@@ -1154,7 +1182,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-52:
+.. _section-53:
 
 0.13.0 - 2017-12-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1183,7 +1211,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-53:
+.. _section-54:
 
 0.12.0
 ~~~~~~
@@ -1200,7 +1228,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-54:
+.. _section-55:
 
 0.11.3
 ^^^^^^
@@ -1212,7 +1240,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-55:
+.. _section-56:
 
 0.11.2
 ^^^^^^
@@ -1220,14 +1248,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-56:
+.. _section-57:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-57:
+.. _section-58:
 
 0.11.0 - 2017-06-21
 ~~~~~~~~~~~~~~~~~~~
@@ -1241,14 +1269,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-58:
+.. _section-59:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-59:
+.. _section-60:
 
 0.10.0
 ~~~~~~
@@ -1263,7 +1291,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-60:
+.. _section-61:
 
 0.9.4
 ^^^^^
@@ -1286,7 +1314,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-61:
+.. _section-62:
 
 0.9.2
 ^^^^^
@@ -1295,7 +1323,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-62:
+.. _section-63:
 
 0.9.1
 ^^^^^
@@ -1303,7 +1331,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-63:
+.. _section-64:
 
 0.9.0
 ~~~~~
@@ -1319,7 +1347,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-64:
+.. _section-65:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -1336,7 +1364,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-65:
+.. _section-66:
 
 0.8.0
 ~~~~~
@@ -1355,7 +1383,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-66:
+.. _section-67:
 
 0.7.1
 ^^^^^
@@ -1374,7 +1402,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-67:
+.. _section-68:
 
 0.7.0 - 2015-03-01
 ~~~~~~~~~~~~~~~~~~
@@ -1393,7 +1421,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-68:
+.. _section-69:
 
 0.6.1
 ^^^^^
@@ -1405,7 +1433,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-69:
+.. _section-70:
 
 0.6.0 - 2015-02-04
 ~~~~~~~~~~~~~~~~~~
@@ -1428,7 +1456,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-70:
+.. _section-71:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1449,7 +1477,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-71:
+.. _section-72:
 
 0.5.0 - 2014-12-07
 ~~~~~~~~~~~~~~~~~~
@@ -1462,7 +1490,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-72:
+.. _section-73:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1474,7 +1502,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-73:
+.. _section-74:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -1495,7 +1523,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-74:
+.. _section-75:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -1515,7 +1543,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-75:
+.. _section-76:
 
 0.4.1.1
 ^^^^^^^
@@ -1528,7 +1556,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-76:
+.. _section-77:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -1547,7 +1575,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-77:
+.. _section-78:
 
 0.4.0 - 2014-06-08
 ~~~~~~~~~~~~~~~~~~

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1867,7 +1867,7 @@ class ParametricRegressionFitter(BaseFitter):
             an iterable (array, list, series) of increasing times to predict the cumulative hazard at. Default
             is the set of all durations in the training dataset (observed and unobserved).
         conditional_after: iterable, optional
-            Must be equal is size to df.shape[0] (denoted `n` above).  An iterable (array, list, series) of possibly non-zero values that represent how long the
+            Must be equal is size to (df.shape[0],) (`n` above).  An iterable (array, list, series) of possibly non-zero values that represent how long the
             subject has already lived for. Ex: if :math:`T` is the unknown event time, then this represents
             :math`T | T > s`. This is useful for knowing the *remaining* hazard/survival of censored subjects.
             The new timeline is the remaining duration of the subject, i.e. normalized back to starting at 0.
@@ -1897,8 +1897,8 @@ class ParametricRegressionFitter(BaseFitter):
                 self._cumulative_hazard(params_dict, np.tile(times, (n, 1)).T, Xs), index=times, columns=df.index
             )
         else:
-            conditional_after = np.asarray(conditional_after)
-            times_to_evaluate_at = (conditional_after[:, None] + np.tile(times, (n, 1))).T
+            conditional_after = np.asarray(conditional_after).reshape((n, 1))
+            times_to_evaluate_at = (conditional_after + np.tile(times, (n, 1))).T
             return pd.DataFrame(
                 np.clip(
                     self._cumulative_hazard(params_dict, times_to_evaluate_at, Xs)

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -178,7 +178,7 @@ class UnivariateFitter(BaseFitter):
         """
         if callable(self._estimation_method):
             return (
-                pd.DataFrame(self._estimation_method(utils._to_array(times)), index=utils._to_array(times))
+                pd.DataFrame(self._estimation_method(utils._to_1d_array(times)), index=utils._to_1d_array(times))
                 .loc[times]
                 .squeeze()
             )
@@ -186,7 +186,7 @@ class UnivariateFitter(BaseFitter):
         estimate = getattr(self, self._estimation_method)
         if not interpolate:
             return estimate.asof(times).squeeze()
-        return utils.dataframe_interpolate_at_times(estimate, times)
+        return utils.interpolate_at_times_and_return_pandas(estimate, times)
 
     @property
     def conditional_time_to_event_(self):
@@ -1019,7 +1019,7 @@ class ParametericUnivariateFitter(UnivariateFitter):
         """
         label = utils.coalesce(label, self._label)
         return pd.Series(
-            self._survival_function(self._fitted_parameters_, times), index=utils._to_array(times), name=label
+            self._survival_function(self._fitted_parameters_, times), index=utils._to_1d_array(times), name=label
         )
 
     def cumulative_density_at_times(self, times, label=None):
@@ -1040,7 +1040,7 @@ class ParametericUnivariateFitter(UnivariateFitter):
         """
         label = utils.coalesce(label, self._label)
         return pd.Series(
-            self._cumulative_density(self._fitted_parameters_, times), index=utils._to_array(times), name=label
+            self._cumulative_density(self._fitted_parameters_, times), index=utils._to_1d_array(times), name=label
         )
 
     def cumulative_hazard_at_times(self, times, label=None):
@@ -1061,7 +1061,7 @@ class ParametericUnivariateFitter(UnivariateFitter):
         """
         label = utils.coalesce(label, self._label)
         return pd.Series(
-            self._cumulative_hazard(self._fitted_parameters_, times), index=utils._to_array(times), name=label
+            self._cumulative_hazard(self._fitted_parameters_, times), index=utils._to_1d_array(times), name=label
         )
 
     def hazard_at_times(self, times, label=None):
@@ -1081,7 +1081,7 @@ class ParametericUnivariateFitter(UnivariateFitter):
 
         """
         label = utils.coalesce(label, self._label)
-        return pd.Series(self._hazard(self._fitted_parameters_, times), index=utils._to_array(times), name=label)
+        return pd.Series(self._hazard(self._fitted_parameters_, times), index=utils._to_1d_array(times), name=label)
 
     @property
     def confidence_interval_(self):
@@ -2090,7 +2090,7 @@ class ParametricRegressionFitter(BaseFitter):
         from matplotlib import pyplot as plt
 
         covariates = utils._to_list(covariates)
-        values = utils._to_array(values)
+        values = utils._to_1d_array(values)
         if len(values.shape) == 1:
             values = values[None, :].T
 
@@ -2768,7 +2768,7 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         from matplotlib import pyplot as plt
 
         covariates = utils._to_list(covariates)
-        values = utils._to_array(values)
+        values = utils._to_1d_array(values)
         if len(values.shape) == 1:
             values = values[None, :].T
 

--- a/lifelines/fitters/breslow_fleming_harrington_fitter.py
+++ b/lifelines/fitters/breslow_fleming_harrington_fitter.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from lifelines.fitters import UnivariateFitter
 from lifelines import NelsonAalenFitter
-from lifelines.utils import _to_array, coalesce, CensoringType
+from lifelines.utils import _to_1d_array, coalesce, CensoringType
 
 
 class BreslowFlemingHarringtonFitter(UnivariateFitter):
@@ -110,4 +110,4 @@ class BreslowFlemingHarringtonFitter(UnivariateFitter):
 
         """
         label = coalesce(label, self._label)
-        return pd.Series(self.predict(times), index=_to_array(times), name=label)
+        return pd.Series(self.predict(times), index=_to_1d_array(times), name=label)

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -43,7 +43,7 @@ from lifelines.utils import (
 
 __all__ = ["CoxTimeVaryingFitter"]
 
-matrix_axis_0_sum_to_array = lambda m: np.sum(m, 0)
+matrix_axis_0_sum_to_1d_array = lambda m: np.sum(m, 0)
 
 
 class CoxTimeVaryingFitter(BaseFitter):
@@ -513,7 +513,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
             # Calculate sums of Risk set
             risk_phi = array_sum_to_scalar(phi_i)
-            risk_phi_x = matrix_axis_0_sum_to_array(phi_x_i)
+            risk_phi_x = matrix_axis_0_sum_to_1d_array(phi_x_i)
             risk_phi_x_x = phi_x_x_i
 
             # Calculate the sums of Tie set
@@ -523,7 +523,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
             xi_deaths = X_at_t[deaths]
 
-            x_death_sum = matrix_axis_0_sum_to_array(weights_at_t[deaths, None] * xi_deaths)
+            x_death_sum = matrix_axis_0_sum_to_1d_array(weights_at_t[deaths, None] * xi_deaths)
 
             weight_count = array_sum_to_scalar(weights_at_t[deaths])
             weighted_average = weight_count / tied_death_counts
@@ -543,7 +543,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
                 # https://github.com/CamDavidsonPilon/lifelines/blob/e7056e7817272eb5dff5983556954f56c33301b1/lifelines/fitters/cox_time_varying_fitter.py#L458-L490
 
                 tie_phi = array_sum_to_scalar(phi_i[deaths])
-                tie_phi_x = matrix_axis_0_sum_to_array(phi_x_i[deaths])
+                tie_phi_x = matrix_axis_0_sum_to_1d_array(phi_x_i[deaths])
                 tie_phi_x_x = np.dot(xi_deaths.T, phi_i[deaths, None] * xi_deaths)
 
                 increasing_proportion = np.arange(tied_death_counts) / tied_death_counts

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -935,7 +935,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         partial_hazard = self.predict_partial_hazard(X)[0].values
 
         if not self.strata:
-            baseline_at_T = self.baseline_cumulative_hazard_.loc[T, "baseline hazard"].values
+            baseline_at_T = self.baseline_cumulative_hazard_.loc[T, "baseline cumulative hazard"].values
         else:
             baseline_at_T = np.empty(0)
             for name, T_ in T.groupby(by=self.strata):
@@ -1490,16 +1490,16 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
                 col = _get_index(stratified_X)
                 v = self.predict_partial_hazard(stratified_X)
                 times_ = coalesce(times, self.baseline_cumulative_hazard_.index)
-
+                n_ = stratified_X.shape[0]
                 if conditional_after is not None:
-                    times_to_evaluate_at = np.tile(times_, (n, 1)) + conditional_after
+                    times_to_evaluate_at = np.tile(times_, (n_, 1)) + conditional_after
 
                     c_0_ = interpolate_at_times(strata_c_0, times_to_evaluate_at)
                     c_0_conditional_after = interpolate_at_times(strata_c_0, conditional_after)
                     c_0_ = np.clip((c_0_ - c_0_conditional_after).T, 0, np.inf)
 
                 else:
-                    times_to_evaluate_at = np.tile(times_, (n, 1))
+                    times_to_evaluate_at = np.tile(times_, (n_, 1))
                     c_0_ = interpolate_at_times(strata_c_0, times_to_evaluate_at).T
 
                 cumulative_hazard_ = cumulative_hazard_.merge(
@@ -1686,8 +1686,8 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
     def _compute_baseline_cumulative_hazard(self):
         cumulative = self.baseline_hazard_.cumsum()
-        if self.strata is None:
-            cumulative = cumulative.rename({"baseline hazard": "baseline cumulative hazard"})
+        if not self.strata:
+            cumulative = cumulative.rename(columns={"baseline hazard": "baseline cumulative hazard"})
         return cumulative
 
     def _compute_baseline_survival(self):
@@ -1709,8 +1709,8 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         >>> kmf.plot(ax=ax)
         """
         survival_df = np.exp(-self.baseline_cumulative_hazard_)
-        if self.strata is None:
-            survival_df = survival_df.rename({"baseline cumulative hazard": "baseline survival"})
+        if not self.strata:
+            survival_df = survival_df.rename(columns={"baseline cumulative hazard": "baseline survival"})
         return survival_df
 
     def plot(self, columns=None, hazard_ratios=False, **errorbar_kwargs):

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1848,7 +1848,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
 
         covariates = _to_list(covariates)
         n_covariates = len(covariates)
-        values = _to_1d_array(values)
+        values = np.asarray(values)
         if len(values.shape) == 1:
             values = values[None, :].T
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -20,7 +20,7 @@ from lifelines.utils import (
     _get_index,
     _to_list,
     _to_tuple,
-    _to_array,
+    _to_1d_array,
     inv_normal_cdf,
     normalize,
     qth_survival_times,
@@ -38,8 +38,9 @@ from lifelines.utils import (
     format_p_value,
     format_floats,
     format_exp_floats,
-    dataframe_interpolate_at_times,
+    interpolate_at_times_and_return_pandas,
     CensoringType,
+    interpolate_at_times,
 )
 
 __all__ = ["CoxPHFitter"]
@@ -1456,62 +1457,76 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             Must be equal is size to X.shape[0] (denoted `n` above).  An iterable (array, list, series) of possibly non-zero values that represent how long the
             subject has already lived for. Ex: if :math:`T` is the unknown event time, then this represents
             :math`T | T > s`. This is useful for knowing the *remaining* hazard/survival of censored subjects.
-            The new timeline is the remaining duration of the subject, i.e. normalized back to starting at 0.
+            The new timeline is the remaining duration of the subject, i.e. reset back to starting at 0.
 
         Returns
         -------
         cumulative_hazard_ : DataFrame
             the cumulative hazard of individuals over the timeline
         """
-        if conditional_after is not None and self.strata is not None:
-            raise NotImplementedError(
-                "Sorry, conditional_after for Cox with strata is tricky to do. It's not implemented yet."
-            )
+        if isinstance(X, pd.Series):
+            return self.predict_cumulative_hazard(X.to_frame().T, times=times, conditional_after=conditional_after)
+
+        n = X.shape[0]
+
+        if times is not None:
+            times = np.atleast_1d(times).astype(float)
+        if conditional_after is not None:
+            conditional_after = _to_1d_array(conditional_after).reshape(n, 1)
 
         if self.strata:
             cumulative_hazard_ = pd.DataFrame()
             for stratum, stratified_X in X.groupby(self.strata):
                 try:
-                    c_0 = self.baseline_cumulative_hazard_[[stratum]]
+                    strata_c_0 = self.baseline_cumulative_hazard_[[stratum]]
                 except KeyError:
                     raise StatError(
-                        """The stratum %s was not found in the original training data. For example, try
-the following on the original dataset, df: `df.groupby(%s).size()`. Expected is that %s is not present in the output.
-"""
-                        % (stratum, self.strata, stratum)
+                        dedent(
+                            """The stratum %s was not found in the original training data. For example, try
+                            the following on the original dataset, df: `df.groupby(%s).size()`. Expected is that %s is not present in the output."""
+                            % (stratum, self.strata, stratum)
+                        )
                     )
                 col = _get_index(stratified_X)
                 v = self.predict_partial_hazard(stratified_X)
+                times_ = coalesce(times, self.baseline_cumulative_hazard_.index)
+
+                if conditional_after is not None:
+                    times_to_evaluate_at = np.tile(times_, (n, 1)) + conditional_after
+
+                    c_0_ = interpolate_at_times(strata_c_0, times_to_evaluate_at)
+                    c_0_conditional_after = interpolate_at_times(strata_c_0, conditional_after)
+                    c_0_ = np.clip((c_0_ - c_0_conditional_after).T, 0, np.inf)
+
+                else:
+                    times_to_evaluate_at = np.tile(times_, (n, 1))
+                    c_0_ = interpolate_at_times(strata_c_0, times_to_evaluate_at).T
+
                 cumulative_hazard_ = cumulative_hazard_.merge(
-                    pd.DataFrame(np.dot(c_0, v.T), index=c_0.index, columns=col),
+                    pd.DataFrame(c_0_ * v.values[:, 0], columns=col, index=times_),
                     how="outer",
                     right_index=True,
                     left_index=True,
                 )
         else:
 
-            c_0 = self.baseline_cumulative_hazard_["baseline hazard"].values
             v = self.predict_partial_hazard(X)
             col = _get_index(v)
+            times_ = coalesce(times, self.baseline_cumulative_hazard_.index)
 
             if conditional_after is not None:
-                c_0_conditional_after = dataframe_interpolate_at_times(
-                    self.baseline_cumulative_hazard_, conditional_after
-                )[:, None]
+                times_to_evaluate_at = np.tile(times_, (n, 1)) + conditional_after
+
+                c_0 = interpolate_at_times(self.baseline_cumulative_hazard_, times_to_evaluate_at)
+                c_0_conditional_after = interpolate_at_times(self.baseline_cumulative_hazard_, conditional_after)
                 c_0 = np.clip((c_0 - c_0_conditional_after).T, 0, np.inf)
 
-            cumulative_hazard_ = pd.DataFrame(
-                c_0 * v.values[:, 0], columns=col, index=self.baseline_cumulative_hazard_.index
-            )
+            else:
+                times_to_evaluate_at = np.tile(times_, (n, 1))
+                c_0 = interpolate_at_times(self.baseline_cumulative_hazard_, times_to_evaluate_at).T
 
-            if conditional_after is not None:
-                ix = (cumulative_hazard_ > 0).idxmax(0)
-                cumulative_hazard_ = cumulative_hazard_.apply(lambda s: s.shift(-int(ix.loc[s.name]))).ffill()
+            cumulative_hazard_ = pd.DataFrame(c_0 * v.values[:, 0], columns=col, index=times_)
 
-        if times is not None:
-            # non-linear interpolations can push the survival curves above 1 and below 0.
-            times = np.atleast_1d(times).astype(float)
-            return dataframe_interpolate_at_times(cumulative_hazard_, times)
         return cumulative_hazard_
 
     def predict_survival_function(self, X, times=None, conditional_after=None):
@@ -1833,7 +1848,7 @@ the following on the original dataset, df: `df.groupby(%s).size()`. Expected is 
 
         covariates = _to_list(covariates)
         n_covariates = len(covariates)
-        values = _to_array(values)
+        values = _to_1d_array(values)
         if len(values.shape) == 1:
             values = values[None, :].T
 

--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -8,7 +8,7 @@ from lifelines.fitters import UnivariateFitter
 from lifelines.utils import (
     _preprocess_inputs,
     _additive_estimate,
-    _to_array,
+    _to_1d_array,
     StatError,
     inv_normal_cdf,
     median_survival_times,
@@ -307,7 +307,7 @@ class KaplanMeierFitter(UnivariateFitter):
 
         """
         label = coalesce(label, self._label)
-        return pd.Series(self.predict(times), index=_to_array(times), name=label)
+        return pd.Series(self.predict(times), index=_to_1d_array(times), name=label)
 
     def cumulative_density_at_times(self, times, label=None):
         """
@@ -323,7 +323,7 @@ class KaplanMeierFitter(UnivariateFitter):
 
         """
         label = coalesce(label, self._label)
-        return pd.Series(1 - self.predict(times), index=_to_array(times), name=label)
+        return pd.Series(1 - self.predict(times), index=_to_1d_array(times), name=label)
 
     def plot_survival_function(self, **kwargs):
         """Alias of ``plot``"""

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -7,13 +7,13 @@ from scipy import stats
 import pandas as pd
 
 from lifelines.utils import (
-    _to_array,
+    _to_1d_array,
     _to_list,
     group_survival_table_from_events,
     string_justify,
     format_p_value,
     format_floats,
-    dataframe_interpolate_at_times,
+    interpolate_at_times_and_return_pandas,
 )
 
 from lifelines import KaplanMeierFitter
@@ -229,8 +229,8 @@ def survival_difference_at_fixed_point_in_time_test(
     sB_t = kmfB.predict(point_in_time)
 
     # this is doing a prediction/interpolation between the kmf's index.
-    sigma_sqA = dataframe_interpolate_at_times(kmfA._cumulative_sq_, point_in_time)
-    sigma_sqB = dataframe_interpolate_at_times(kmfB._cumulative_sq_, point_in_time)
+    sigma_sqA = interpolate_at_times_and_return_pandas(kmfA._cumulative_sq_, point_in_time)
+    sigma_sqB = interpolate_at_times_and_return_pandas(kmfB._cumulative_sq_, point_in_time)
 
     log = np.log
     clog = lambda s: log(-log(s))
@@ -546,8 +546,8 @@ class StatisticalResult(object):
         self.p_value = p_value
         self.test_statistic = test_statistic
 
-        self._p_value = _to_array(p_value)
-        self._test_statistic = _to_array(test_statistic)
+        self._p_value = _to_1d_array(p_value)
+        self._test_statistic = _to_1d_array(test_statistic)
 
         assert len(self._p_value) == len(self._test_statistic)
 
@@ -726,7 +726,7 @@ def proportional_hazard_test(
         for transform_name, transform in ((_, TimeTransformers().get(_)) for _ in time_transform):
             times = transform(durations, events, weights)[events.values]
             T = compute_statistic(times, scaled_resids)
-            p_values = _to_array([chisq_test(t, 1) for t in T])
+            p_values = _to_1d_array([chisq_test(t, 1) for t in T])
             result += StatisticalResult(
                 p_values,
                 T,
@@ -747,7 +747,7 @@ def proportional_hazard_test(
 
         T = compute_statistic(times, scaled_resids)
 
-        p_values = _to_array([chisq_test(t, 1) for t in T])
+        p_values = _to_1d_array([chisq_test(t, 1) for t in T])
         result = StatisticalResult(
             p_values,
             T,

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1562,7 +1562,7 @@ def interpolate_at_times_and_return_pandas(df_or_series, new_times):
     """
     new_times = _to_1d_array(new_times)
     return pd.DataFrame(
-        interpolate_at_times(df_or_series, new_times), index=new_times, cols=df_or_series.columns
+        interpolate_at_times(df_or_series, new_times), index=new_times, columns=df_or_series.columns
     ).squeeze()
 
 

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1535,7 +1535,12 @@ def format_floats(decimals):
 
 
 def dataframe_interpolate_at_times(df, times):
-    return df.reindex(df.index.union(_to_array(times))).interpolate(method="index").loc[times].squeeze()
+    return (
+        df.reindex(df.index.union(_to_array(times)))
+        .interpolate(method="index", limit_direction="both")
+        .loc[times]
+        .squeeze()
+    )
 
 
 string_justify = lambda width: lambda s: s.rjust(width, " ")

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.22.5"
+__version__ = "0.22.6"

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -3570,10 +3570,18 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
         rossi = rossi[["week", "arrest", "fin", "age"]]
         cp = CoxPHFitter()
         cp.fit(rossi, "week", "arrest", weights_col="age")
-        npt.assert_almost_equal(cp.baseline_cumulative_hazard_["baseline hazard"].loc[1.0], 0.00183466, decimal=4)
-        npt.assert_almost_equal(cp.baseline_cumulative_hazard_["baseline hazard"].loc[2.0], 0.005880265, decimal=4)
-        npt.assert_almost_equal(cp.baseline_cumulative_hazard_["baseline hazard"].loc[10.0], 0.035425868, decimal=4)
-        npt.assert_almost_equal(cp.baseline_cumulative_hazard_["baseline hazard"].loc[52.0], 0.274341397, decimal=3)
+        npt.assert_almost_equal(
+            cp.baseline_cumulative_hazard_["baseline cumulative hazard"].loc[1.0], 0.00183466, decimal=4
+        )
+        npt.assert_almost_equal(
+            cp.baseline_cumulative_hazard_["baseline cumulative hazard"].loc[2.0], 0.005880265, decimal=4
+        )
+        npt.assert_almost_equal(
+            cp.baseline_cumulative_hazard_["baseline cumulative hazard"].loc[10.0], 0.035425868, decimal=4
+        )
+        npt.assert_almost_equal(
+            cp.baseline_cumulative_hazard_["baseline cumulative hazard"].loc[52.0], 0.274341397, decimal=3
+        )
 
     def test_strata_from_init_is_used_in_fit_later(self, rossi):
         strata = ["race", "paro", "mar"]


### PR DESCRIPTION
#### 0.22.6

##### New features
 - `conditional_after` works for `CoxPHFitter` prediction models 😅

##### Bug fixes

##### API Changes
 - `CoxPHFitter.baseline_cumulative_hazard_`'s column is renamed `"baseline cumulative hazard"` - previously it was `"baseline hazard"`. (Only applies if the model has no strata.)
 - `utils.dataframe_interpolate_at_times` renamed to `utils.interpolate_at_times_and_return_pandas`.

