### PR TITLE
Updates `median_` to `median_survival_time_`

### DIFF
--- a/lifelines/fitters/exponential_fitter.py
+++ b/lifelines/fitters/exponential_fitter.py
@@ -47,7 +47,7 @@ class ExponentialFitter(KnownModelParametricUnivariateFitter):
         The lower and upper confidence intervals for the survival function
     variance_matrix_ : numpy array
         The variance matrix of the coefficients
-    median_: float
+    median_survival_time_: float
         The median time to event
     lambda_: float
         The fitted parameter in the model


### PR DESCRIPTION
Since `median_survival_time_` was changed to `median_survival_time_` in 0.23.0, this updates the associated documentation.