### PR TITLE
MANIFEST: Add "reqs"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,6 @@ include *.ipynb
 recursive-include lifelines *
 recursive-include datasets *
 recursive-include styles *
+recursive-include reqs *
 
 recursive-exclude * *.py[co]


### PR DESCRIPTION
If not added, source installations created with `sdist`
don't work.

Fixes https://github.com/CamDavidsonPilon/lifelines/issues/900