### PR TITLE
Changes `median_` to `median_survival_time_` in docs

### DIFF
--- a/lifelines/fitters/generalized_gamma_fitter.py
+++ b/lifelines/fitters/generalized_gamma_fitter.py
@@ -79,7 +79,7 @@ class GeneralizedGammaFitter(KnownModelParametricUnivariateFitter):
         The estimated cumulative density function (with custom timeline if provided)
     variance_matrix_ : numpy array
         The variance matrix of the coefficients
-    median_: float
+    median_survival_time_: float
         The median time to event
     lambda_: float
         The fitted parameter in the model

--- a/lifelines/fitters/log_logistic_fitter.py
+++ b/lifelines/fitters/log_logistic_fitter.py
@@ -57,7 +57,7 @@ class LogLogisticFitter(KnownModelParametricUnivariateFitter):
         The estimated cumulative density function (with custom timeline if provided)
     variance_matrix_ : numpy array
         The variance matrix of the coefficients
-    median_: float
+    median_survival_time_: float
         The median time to event
     alpha_: float
         The fitted parameter in the model

--- a/lifelines/fitters/log_normal_fitter.py
+++ b/lifelines/fitters/log_normal_fitter.py
@@ -40,7 +40,7 @@ class LogNormalFitter(KnownModelParametricUnivariateFitter):
         The estimated cumulative density function (with custom timeline if provided)
     variance_matrix_ : numpy array
         The variance matrix of the coefficients
-    median_: float
+    median_survival_time_: float
         The median time to event
     mu_: float
         The fitted parameter in the model

--- a/lifelines/fitters/piecewise_exponential_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_fitter.py
@@ -45,7 +45,7 @@ class PiecewiseExponentialFitter(KnownModelParametricUnivariateFitter):
         The estimated cumulative density function (with custom timeline if provided)
     variance_matrix_ : numpy array
         The variance matrix of the coefficients
-    median_: float
+    median_survival_time_: float
         The median time to event
     lambda_i_: float
         The fitted parameter in the model, for i = 0, 1 ... n-1 breakpoints

--- a/lifelines/fitters/weibull_fitter.py
+++ b/lifelines/fitters/weibull_fitter.py
@@ -65,7 +65,7 @@ class WeibullFitter(KnownModelParametricUnivariateFitter):
         The estimated cumulative density function (with custom timeline if provided)
     variance_matrix_ : numpy array
         The variance matrix of the coefficients
-    median_: float
+    median_survival_time_: float
         The median time to event
     lambda_: float
         The fitted parameter in the model


### PR DESCRIPTION
Since `median_survival_time_` was changed to `median_survival_time_` in 0.23.0, this updates the associated documentation.