### PR TITLE
Updates to `median_survival_time_ ` in Quickstart

### DIFF
--- a/docs/Quickstart.rst
+++ b/docs/Quickstart.rst
@@ -62,7 +62,7 @@ After calling the :meth:`~lifelines.fitters.kaplan_meier_fitter.KaplanMeierFitte
 
     kmf.survival_function_
     kmf.cumulative_density_
-    kmf.median_
+    kmf.median_survival_time_
     kmf.plot_survival_function() # or just kmf.plot()
 
 


### PR DESCRIPTION
Updates `median_ ` to `median_survival_time_ `, to reflect change that happened in [0.23.0](https://lifelines.readthedocs.io/en/latest/Changelog.html#section-1)