### PR TITLE
Fix pickle issues

### DIFF
--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -301,9 +301,6 @@ class ParametericUnivariateFitter(UnivariateFitter):
     def __init__(self, *args, **kwargs):
         super(ParametericUnivariateFitter, self).__init__(*args, **kwargs)
         self._estimate_name = "cumulative_hazard_"
-        if not hasattr(self, "_hazard"):
-            # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
-            self._hazard = egrad(self._cumulative_hazard, argnum=1)
         if not hasattr(self, "_bounds"):
             self._bounds = [(0.0, None)] * len(self._fitted_parameter_names)
         self._bounds = list(self._buffer_bounds(self._bounds))
@@ -375,6 +372,10 @@ class ParametericUnivariateFitter(UnivariateFitter):
 
     def _cumulative_hazard(self, params, times):
         return -anp.log(self._survival_function(params, times))
+
+    def _hazard(self, *args, **kwargs):
+        # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
+        return egrad(self._cumulative_hazard, argnum=1)(*args, **kwargs)
 
     def _survival_function(self, params, times):
         return anp.exp(-self._cumulative_hazard(params, times))
@@ -1175,7 +1176,6 @@ class ParametricRegressionFitter(BaseFitter):
 
     def __init__(self, alpha=0.05, penalizer=0.0):
         super(ParametricRegressionFitter, self).__init__(alpha=alpha)
-        self._hazard = egrad(self._cumulative_hazard, argnum=1)  # pylint: disable=unexpected-keyword-arg
         self.penalizer = penalizer
 
     def _check_values(self, df, T, E, weights, entries):
@@ -1201,6 +1201,9 @@ class ParametricRegressionFitter(BaseFitter):
 
         if self.entry_col:
             utils.check_entry_times(T, entries)
+
+    def _hazard(self, *args, **kwargs):
+        return egrad(self._cumulative_hazard, argnum=1)(*args, **kwargs)  # pylint: disable=unexpected-keyword-arg
 
     def _log_hazard(self, params, T, Xs):
         # can be overwritten to improve convergence, see example in WeibullAFTFitter
@@ -2129,12 +2132,15 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
 
     def __init__(self, alpha=0.05, penalizer=0.0, l1_ratio=0.0, fit_intercept=True, model_ancillary=False):
         super(ParametericAFTRegressionFitter, self).__init__(alpha=alpha)
-        self._hazard = egrad(self._cumulative_hazard, argnum=1)  # pylint: disable=unexpected-keyword-arg
+        # self._hazard = egrad(self._cumulative_hazard, argnum=1)  # pylint: disable=unexpected-keyword-arg
         self._fitted_parameter_names = [self._primary_parameter_name, self._ancillary_parameter_name]
         self.penalizer = penalizer
         self.l1_ratio = l1_ratio
         self.fit_intercept = fit_intercept
         self.model_ancillary = model_ancillary
+
+    def _hazard(self, *args, **kwargs):
+        return egrad(self._cumulative_hazard, argnum=1)(*args, **kwargs)  # pylint: disable=unexpected-keyword-arg
 
     @utils.CensoringType.right_censoring
     def fit(

--- a/lifelines/utils/sklearn_adapter.py
+++ b/lifelines/utils/sklearn_adapter.py
@@ -44,7 +44,7 @@ class _SklearnModel(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
 
         """
         if not isinstance(X, pd.DataFrame):
-            raise ValueError("X must be a DataFrame")
+            raise ValueError("X must be a DataFrame. Got type: {}".format(type(X)))
 
         X = X.copy()
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -600,7 +600,6 @@ class TestUnivariateFitters:
             with pytest.raises(TypeError):
                 fitter().fit(T, E)
 
-    @pytest.mark.xfail()
     def test_pickle_serialization(self, positive_sample_lifetimes, univariate_fitters):
         T = positive_sample_lifetimes[0]
         for f in univariate_fitters:
@@ -620,6 +619,19 @@ class TestUnivariateFitters:
             fitter.fit(T)
 
             unpickled = loads(dumps(fitter))
+            dif = (fitter.durations - unpickled.durations).sum()
+            assert dif == 0
+
+    def test_joblib_serialization(self, positive_sample_lifetimes, univariate_fitters):
+        from joblib import dump, load
+
+        T = positive_sample_lifetimes[0]
+        for f in univariate_fitters:
+            fitter = f()
+            fitter.fit(T)
+
+            dump(fitter, "filename.joblib")
+            unpickled = load("filename.joblib")
             dif = (fitter.durations - unpickled.durations).sum()
             assert dif == 0
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1480,6 +1480,14 @@ class TestRegressionFitters:
         regression_models_sans_strata_model.append(CoxPHFitter(strata=["race", "paro", "mar", "wexp"]))
         return regression_models_sans_strata_model
 
+    def test_pickle_serialization(self, rossi, regression_models):
+        for fitter in regression_models:
+            fitter.fit(rossi, "week", "arrest")
+
+            unpickled = pickle.loads(pickle.dumps(fitter))
+            dif = (fitter.durations - unpickled.durations).sum()
+            assert dif == 0
+
     def test_dill_serialization(self, rossi, regression_models):
         from dill import dumps, loads
 
@@ -1490,7 +1498,6 @@ class TestRegressionFitters:
             dif = (fitter.durations - unpickled.durations).sum()
             assert dif == 0
 
-    @pytest.mark.xfail()
     def test_joblib_serialization(self, rossi, regression_models):
         from joblib import dump, load
 
@@ -1501,15 +1508,6 @@ class TestRegressionFitters:
             unpickled = load("filename.joblib")
             dif = (fitter.durations - unpickled.durations).sum()
             assert dif == 0
-
-    @pytest.mark.xfail()
-    def test_pickle(self, rossi, regression_models):
-        from pickle import dump
-
-        for fitter in regression_models:
-            output = stringio()
-            f = fitter.fit(rossi, "week", "arrest")
-            dump(f, output)
 
     def test_fit_will_accept_object_dtype_as_event_col(self, regression_models_sans_strata_model, rossi):
         # issue #638


### PR DESCRIPTION
For univariate models: `_hazard` is a property in the object, but actually a function - By making it a function, it becomes a part of the class definition and hence the pickle does not consider it as a property that needs to be serialized.

From my manual testing, these fitters can now be pickled:
 - LogLogisticFitter
 - WeibullFitter
 - GeneralizedGammaFitter
Also, removed the xfail from the pickle and added joblib test cases in Univariate.

EDIT: I did some more digging and figured out the issue for the Regression models too.
For regression models: `_neg_likelihood_with_penalty_function` is a property in the object, but actually a function. By making it a functools.partial, pickle will know how to pickle it. Also, it needs the `unflatten` function which is an autograd function which cannot be pickled. So, we save the data to recreate it with autograd instead of saving the autograd function itself.

From my manual testing, these fitters can now be pickled:
 - WeibullAFTFitter
 - LogNormalAFTFitter
 - LogLogisticAFTFitter
And I also added pickle test cases for this, and removed the xfail from joblib test case for Regression models

Fixes https://github.com/CamDavidsonPilon/lifelines/issues/188