### PR TITLE
v0.22.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
  - fixed bug in `survival_difference_at_fixed_point_in_time_test`
 
 ##### API Changes
- -`utils.qth_survival_time` no longer takes a `cdf` argument - users should take the compliment (1-cdf).
+
+ - `utils.qth_survival_time` no longer takes a `cdf` argument - users should take the compliment (1-cdf).
  - Some previous `StatisticalWarnings` have been replaced by `ApproximationWarning`
 
 #### 0.22.6 - 2019-09-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ##### Bug fixes
  - fixed a bug in parametric prediction for interval censored data.
  - realigned values in `print_summary`.
+ - fixed bug in `survival_difference_at_fixed_point_in_time_test`
 
 ##### API Changes
  -`utils.qth_survival_time` no longer takes a `cdf` argument - users should take the compliment (1-cdf).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 ## Changelog
 
-#### 0.22.6
+#### 0.22.7
+
+##### New features
+ - new `ApproximationWarning` to tell you if the package is making an potentially mislead approximation.
+
+##### Bug fixes
+ - fixed a bug in parametric prediction for interval censored data.
+ - realigned values in `print_summary`.
+
+##### API Changes
+ -`utils.qth_survival_time` no longer takes a `cdf` argument - users should take the compliment (1-cdf).
+ - Some previous `StatisticalWarnings` have been replaced by `ApproximationWarning`
+
+#### 0.22.6 - 2019-09-25
 
 ##### New features
  - `conditional_after` works for `CoxPHFitter` prediction models 😅

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,16 +1,48 @@
 Changelog
 ---------
 
-0.22.6
+0.22.7
 ^^^^^^
+
+New features
+''''''''''''
+
+-  new ``ApproximationWarning`` to tell you if the package is making an
+   potentially mislead approximation.
+
+Bug fixes
+'''''''''
+
+-  fixed a bug in parametric prediction for interval censored data.
+-  realigned values in ``print_summary``.
+-  fixed bug in ``survival_difference_at_fixed_point_in_time_test``
+
+API Changes
+'''''''''''
+
+-  ``utils.qth_survival_time`` no longer takes a ``cdf`` argument -
+   users should take the compliment (1-cdf).
+-  Some previous ``StatisticalWarnings`` have been replaced by
+   ``ApproximationWarning``
+
+.. _section-1:
+
+0.22.6 - 2019-09-25
+^^^^^^^^^^^^^^^^^^^
+
+.. _new-features-1:
 
 New features
 ''''''''''''
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
+.. _bug-fixes-1:
+
 Bug fixes
 '''''''''
+
+.. _api-changes-1:
 
 API Changes
 '''''''''''
@@ -21,12 +53,12 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-1:
+.. _section-2:
 
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ''''''''''''
@@ -35,7 +67,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -44,7 +76,7 @@ Bug fixes
 -  Fixed an issue with ``AalenJohansenFitter`` failing to plot
    confidence intervals.
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API Changes
 '''''''''''
@@ -52,12 +84,12 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-2:
+.. _section-3:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ''''''''''''
@@ -68,7 +100,7 @@ New features
 -  new ``utils.restricted_mean_survival_time`` that approximates the
    RMST using numerical integration against survival functions.
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API changes
 '''''''''''
@@ -76,7 +108,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
@@ -84,12 +116,12 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-3:
+.. _section-4:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ''''''''''''
@@ -102,7 +134,7 @@ New features
 -  smarter initial conditions for parametric regression models.
 -  New regression model: ``GeneralizedGammaRegressionFitter``
 
-.. _api-changes-3:
+.. _api-changes-4:
 
 API changes
 '''''''''''
@@ -113,7 +145,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -125,19 +157,19 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-4:
+.. _section-5:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ''''''''''''
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -148,12 +180,12 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-5:
+.. _section-6:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ''''''''''''
@@ -168,7 +200,7 @@ New features
    right censoring)
 -  improvements to ``lifelines.utils.gamma``
 
-.. _api-changes-4:
+.. _api-changes-5:
 
 API changes
 '''''''''''
@@ -181,7 +213,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
@@ -191,12 +223,12 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-6:
+.. _section-7:
 
 0.22.0 - 2019-07-03
 ~~~~~~~~~~~~~~~~~~~
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ''''''''''''
@@ -208,7 +240,7 @@ New features
 -  for parametric univariate models, the ``conditional_time_to_event_``
    is now exact instead of an approximation.
 
-.. _api-changes-5:
+.. _api-changes-6:
 
 API changes
 '''''''''''
@@ -230,7 +262,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -239,21 +271,21 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-7:
+.. _section-8:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 I’m skipping 0.21.4 version because of deployment issues.
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ''''''''''''
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
@@ -263,12 +295,12 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-8:
+.. _section-9:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-8:
+.. _new-features-9:
 
 New features
 ''''''''''''
@@ -282,19 +314,19 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-9:
+.. _section-10:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-9:
+.. _new-features-10:
 
 New features
 ''''''''''''
@@ -306,7 +338,7 @@ New features
    that computes, you guessed it, the log-likelihood ratio test.
    Previously this was an internal API that is being exposed.
 
-.. _api-changes-6:
+.. _api-changes-7:
 
 API changes
 '''''''''''
@@ -318,17 +350,17 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
 
-.. _section-10:
+.. _section-11:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-10:
+.. _new-features-11:
 
 New features
 ''''''''''''
@@ -337,7 +369,7 @@ New features
    ``add_covariate_to_timeline``
 -  PiecewiseExponentialFitter now allows numpy arrays as breakpoints
 
-.. _api-changes-7:
+.. _api-changes-8:
 
 API changes
 '''''''''''
@@ -345,19 +377,19 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-11:
+.. _section-12:
 
 0.21.0 - 2019-04-12
 ~~~~~~~~~~~~~~~~~~~
 
-.. _new-features-11:
+.. _new-features-12:
 
 New features
 ''''''''''''
@@ -371,7 +403,7 @@ New features
 -  a new interval censored dataset is available under
    ``lifelines.datasets.load_diabetes``
 
-.. _api-changes-8:
+.. _api-changes-9:
 
 API changes
 '''''''''''
@@ -382,7 +414,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
@@ -392,19 +424,19 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-12:
+.. _section-13:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-12:
+.. _new-features-13:
 
 New features
 ''''''''''''
 
 -  performance improvements for ``print_summary``.
 
-.. _api-changes-9:
+.. _api-changes-10:
 
 API changes
 '''''''''''
@@ -414,7 +446,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
@@ -423,12 +455,12 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-13:
+.. _section-14:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-13:
+.. _new-features-14:
 
 New features
 ''''''''''''
@@ -439,7 +471,7 @@ New features
    generating piecewise exp. data
 -  Faster ``print_summary`` for AFT models.
 
-.. _api-changes-10:
+.. _api-changes-11:
 
 API changes
 '''''''''''
@@ -447,7 +479,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
@@ -456,12 +488,12 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-14:
+.. _section-15:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-14:
+.. _new-features-15:
 
 New features
 ''''''''''''
@@ -474,12 +506,12 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-15:
+.. _section-16:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-15:
+.. _new-features-16:
 
 New features
 ''''''''''''
@@ -494,7 +526,7 @@ New features
 -  add a ``lifelines.plotting.qq_plot`` for univariate parametric models
    that handles censored data.
 
-.. _api-changes-11:
+.. _api-changes-12:
 
 API changes
 '''''''''''
@@ -503,7 +535,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 '''''''''
@@ -519,7 +551,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-16:
+.. _section-17:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -533,7 +565,7 @@ Bug fixes
    decades of development.
 -  suppressed unimportant warnings
 
-.. _api-changes-12:
+.. _api-changes-13:
 
 API changes
 '''''''''''
@@ -543,7 +575,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-17:
+.. _section-18:
 
 0.20.0 - 2019-03-05
 ~~~~~~~~~~~~~~~~~~~
@@ -552,7 +584,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-16:
+.. _new-features-17:
 
 New features
 ''''''''''''
@@ -560,7 +592,7 @@ New features
 -  smarter initialization for AFT models which should improve
    convergence.
 
-.. _api-changes-13:
+.. _api-changes-14:
 
 API changes
 '''''''''''
@@ -572,19 +604,19 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-18:
+.. _section-19:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-17:
+.. _new-features-18:
 
 New features
 ''''''''''''
@@ -594,24 +626,24 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-19:
+.. _section-20:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-20:
+.. _section-21:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-18:
+.. _new-features-19:
 
 New features
 ''''''''''''
@@ -623,12 +655,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-21:
+.. _section-22:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-19:
+.. _new-features-20:
 
 New features
 ''''''''''''
@@ -636,7 +668,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 '''''''''
@@ -646,12 +678,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-22:
+.. _section-23:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-20:
+.. _new-features-21:
 
 New features
 ''''''''''''
@@ -659,7 +691,7 @@ New features
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-14:
+.. _api-changes-15:
 
 API changes
 '''''''''''
@@ -668,12 +700,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-23:
+.. _section-24:
 
 0.19.0 - 2019-02-20
 ~~~~~~~~~~~~~~~~~~~
 
-.. _new-features-21:
+.. _new-features-22:
 
 New features
 ''''''''''''
@@ -686,7 +718,7 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-15:
+.. _api-changes-16:
 
 API changes
 '''''''''''
@@ -712,7 +744,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug Fixes
 '''''''''
@@ -729,7 +761,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-24:
+.. _section-25:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -739,7 +771,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-25:
+.. _section-26:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -760,7 +792,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-26:
+.. _section-27:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -770,7 +802,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-27:
+.. _section-28:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -780,7 +812,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-28:
+.. _section-29:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -796,7 +828,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-29:
+.. _section-30:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -807,7 +839,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-30:
+.. _section-31:
 
 0.18.0 - 2019-01-31
 ~~~~~~~~~~~~~~~~~~~
@@ -844,7 +876,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-31:
+.. _section-32:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -852,7 +884,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-32:
+.. _section-33:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -864,7 +896,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-33:
+.. _section-34:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -872,7 +904,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-34:
+.. _section-35:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -883,7 +915,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-35:
+.. _section-36:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -900,7 +932,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-36:
+.. _section-37:
 
 0.17.0 - 2019-01-11
 ~~~~~~~~~~~~~~~~~~~
@@ -921,7 +953,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-37:
+.. _section-38:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -929,7 +961,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-38:
+.. _section-39:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -940,14 +972,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-39:
+.. _section-40:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-40:
+.. _section-41:
 
 0.16.0 - 2019-01-01
 ~~~~~~~~~~~~~~~~~~~
@@ -983,7 +1015,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-41:
+.. _section-42:
 
 0.15.4
 ^^^^^^
@@ -991,14 +1023,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-42:
+.. _section-43:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-43:
+.. _section-44:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1009,7 +1041,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-44:
+.. _section-45:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1018,7 +1050,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-45:
+.. _section-46:
 
 0.15.0 - 2018-11-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1089,7 +1121,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-46:
+.. _section-47:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1097,7 +1129,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-47:
+.. _section-48:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1105,7 +1137,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-48:
+.. _section-49:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1122,7 +1154,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-49:
+.. _section-50:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1134,7 +1166,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-50:
+.. _section-51:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1142,7 +1174,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-51:
+.. _section-52:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1160,7 +1192,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-52:
+.. _section-53:
 
 0.14.0 - 2018-03-03
 ~~~~~~~~~~~~~~~~~~~
@@ -1182,7 +1214,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-53:
+.. _section-54:
 
 0.13.0 - 2017-12-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1211,7 +1243,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-54:
+.. _section-55:
 
 0.12.0
 ~~~~~~
@@ -1228,7 +1260,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-55:
+.. _section-56:
 
 0.11.3
 ^^^^^^
@@ -1240,7 +1272,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-56:
+.. _section-57:
 
 0.11.2
 ^^^^^^
@@ -1248,14 +1280,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-57:
+.. _section-58:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-58:
+.. _section-59:
 
 0.11.0 - 2017-06-21
 ~~~~~~~~~~~~~~~~~~~
@@ -1269,14 +1301,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-59:
+.. _section-60:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-60:
+.. _section-61:
 
 0.10.0
 ~~~~~~
@@ -1291,7 +1323,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-61:
+.. _section-62:
 
 0.9.4
 ^^^^^
@@ -1314,7 +1346,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-62:
+.. _section-63:
 
 0.9.2
 ^^^^^
@@ -1323,7 +1355,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-63:
+.. _section-64:
 
 0.9.1
 ^^^^^
@@ -1331,7 +1363,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-64:
+.. _section-65:
 
 0.9.0
 ~~~~~
@@ -1347,7 +1379,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-65:
+.. _section-66:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -1364,7 +1396,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-66:
+.. _section-67:
 
 0.8.0
 ~~~~~
@@ -1383,7 +1415,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-67:
+.. _section-68:
 
 0.7.1
 ^^^^^
@@ -1402,7 +1434,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-68:
+.. _section-69:
 
 0.7.0 - 2015-03-01
 ~~~~~~~~~~~~~~~~~~
@@ -1421,7 +1453,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-69:
+.. _section-70:
 
 0.6.1
 ^^^^^
@@ -1433,7 +1465,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-70:
+.. _section-71:
 
 0.6.0 - 2015-02-04
 ~~~~~~~~~~~~~~~~~~
@@ -1456,7 +1488,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-71:
+.. _section-72:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1477,7 +1509,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-72:
+.. _section-73:
 
 0.5.0 - 2014-12-07
 ~~~~~~~~~~~~~~~~~~
@@ -1490,7 +1522,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-73:
+.. _section-74:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1502,7 +1534,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-74:
+.. _section-75:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -1523,7 +1555,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-75:
+.. _section-76:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -1543,7 +1575,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-76:
+.. _section-77:
 
 0.4.1.1
 ^^^^^^^
@@ -1556,7 +1588,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-77:
+.. _section-78:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -1575,7 +1607,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-78:
+.. _section-79:
 
 0.4.0 - 2014-06-08
 ~~~~~~~~~~~~~~~~~~

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -282,8 +282,8 @@ class UnivariateFitter(BaseFitter):
         For known parametric models, this should be overwritten by something more accurate.
         """
         warnings.warn(
-            "Approximating using `survival_function_`. Try using or increasing the resolution of the timeline kwarg in `.fit(..., timeline=timeline)`.",
-            utils.StatisticalWarning,
+            "Approximating using `survival_function_`. To increase accuracy, try using or increasing the resolution of the timeline kwarg in `.fit(..., timeline=timeline)`.",
+            utils.ApproximationWarning,
         )
         return utils.qth_survival_times(p, self.survival_function_)
 
@@ -948,7 +948,7 @@ class ParametericUnivariateFitter(UnivariateFitter):
                 """
                 % self._class_name
             )
-            warnings.warn(warning_text, utils.StatisticalWarning)
+            warnings.warn(warning_text, utils.ApproximationWarning)
         finally:
             if (self.variance_matrix_.diagonal() < 0).any():
                 warning_text = dedent(
@@ -1571,7 +1571,7 @@ class ParametricRegressionFitter(BaseFitter):
                 """
                 % self._class_name
             )
-            warnings.warn(warning_text, utils.StatisticalWarning)
+            warnings.warn(warning_text, utils.ApproximationWarning)
         finally:
             if (unit_scaled_variance_matrix_.diagonal() < 0).any():
                 warning_text = dedent(
@@ -1937,6 +1937,7 @@ class ParametricRegressionFitter(BaseFitter):
         predict_median
         predict_percentile
         """
+        warnings.warn("""Approximating the expected value using trapezoid rule.""", utils.ApproximationWarning)
         subjects = utils._get_index(X)
         v = self.predict_survival_function(X)[subjects]
         return pd.DataFrame(trapz(v.values.T, v.index), index=subjects)

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -934,13 +934,13 @@ class ParametericUnivariateFitter(UnivariateFitter):
             warning_text = dedent(
                 """\
 
-                The Hessian for %s's fit was not invertible. This could be a modeling problem:
+                The Hessian for %s's fit was not invertible. We will instead approximate it using the pseudo-inverse.
+                This could be a modeling problem:
 
                 1. Are two parameters in the model collinear / exchangeable?
                 2. Is the cumulative hazard always non-negative and always non-decreasing?
                 3. Are there cusps/ in the cumulative hazard?
 
-                We will instead approximate it using the pseudo-inverse.
 
                 It's advisable to not trust the variances reported, and to be suspicious of the
                 fitted parameters too. Perform plots of the cumulative hazard to help understand

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -620,10 +620,10 @@ class ParametericUnivariateFitter(UnivariateFitter):
             multiple outputs.
 
         """
-        justify = utils.string_justify(18)
+        justify = utils.string_justify(25)
         print(self)
-        print("{} = {}".format(justify("number of observations"), self.weights.sum()))
-        print("{} = {}".format(justify("number of events observed"), self.weights[self.event_observed > 0].sum()))
+        print("{} = {:g}".format(justify("number of observations"), self.weights.sum()))
+        print("{} = {:g}".format(justify("number of events observed"), self.weights[self.event_observed > 0].sum()))
         print("{} = {:.{prec}f}".format(justify("log-likelihood"), self.log_likelihood_, prec=decimals))
         print(
             "{} = {}".format(
@@ -1721,7 +1721,7 @@ class ParametricRegressionFitter(BaseFitter):
         """
 
         # Print information about data first
-        justify = utils.string_justify(18)
+        justify = utils.string_justify(25)
         print(self)
         if self.event_col:
             print("{} = '{}'".format(justify("event col"), self.event_col))
@@ -1733,8 +1733,8 @@ class ParametricRegressionFitter(BaseFitter):
         if self.robust:
             print("{} = {}".format(justify("robust variance"), True))
 
-        print("{} = {}".format(justify("number of observations"), self.weights.sum()))
-        print("{} = {}".format(justify("number of events observed"), self.weights[self.event_observed > 0].sum()))
+        print("{} = {:g}".format(justify("number of observations"), self.weights.sum()))
+        print("{} = {:g}".format(justify("number of events observed"), self.weights[self.event_observed > 0].sum()))
         print("{} = {:.{prec}f}".format(justify("log-likelihood"), self.log_likelihood_, prec=decimals))
         print("{} = {}".format(justify("time fit was run"), self._time_fit_was_called))
 
@@ -1879,7 +1879,7 @@ class ParametricRegressionFitter(BaseFitter):
 
         """
         df = df.copy().astype(float)
-        times = utils.coalesce(times, self.timeline, np.unique(self.durations))
+        times = utils.coalesce(times, self.timeline)
         times = np.atleast_1d(times).astype(float)
 
         if isinstance(df, pd.Series):
@@ -2946,7 +2946,7 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         predict_percentile, predict_expectation, predict_survival_function
         """
         df = df.copy().astype(float)
-        times = utils.coalesce(times, self.timeline, np.unique(self.durations))
+        times = utils.coalesce(times, self.timeline)
         times = np.atleast_1d(times).astype(float)
 
         if isinstance(df, pd.Series):

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1267,7 +1267,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         """
 
         # Print information about data first
-        justify = string_justify(18)
+        justify = string_justify(25)
         print(self)
         print("{} = '{}'".format(justify("duration col"), self.duration_col))
 
@@ -1288,8 +1288,8 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         if self.penalizer > 0:
             print("{} = {}".format(justify("penalizer"), self.penalizer))
 
-        print("{} = {}".format(justify("number of observations"), self.weights.sum()))
-        print("{} = {}".format(justify("number of events observed"), self.weights[self.event_observed > 0].sum()))
+        print("{} = {:g}".format(justify("number of observations"), self.weights.sum()))
+        print("{} = {:g}".format(justify("number of events observed"), self.weights[self.event_observed > 0].sum()))
         print("{} = {:.{prec}f}".format(justify("partial log-likelihood"), self.log_likelihood_, prec=decimals))
         print("{} = {}".format(justify("time fit was run"), self._time_fit_was_called))
 

--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -266,8 +266,8 @@ class KaplanMeierFitter(UnivariateFitter):
 
         self.__estimate = getattr(self, primary_estimate_name)
         self.confidence_interval_ = self._bounds(cumulative_sq_[:, None], alpha, ci_labels)
-        self._median = median_survival_times(self.__estimate, left_censorship=is_left_censoring)
-        self.percentile = functools.partial(qth_survival_time, survival_function=self.__estimate, cdf=is_left_censoring)
+        self._median = median_survival_times(self.survival_function_)
+        self.percentile = functools.partial(qth_survival_time, model_or_survival_function=self.survival_function_)
         self._cumulative_sq_ = cumulative_sq_
 
         setattr(self, "confidence_interval_" + primary_estimate_name, self.confidence_interval_)
@@ -282,6 +282,10 @@ class KaplanMeierFitter(UnivariateFitter):
 
     @property
     def median_(self):
+        warnings.warn(
+            """Please use `median_survival_time_` property instead. Future property `median_` will be removed.""",
+            FutureWarning,
+        )
         return self._median
 
     def _check_values(self, array):

--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -288,12 +288,16 @@ class KaplanMeierFitter(UnivariateFitter):
         )
         return self._median
 
+    @property
+    def median_survival_time_(self):
+        return self._median
+
     def _check_values(self, array):
         check_nans_or_infs(array)
 
     def plot_loglogs(self, *args, **kwargs):
         r"""
-        Plot :math:`\log(S(t))` against :math:`\log(t)`
+        Plot :math:`\log(S(t))` against :math:`\log(t)`. Same arguments as ``.plot``.
         """
         return plot_loglogs(self, *args, **kwargs)
 

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -685,7 +685,7 @@ def proportional_hazard_test(
         {'all', 'km', 'rank', 'identity', 'log'}
         One of the strings above, a list of strings, or a function to transform the time (must accept (time, durations, weights) however). 'all' will present all the transforms.
     precomputed_residuals: DataFrame, optional
-        specify the residuals, if already computed.
+        specify the scaled schoenfeld residuals, if already computed.
     kwargs:
         additional parameters to add to the StatisticalResult
 

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1565,9 +1565,12 @@ def interpolate_at_times_and_return_pandas(df_or_series, new_times):
     TODO
     """
     new_times = _to_1d_array(new_times)
-    return pd.DataFrame(
-        interpolate_at_times(df_or_series, new_times), index=new_times, columns=df_or_series.columns
-    ).squeeze()
+    try:
+        cols = df_or_series.columns
+    except AttributeError:
+        cols = None
+
+    return pd.DataFrame(interpolate_at_times(df_or_series, new_times), index=new_times, columns=cols).squeeze()
 
 
 string_justify = lambda width: lambda s: s.rjust(width, " ")

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -17,10 +17,10 @@ from lifelines.utils.concordance import concordance_index
 
 
 __all__ = [
-    "qth_survival_times",
     "qth_survival_time",
-    "median_survival_times",
     "restricted_mean_survival_time",
+    "median_survival_times",
+    "qth_survival_times",
     "survival_table_from_events",
     "group_survival_table_from_events",
     "survival_events_from_table",
@@ -108,7 +108,11 @@ class StatisticalWarning(RuntimeWarning):
     pass
 
 
-def qth_survival_times(q, survival_functions, cdf=False):
+class ApproximationWarning(RuntimeWarning):
+    pass
+
+
+def qth_survival_times(q, survival_functions):
     """
     Find the times when one or more survival functions reach the qth percentile.
 
@@ -119,8 +123,6 @@ def qth_survival_times(q, survival_functions, cdf=False):
     survival_functions: a (n,d) DataFrame or numpy array.
       If DataFrame, will return index values (actual times)
       If numpy array, will return indices.
-    cdf: boolean, optional
-      When doing left-censored data, cdf=True is used.
 
     Returns
     -------
@@ -146,9 +148,9 @@ def qth_survival_times(q, survival_functions, cdf=False):
         # If you add print statements to `qth_survival_time`, you'll see it's called
         # once too many times. This is expected Pandas behavior
         # https://stackoverflow.com/questions/21635915/why-does-pandas-apply-calculate-twice
-        return survival_functions.apply(lambda s: qth_survival_time(q, s, cdf=cdf)).iloc[0]
+        return survival_functions.apply(lambda s: qth_survival_time(q, s)).iloc[0]
     else:
-        d = {_q: survival_functions.apply(lambda s: qth_survival_time(_q, s, cdf=cdf)) for _q in q}
+        d = {_q: survival_functions.apply(lambda s: qth_survival_time(_q, s)) for _q in q}
         survival_times = pd.DataFrame(d).T
 
         #  Typically, one would expect that the output should equal the "height" of q.
@@ -160,17 +162,17 @@ def qth_survival_times(q, survival_functions, cdf=False):
         return survival_times
 
 
-def qth_survival_time(q, survival_function, cdf=False):
+def qth_survival_time(q, model_or_survival_function):
     """
-    Returns the time when a single survival function reaches the qth percentile.
+    Returns the time when a single survival function reaches the qth percentile, that is,
+    solves  :math:`q = S(t)` for :math:`t`.
 
     Parameters
     ----------
     q: float
-      a float between 0 and 1 that represents the time when the survival function hit's the qth percentile.
-    survival_function: Series or single-column DataFrame.
-    cdf: boolean, optional
-      When doing left-censored data, cdf=True is used.
+      value between 0 and 1.
+    model_or_survival_function: Pandas Series or single-column DataFrame, or lifelines model
+
 
     Returns
     -------
@@ -180,46 +182,49 @@ def qth_survival_time(q, survival_function, cdf=False):
     --------
     qth_survival_times, median_survival_times
     """
-    if isinstance(survival_function, pd.DataFrame):
-        if survival_function.shape[1] > 1:
-            raise ValueError(
-                "Expecting a dataframe (or series) with a single column. Provide that or use utils.qth_survival_times."
-            )
+    import lifelines
 
-        survival_function = survival_function.T.squeeze()
-    if cdf:
-        if survival_function.iloc[0] > q:
-            return -np.inf
-        v = survival_function.index[survival_function.searchsorted([q])[0]]
-    else:
-        if survival_function.iloc[-1] > q:
+    if isinstance(model_or_survival_function, lifelines.fitters.UnivariateFitter):
+        return model.percentile(q)
+    elif isinstance(model_or_survival_function, pd.DataFrame):
+        if model_or_survival_function.shape[1] > 1:
+            raise ValueError(
+                "Expecting a DataFrame (or Series) with a single column. Provide that or use utils.qth_survival_times."
+            )
+        return qth_survival_time(q, model_or_survival_function.T.squeeze())
+    elif isinstance(model_or_survival_function, pd.Series):
+        if model_or_survival_function.iloc[-1] > q:
             return np.inf
-        v = survival_function.index[(-survival_function).searchsorted([-q])[0]]
+        v = model_or_survival_function.index[(-model_or_survival_function).searchsorted([-q])[0]]
+    else:
+        raise ValueError(
+            "Unable to compute median of object %s - should be a DataFrame, Series or lifelines univariate model"
+            % model_or_survival_function
+        )
     return v
 
 
-def median_survival_times(model_or_density_or_survival_function, left_censorship=False):
+def median_survival_times(model_or_survival_function):
     """
     Compute the median survival time of survival function(s).
 
     Parameters
     -----------
 
-    model_or_density_or_survival_function: lifelines model or DataFrame
+    model_or_survival_function: lifelines model or DataFrame
         This can be a univariate lifelines model, or a DataFrame of one or more survival functions.
-
     """
     import lifelines
 
-    if isinstance(model_or_density_or_survival_function, pd.DataFrame):
-        return qth_survival_times(0.5, model_or_density_or_survival_function, cdf=left_censorship)
+    if isinstance(model_or_survival_function, pd.DataFrame):
+        return qth_survival_times(0.5, model_or_survival_function)
     elif isinstance(model_or_survival_function, lifelines.fitters.UnivariateFitter):
-        return model.median_
+        return model.median_survival_time_
     else:
-        raise ValueError("Can't compute median surviva time of object %s" % model_or_survival_function)
+        raise ValueError("Can't compute median survival time of object %s" % model_or_survival_function)
 
 
-def restricted_mean_survival_time(model_or_survival_function, t=np.inf):
+def restricted_mean_survival_time(model_or_survival_function, t=np.inf, return_ci=False):
     r"""
     Compute the restricted mean survival time, RMST, of a survival function. This is defined as
 
@@ -260,7 +265,7 @@ def restricted_mean_survival_time(model_or_survival_function, t=np.inf):
     if isinstance(model_or_survival_function, pd.DataFrame):
         warnings.warn(
             "Approximating RMST using the precomputed survival function. You likely will get a more accurate estimate if you provide the fitted Model instead of the survival function.",
-            UserWarning,
+            ApproximationWarning,
         )
         sf = model_or_survival_function.loc[:t]
         sf = sf.append(pd.DataFrame([1], index=[0], columns=sf.columns)).sort_index()
@@ -446,7 +451,6 @@ def survival_table_from_events(
     >>> 15              2         2         0         0         2
     >>> #Collapsed output
     >>>          removed observed censored at_risk
-    >>>              sum      sum      sum     max
     >>> event_at
     >>> (0, 2]        34       33        1     312
     >>> (2, 4]        84       42       42     278

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.22.6"
+__version__ = "0.22.7"

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -13,3 +13,4 @@ dill
 statsmodels
 flaky
 scikit-learn
+easydev

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -347,6 +347,7 @@ class TestUnivariateFitters:
         for fitter in univariate_fitters:
             f = fitter().fit(positive_sample_lifetimes[0])
             if hasattr(f, "survival_function_"):
+                print(f)
                 assert f.percentile(0.5) == f.median_survival_time_
 
     def test_default_alpha_is_005(self, univariate_fitters):
@@ -913,8 +914,8 @@ class TestWeibullFitter:
         wf.fit(T)
         assert abs(wf.rho_ - 0.5) < 0.01
         assert abs(wf.lambda_ / 5 - 1) < 0.01
-        assert abs(wf.median_ - 5 * np.log(2) ** 2) < 0.1  # worse convergence
-        assert abs(wf.median_ - np.median(T)) < 0.1
+        assert abs(wf.median_survival_time_ - 5 * np.log(2) ** 2) < 0.1  # worse convergence
+        assert abs(wf.median_survival_time_ - np.median(T)) < 0.1
 
     def test_exponential_data_produces_correct_inference_with_censorship(self):
         wf = WeibullFitter()
@@ -925,7 +926,7 @@ class TestWeibullFitter:
         wf.fit(np.minimum(T, T_), (T < T_))
         assert abs(wf.rho_ - 1.0) < 0.05
         assert abs(wf.lambda_ / factor - 1) < 0.05
-        assert abs(wf.median_ - factor * np.log(2)) < 0.1
+        assert abs(wf.median_survival_time_ - factor * np.log(2)) < 0.1
 
     def test_convergence_completes_for_ever_increasing_data_sizes(self):
         wf = WeibullFitter()

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -347,7 +347,7 @@ class TestUnivariateFitters:
         for fitter in univariate_fitters:
             f = fitter().fit(positive_sample_lifetimes[0])
             if hasattr(f, "survival_function_"):
-                assert f.percentile(0.5) == f.median_
+                assert f.percentile(0.5) == f.median_survival_time_
 
     def test_default_alpha_is_005(self, univariate_fitters):
         for f in univariate_fitters:

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -440,3 +440,12 @@ def test_proportional_hazard_test_with_list():
     cph.fit(df, "T", "E")
     results = stats.proportional_hazard_test(cph, df, time_transform=["rank", "km"])
     assert results.summary.shape[0] == 2 * 2
+
+
+def test_survival_difference_at_fixed_point_in_time_test():
+    df = load_waltons()
+    ix = df["group"] == "miR-137"
+    waltonT1 = df.loc[ix]["T"]
+    waltonT2 = df.loc[~ix]["T"]
+    result = stats.survival_difference_at_fixed_point_in_time_test(10, waltonT1, waltonT2)
+    assert result.p_value < 0.05

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -202,18 +202,6 @@ def test_qth_survival_times_with_duplicate_q_returns_valid_index_and_shape():
     npt.assert_almost_equal(actual.index.values, q.values)
 
 
-def test_qth_survival_time_with_cdf_instead_of_survival_function():
-    cdf = np.linspace(0, 1, 50)
-    sf = 1 - np.linspace(0, 1, 50)
-    assert utils.qth_survival_times(0.5, sf) == 25
-    assert utils.qth_survival_times(0.05, sf) == 3
-
-    cdf = np.linspace(0.1, 1, 50)
-    sf = 1 - np.linspace(0, 1, 50)
-    assert utils.qth_survival_times(0.05, cdf) == -np.inf
-    assert utils.qth_survival_times(0.50, cdf) == 22
-
-
 def test_datetimes_to_durations_with_different_frequencies():
     # days
     start_date = ["2013-10-10 0:00:00", "2013-10-09", "2012-10-10"]
@@ -1069,7 +1057,7 @@ def test_rmst_approximate_solution():
     exp = ExponentialFitter().fit(T)
     lambda_ = exp.lambda_
 
-    with pytest.warns(ApproximationWarning) as w:
+    with pytest.warns(utils.ApproximationWarning) as w:
 
         assert (
             abs(

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1069,10 +1069,12 @@ def test_rmst_approximate_solution():
     exp = ExponentialFitter().fit(T)
     lambda_ = exp.lambda_
 
-    assert (
-        abs(
-            utils.restricted_mean_survival_time(exp, t=lambda_)
-            - utils.restricted_mean_survival_time(exp.survival_function_, t=lambda_)
+    with pytest.warns(ApproximationWarning) as w:
+
+        assert (
+            abs(
+                utils.restricted_mean_survival_time(exp, t=lambda_)
+                - utils.restricted_mean_survival_time(exp.survival_function_, t=lambda_)
+            )
+            < 0.001
         )
-        < 0.001
-    )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -204,12 +204,14 @@ def test_qth_survival_times_with_duplicate_q_returns_valid_index_and_shape():
 
 def test_qth_survival_time_with_cdf_instead_of_survival_function():
     cdf = np.linspace(0, 1, 50)
-    assert utils.qth_survival_times(0.5, cdf, cdf=True) == 25
-    assert utils.qth_survival_times(0.05, cdf, cdf=True) == 3
+    sf = 1 - np.linspace(0, 1, 50)
+    assert utils.qth_survival_times(0.5, sf) == 25
+    assert utils.qth_survival_times(0.05, sf) == 3
 
     cdf = np.linspace(0.1, 1, 50)
-    assert utils.qth_survival_times(0.05, cdf, cdf=True) == -np.inf
-    assert utils.qth_survival_times(0.50, cdf, cdf=True) == 22
+    sf = 1 - np.linspace(0, 1, 50)
+    assert utils.qth_survival_times(0.05, cdf) == -np.inf
+    assert utils.qth_survival_times(0.50, cdf) == 22
 
 
 def test_datetimes_to_durations_with_different_frequencies():


### PR DESCRIPTION
#### 0.22.7

##### New features
 - new `ApproximationWarning` to tell you if the package is making an potentially mislead approximation.

##### Bug fixes
 - fixed a bug in parametric prediction for interval censored data.
 - realigned values in `print_summary`.
 - fixed bug in `survival_difference_at_fixed_point_in_time_test`

##### API Changes
 - `utils.qth_survival_time` no longer takes a `cdf` argument - users should take the compliment (1-cdf).
 - Some previous `StatisticalWarnings` have been replaced by `ApproximationWarning`


closes #841 
closes #839 