### PR TITLE
sklearn_adapter: Better error message for invalid X

### DIFF
--- a/lifelines/utils/sklearn_adapter.py
+++ b/lifelines/utils/sklearn_adapter.py
@@ -44,7 +44,7 @@ class _SklearnModel(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
 
         """
         if not isinstance(X, pd.DataFrame):
-            raise ValueError("X must be a DataFrame")
+            raise ValueError("X must be a DataFrame. Got type: {}".format(type(X)))
 
         X = X.copy()
 


### PR DESCRIPTION
X needs to be a dataframe currently. Print the type of X in the
exception message so it's clearer to users what is not supported.

Thought it would be a good idea, as sometimes I use this with other libraries that try to make pipelines with sklearn regressors - and Im just not sure what those other libraries are passing into lifelines (sklearn supports more inputs than lifelines - for example, sklearn supports numpy arrays)