### PR TITLE
v0.23.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+#### 0.23.6 - 2020-01-14
+
+Bug fixes for py3.5. This will be the last version of lifelines that supports Python 3.5.
+
 #### 0.23.6 - 2020-01-07
 
 ##### New features

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.23.6 - 2020-01-14
+^^^^^^^^^^^^^^^^^^^
+
+Bug fixes for py3.5. This will be the last version of lifelines that
+supports Python 3.5.
+
+.. _section-1:
+
 0.23.6 - 2020-01-07
 ^^^^^^^^^^^^^^^^^^^
 
@@ -16,7 +24,7 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-1:
+.. _section-2:
 
 0.23.5 - 2020-01-05
 ^^^^^^^^^^^^^^^^^^^
@@ -38,14 +46,14 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-2:
+.. _section-3:
 
 0.23.4 - 2019-12-15
 ^^^^^^^^^^^^^^^^^^^
 
 -  Bug fix for PyPI
 
-.. _section-3:
+.. _section-4:
 
 0.23.3 - 2019-12-11
 ^^^^^^^^^^^^^^^^^^^
@@ -65,7 +73,7 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-4:
+.. _section-5:
 
 0.23.2 - 2019-12-07
 ^^^^^^^^^^^^^^^^^^^
@@ -91,7 +99,7 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-5:
+.. _section-6:
 
 0.23.1 - 2019-11-27
 ^^^^^^^^^^^^^^^^^^^
@@ -118,7 +126,7 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-6:
+.. _section-7:
 
 0.23.0 - 2019-11-17
 ^^^^^^^^^^^^^^^^^^^
@@ -152,7 +160,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-7:
+.. _section-8:
 
 0.22.10 - 2019-11-08
 ^^^^^^^^^^^^^^^^^^^^
@@ -170,7 +178,7 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-8:
+.. _section-9:
 
 0.22.9 - 2019-10-30
 ^^^^^^^^^^^^^^^^^^^
@@ -187,7 +195,7 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-9:
+.. _section-10:
 
 0.22.8 - 2019-10-06
 ^^^^^^^^^^^^^^^^^^^
@@ -209,7 +217,7 @@ Bug fixes
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-10:
+.. _section-11:
 
 0.22.7 - 2019-09-29
 ^^^^^^^^^^^^^^^^^^^
@@ -241,7 +249,7 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-11:
+.. _section-12:
 
 0.22.6 - 2019-09-25
 ^^^^^^^^^^^^^^^^^^^
@@ -269,7 +277,7 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-12:
+.. _section-13:
 
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
@@ -300,7 +308,7 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-13:
+.. _section-14:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
@@ -332,7 +340,7 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-14:
+.. _section-15:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
@@ -373,7 +381,7 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-15:
+.. _section-16:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
@@ -396,7 +404,7 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-16:
+.. _section-17:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
@@ -439,7 +447,7 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-17:
+.. _section-18:
 
 0.22.0 - 2019-07-03
 ~~~~~~~~~~~~~~~~~~~
@@ -487,7 +495,7 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-18:
+.. _section-19:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
@@ -511,7 +519,7 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-19:
+.. _section-20:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
@@ -537,7 +545,7 @@ Bug fixes
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-20:
+.. _section-21:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
@@ -571,7 +579,7 @@ API changes
 Bug fixes
 '''''''''
 
-.. _section-21:
+.. _section-22:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
@@ -600,7 +608,7 @@ Bug fixes
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-22:
+.. _section-23:
 
 0.21.0 - 2019-04-12
 ~~~~~~~~~~~~~~~~~~~
@@ -640,7 +648,7 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-23:
+.. _section-24:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
@@ -671,7 +679,7 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-24:
+.. _section-25:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
@@ -704,7 +712,7 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-25:
+.. _section-26:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
@@ -722,7 +730,7 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-26:
+.. _section-27:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
@@ -767,7 +775,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-27:
+.. _section-28:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -791,7 +799,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-28:
+.. _section-29:
 
 0.20.0 - 2019-03-05
 ~~~~~~~~~~~~~~~~~~~
@@ -827,7 +835,7 @@ Bug fixes
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-29:
+.. _section-30:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
@@ -842,7 +850,7 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-30:
+.. _section-31:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
@@ -854,7 +862,7 @@ Bug fixes
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-31:
+.. _section-32:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
@@ -871,7 +879,7 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-32:
+.. _section-33:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
@@ -894,7 +902,7 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-33:
+.. _section-34:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
@@ -916,7 +924,7 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-34:
+.. _section-35:
 
 0.19.0 - 2019-02-20
 ~~~~~~~~~~~~~~~~~~~
@@ -977,7 +985,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-35:
+.. _section-36:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -987,7 +995,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-36:
+.. _section-37:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1008,7 +1016,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-37:
+.. _section-38:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -1018,7 +1026,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-38:
+.. _section-39:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -1028,7 +1036,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-39:
+.. _section-40:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1044,7 +1052,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-40:
+.. _section-41:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1055,7 +1063,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-41:
+.. _section-42:
 
 0.18.0 - 2019-01-31
 ~~~~~~~~~~~~~~~~~~~
@@ -1092,7 +1100,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-42:
+.. _section-43:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1100,7 +1108,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-43:
+.. _section-44:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -1112,7 +1120,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-44:
+.. _section-45:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1120,7 +1128,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-45:
+.. _section-46:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -1131,7 +1139,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-46:
+.. _section-47:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1148,7 +1156,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-47:
+.. _section-48:
 
 0.17.0 - 2019-01-11
 ~~~~~~~~~~~~~~~~~~~
@@ -1169,7 +1177,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-48:
+.. _section-49:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1177,7 +1185,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-49:
+.. _section-50:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1188,14 +1196,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-50:
+.. _section-51:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-51:
+.. _section-52:
 
 0.16.0 - 2019-01-01
 ~~~~~~~~~~~~~~~~~~~
@@ -1231,7 +1239,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-52:
+.. _section-53:
 
 0.15.4
 ^^^^^^
@@ -1239,14 +1247,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-53:
+.. _section-54:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-54:
+.. _section-55:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1257,7 +1265,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-55:
+.. _section-56:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1266,7 +1274,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-56:
+.. _section-57:
 
 0.15.0 - 2018-11-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1337,7 +1345,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-57:
+.. _section-58:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1345,7 +1353,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-58:
+.. _section-59:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1353,7 +1361,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-59:
+.. _section-60:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1370,7 +1378,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-60:
+.. _section-61:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1382,7 +1390,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-61:
+.. _section-62:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1390,7 +1398,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-62:
+.. _section-63:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1408,7 +1416,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-63:
+.. _section-64:
 
 0.14.0 - 2018-03-03
 ~~~~~~~~~~~~~~~~~~~
@@ -1430,7 +1438,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-64:
+.. _section-65:
 
 0.13.0 - 2017-12-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1459,7 +1467,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-65:
+.. _section-66:
 
 0.12.0
 ~~~~~~
@@ -1476,7 +1484,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-66:
+.. _section-67:
 
 0.11.3
 ^^^^^^
@@ -1488,7 +1496,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-67:
+.. _section-68:
 
 0.11.2
 ^^^^^^
@@ -1496,14 +1504,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-68:
+.. _section-69:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-69:
+.. _section-70:
 
 0.11.0 - 2017-06-21
 ~~~~~~~~~~~~~~~~~~~
@@ -1517,14 +1525,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-70:
+.. _section-71:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-71:
+.. _section-72:
 
 0.10.0
 ~~~~~~
@@ -1539,7 +1547,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-72:
+.. _section-73:
 
 0.9.4
 ^^^^^
@@ -1562,7 +1570,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-73:
+.. _section-74:
 
 0.9.2
 ^^^^^
@@ -1571,7 +1579,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-74:
+.. _section-75:
 
 0.9.1
 ^^^^^
@@ -1579,7 +1587,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-75:
+.. _section-76:
 
 0.9.0
 ~~~~~
@@ -1595,7 +1603,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-76:
+.. _section-77:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -1612,7 +1620,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-77:
+.. _section-78:
 
 0.8.0
 ~~~~~
@@ -1631,7 +1639,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-78:
+.. _section-79:
 
 0.7.1
 ^^^^^
@@ -1650,7 +1658,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-79:
+.. _section-80:
 
 0.7.0 - 2015-03-01
 ~~~~~~~~~~~~~~~~~~
@@ -1669,7 +1677,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-80:
+.. _section-81:
 
 0.6.1
 ^^^^^
@@ -1681,7 +1689,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-81:
+.. _section-82:
 
 0.6.0 - 2015-02-04
 ~~~~~~~~~~~~~~~~~~
@@ -1704,7 +1712,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-82:
+.. _section-83:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1725,7 +1733,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-83:
+.. _section-84:
 
 0.5.0 - 2014-12-07
 ~~~~~~~~~~~~~~~~~~
@@ -1738,7 +1746,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-84:
+.. _section-85:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1750,7 +1758,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-85:
+.. _section-86:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -1771,7 +1779,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-86:
+.. _section-87:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -1791,7 +1799,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-87:
+.. _section-88:
 
 0.4.1.1
 ^^^^^^^
@@ -1804,7 +1812,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-88:
+.. _section-89:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -1823,7 +1831,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-89:
+.. _section-90:
 
 0.4.0 - 2014-06-08
 ~~~~~~~~~~~~~~~~~~

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.23.6"
+__version__ = "0.23.7"


### PR DESCRIPTION
Bug fixes for py3.5. This will be the last version of lifelines that supports Python 3.5.


closes #784 