### PR TITLE
v0.22.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 ## Changelog
 
 
-#### 0.22.9 - unreleased
+#### 0.22.9 - 2019-10-30
 
 
 ##### Bug fixes
  - fixed `predict_` methods in AFT models when `timeline` was not specified.
+ - fixed error in `qq_plot`
+ - fixed error when submitting a model in `qth_survival_time`
+ - `CoxPHFitter` now displays correct columns values when changing alpha param.
 
 
-
-#### 0.22.8
+#### 0.22.8 - 2019-10-06
 
 ##### New features
  - Serializing lifelines is better supported. Packages like joblib and pickle are now supported. Thanks @AbdealiJK!

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,8 +1,23 @@
 Changelog
 ---------
 
-0.22.8
-^^^^^^
+0.22.9 - 2019-10-30
+^^^^^^^^^^^^^^^^^^^
+
+Bug fixes
+'''''''''
+
+-  fixed ``predict_`` methods in AFT models when ``timeline`` was not
+   specified.
+-  fixed error in ``qq_plot``
+-  fixed error when submitting a model in ``qth_survival_time``
+-  ``CoxPHFitter`` now displays correct columns values when changing
+   alpha param.
+
+.. _section-1:
+
+0.22.8 - 2019-10-06
+^^^^^^^^^^^^^^^^^^^
 
 New features
 ''''''''''''
@@ -12,12 +27,14 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
+.. _bug-fixes-1:
+
 Bug fixes
 '''''''''
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-1:
+.. _section-2:
 
 0.22.7 - 2019-09-29
 ^^^^^^^^^^^^^^^^^^^
@@ -30,7 +47,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -47,7 +64,7 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-2:
+.. _section-3:
 
 0.22.6 - 2019-09-25
 ^^^^^^^^^^^^^^^^^^^
@@ -59,7 +76,7 @@ New features
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
@@ -75,7 +92,7 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-3:
+.. _section-4:
 
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
@@ -89,7 +106,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -106,7 +123,7 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-4:
+.. _section-5:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
@@ -130,7 +147,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -138,7 +155,7 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-5:
+.. _section-6:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
@@ -167,7 +184,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
@@ -179,7 +196,7 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-6:
+.. _section-7:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
@@ -191,7 +208,7 @@ New features
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -202,7 +219,7 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-7:
+.. _section-8:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
@@ -235,7 +252,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
@@ -245,7 +262,7 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-8:
+.. _section-9:
 
 0.22.0 - 2019-07-03
 ~~~~~~~~~~~~~~~~~~~
@@ -284,7 +301,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
@@ -293,7 +310,7 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-9:
+.. _section-10:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
@@ -307,7 +324,7 @@ New features
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
@@ -317,7 +334,7 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-10:
+.. _section-11:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
@@ -336,14 +353,14 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-11:
+.. _section-12:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
@@ -372,12 +389,12 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
 
-.. _section-12:
+.. _section-13:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
@@ -399,14 +416,14 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-13:
+.. _section-14:
 
 0.21.0 - 2019-04-12
 ~~~~~~~~~~~~~~~~~~~
@@ -436,7 +453,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
@@ -446,7 +463,7 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-14:
+.. _section-15:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
@@ -468,7 +485,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 '''''''''
@@ -477,7 +494,7 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-15:
+.. _section-16:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
@@ -501,7 +518,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 '''''''''
@@ -510,7 +527,7 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-16:
+.. _section-17:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
@@ -528,7 +545,7 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-17:
+.. _section-18:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
@@ -557,7 +574,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 '''''''''
@@ -573,7 +590,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-18:
+.. _section-19:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -597,7 +614,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-19:
+.. _section-20:
 
 0.20.0 - 2019-03-05
 ~~~~~~~~~~~~~~~~~~~
@@ -626,14 +643,14 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-20:
+.. _section-21:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
@@ -648,19 +665,19 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-21:
+.. _section-22:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-22:
+.. _section-23:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
@@ -677,7 +694,7 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-23:
+.. _section-24:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
@@ -690,7 +707,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 '''''''''
@@ -700,7 +717,7 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-24:
+.. _section-25:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
@@ -722,7 +739,7 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-25:
+.. _section-26:
 
 0.19.0 - 2019-02-20
 ~~~~~~~~~~~~~~~~~~~
@@ -766,7 +783,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug Fixes
 '''''''''
@@ -783,7 +800,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-26:
+.. _section-27:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -793,7 +810,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-27:
+.. _section-28:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -814,7 +831,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-28:
+.. _section-29:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -824,7 +841,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-29:
+.. _section-30:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -834,7 +851,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-30:
+.. _section-31:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -850,7 +867,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-31:
+.. _section-32:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -861,7 +878,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-32:
+.. _section-33:
 
 0.18.0 - 2019-01-31
 ~~~~~~~~~~~~~~~~~~~
@@ -898,7 +915,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-33:
+.. _section-34:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -906,7 +923,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-34:
+.. _section-35:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -918,7 +935,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-35:
+.. _section-36:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -926,7 +943,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-36:
+.. _section-37:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -937,7 +954,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-37:
+.. _section-38:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -954,7 +971,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-38:
+.. _section-39:
 
 0.17.0 - 2019-01-11
 ~~~~~~~~~~~~~~~~~~~
@@ -975,7 +992,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-39:
+.. _section-40:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -983,7 +1000,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-40:
+.. _section-41:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -994,14 +1011,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-41:
+.. _section-42:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-42:
+.. _section-43:
 
 0.16.0 - 2019-01-01
 ~~~~~~~~~~~~~~~~~~~
@@ -1037,7 +1054,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-43:
+.. _section-44:
 
 0.15.4
 ^^^^^^
@@ -1045,14 +1062,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-44:
+.. _section-45:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-45:
+.. _section-46:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1063,7 +1080,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-46:
+.. _section-47:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1072,7 +1089,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-47:
+.. _section-48:
 
 0.15.0 - 2018-11-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1143,7 +1160,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-48:
+.. _section-49:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1151,7 +1168,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-49:
+.. _section-50:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1159,7 +1176,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-50:
+.. _section-51:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1176,7 +1193,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-51:
+.. _section-52:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1188,7 +1205,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-52:
+.. _section-53:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1196,7 +1213,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-53:
+.. _section-54:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1214,7 +1231,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-54:
+.. _section-55:
 
 0.14.0 - 2018-03-03
 ~~~~~~~~~~~~~~~~~~~
@@ -1236,7 +1253,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-55:
+.. _section-56:
 
 0.13.0 - 2017-12-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1265,7 +1282,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-56:
+.. _section-57:
 
 0.12.0
 ~~~~~~
@@ -1282,7 +1299,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-57:
+.. _section-58:
 
 0.11.3
 ^^^^^^
@@ -1294,7 +1311,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-58:
+.. _section-59:
 
 0.11.2
 ^^^^^^
@@ -1302,14 +1319,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-59:
+.. _section-60:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-60:
+.. _section-61:
 
 0.11.0 - 2017-06-21
 ~~~~~~~~~~~~~~~~~~~
@@ -1323,14 +1340,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-61:
+.. _section-62:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-62:
+.. _section-63:
 
 0.10.0
 ~~~~~~
@@ -1345,7 +1362,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-63:
+.. _section-64:
 
 0.9.4
 ^^^^^
@@ -1368,7 +1385,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-64:
+.. _section-65:
 
 0.9.2
 ^^^^^
@@ -1377,7 +1394,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-65:
+.. _section-66:
 
 0.9.1
 ^^^^^
@@ -1385,7 +1402,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-66:
+.. _section-67:
 
 0.9.0
 ~~~~~
@@ -1401,7 +1418,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-67:
+.. _section-68:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -1418,7 +1435,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-68:
+.. _section-69:
 
 0.8.0
 ~~~~~
@@ -1437,7 +1454,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-69:
+.. _section-70:
 
 0.7.1
 ^^^^^
@@ -1456,7 +1473,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-70:
+.. _section-71:
 
 0.7.0 - 2015-03-01
 ~~~~~~~~~~~~~~~~~~
@@ -1475,7 +1492,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-71:
+.. _section-72:
 
 0.6.1
 ^^^^^
@@ -1487,7 +1504,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-72:
+.. _section-73:
 
 0.6.0 - 2015-02-04
 ~~~~~~~~~~~~~~~~~~
@@ -1510,7 +1527,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-73:
+.. _section-74:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1531,7 +1548,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-74:
+.. _section-75:
 
 0.5.0 - 2014-12-07
 ~~~~~~~~~~~~~~~~~~
@@ -1544,7 +1561,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-75:
+.. _section-76:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1556,7 +1573,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-76:
+.. _section-77:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -1577,7 +1594,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-77:
+.. _section-78:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -1597,7 +1614,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-78:
+.. _section-79:
 
 0.4.1.1
 ^^^^^^^
@@ -1610,7 +1627,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-79:
+.. _section-80:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -1629,7 +1646,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-80:
+.. _section-81:
 
 0.4.0 - 2014-06-08
 ~~~~~~~~~~~~~~~~~~

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.22.8"
+__version__ = "0.22.9"


### PR DESCRIPTION

#### 0.22.9 - 2019-10-30


##### Bug fixes
 - fixed `predict_` methods in AFT models when `timeline` was not specified.
 - fixed error in `qq_plot`
 - fixed error when submitting a model in `qth_survival_time`
 - `CoxPHFitter` now displays correct columns values when changing alpha param.

