### PR TITLE
v0.23.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+#### 0.23.9 - 2020-01-28
+
+##### Bug fixes
+ - fixed important error when a parametric regression model would not assign the correct labels to fitted
+parameters' variances. See more here: https://github.com/CamDavidsonPilon/lifelines/issues/931. Users of `GeneralizedGammaRegressionFitter` and any custom regression models should update their code as soon as possible.
+
+
 #### 0.23.8 - 2020-01-21
 
 ##### Bug fixes

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,8 +1,24 @@
 Changelog
 ---------
 
+0.23.9 - 2020-01-28
+^^^^^^^^^^^^^^^^^^^
+
+Bug fixes
+'''''''''
+
+-  fixed important error when a parametric regression model would not
+   assign the correct labels to fitted parameters’ variances. See more
+   here: https://github.com/CamDavidsonPilon/lifelines/issues/931. Users
+   of ``GeneralizedGammaRegressionFitter`` and any custom regression
+   models should update their code as soon as possible.
+
+.. _section-1:
+
 0.23.8 - 2020-01-21
 ^^^^^^^^^^^^^^^^^^^
+
+.. _bug-fixes-1:
 
 Bug fixes
 '''''''''
@@ -13,14 +29,14 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-1:
+.. _section-2:
 
 0.23.7 - 2020-01-14
 ^^^^^^^^^^^^^^^^^^^
 
 Bug fixes for py3.5.
 
-.. _section-2:
+.. _section-3:
 
 0.23.6 - 2020-01-07
 ^^^^^^^^^^^^^^^^^^^
@@ -37,7 +53,7 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-3:
+.. _section-4:
 
 0.23.5 - 2020-01-05
 ^^^^^^^^^^^^^^^^^^^
@@ -51,7 +67,7 @@ New features
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -61,14 +77,14 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-4:
+.. _section-5:
 
 0.23.4 - 2019-12-15
 ^^^^^^^^^^^^^^^^^^^
 
 -  Bug fix for PyPI
 
-.. _section-5:
+.. _section-6:
 
 0.23.3 - 2019-12-11
 ^^^^^^^^^^^^^^^^^^^
@@ -80,7 +96,7 @@ New features
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
@@ -88,7 +104,7 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-6:
+.. _section-7:
 
 0.23.2 - 2019-12-07
 ^^^^^^^^^^^^^^^^^^^
@@ -105,7 +121,7 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -114,7 +130,7 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-7:
+.. _section-8:
 
 0.23.1 - 2019-11-27
 ^^^^^^^^^^^^^^^^^^^
@@ -129,7 +145,7 @@ New features
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -141,7 +157,7 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-8:
+.. _section-9:
 
 0.23.0 - 2019-11-17
 ^^^^^^^^^^^^^^^^^^^
@@ -155,7 +171,7 @@ New features
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
@@ -175,7 +191,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-9:
+.. _section-10:
 
 0.22.10 - 2019-11-08
 ^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +199,7 @@ API Changes
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -193,12 +209,12 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-10:
+.. _section-11:
 
 0.22.9 - 2019-10-30
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
@@ -210,7 +226,7 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-11:
+.. _section-12:
 
 0.22.8 - 2019-10-06
 ^^^^^^^^^^^^^^^^^^^
@@ -225,14 +241,14 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-12:
+.. _section-13:
 
 0.22.7 - 2019-09-29
 ^^^^^^^^^^^^^^^^^^^
@@ -245,7 +261,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
@@ -264,7 +280,7 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-13:
+.. _section-14:
 
 0.22.6 - 2019-09-25
 ^^^^^^^^^^^^^^^^^^^
@@ -276,7 +292,7 @@ New features
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
@@ -292,7 +308,7 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-14:
+.. _section-15:
 
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
@@ -306,7 +322,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
@@ -323,7 +339,7 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-15:
+.. _section-16:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
@@ -347,7 +363,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
@@ -355,7 +371,7 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-16:
+.. _section-17:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
@@ -384,7 +400,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
@@ -396,7 +412,7 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-17:
+.. _section-18:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
@@ -408,7 +424,7 @@ New features
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 '''''''''
@@ -419,7 +435,7 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-18:
+.. _section-19:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
@@ -452,7 +468,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 '''''''''
@@ -462,7 +478,7 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-19:
+.. _section-20:
 
 0.22.0 - 2019-07-03
 ~~~~~~~~~~~~~~~~~~~
@@ -501,7 +517,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 '''''''''
@@ -510,7 +526,7 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-20:
+.. _section-21:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
@@ -524,7 +540,7 @@ New features
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 '''''''''
@@ -534,7 +550,7 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-21:
+.. _section-22:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
@@ -553,14 +569,14 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 '''''''''
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-22:
+.. _section-23:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
@@ -589,12 +605,12 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 '''''''''
 
-.. _section-23:
+.. _section-24:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
@@ -616,14 +632,14 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
 '''''''''
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-24:
+.. _section-25:
 
 0.21.0 - 2019-04-12
 ~~~~~~~~~~~~~~~~~~~
@@ -653,7 +669,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
 '''''''''
@@ -663,7 +679,7 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-25:
+.. _section-26:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
@@ -685,7 +701,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
 '''''''''
@@ -694,7 +710,7 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-26:
+.. _section-27:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
@@ -718,7 +734,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
 '''''''''
@@ -727,7 +743,7 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-27:
+.. _section-28:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
@@ -745,7 +761,7 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-28:
+.. _section-29:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
@@ -774,7 +790,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
 '''''''''
@@ -790,7 +806,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-29:
+.. _section-30:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -814,7 +830,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-30:
+.. _section-31:
 
 0.20.0 - 2019-03-05
 ~~~~~~~~~~~~~~~~~~~
@@ -843,14 +859,14 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-31:
+.. _section-32:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
@@ -865,19 +881,19 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-32:
+.. _section-33:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-33:
+.. _section-34:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
@@ -894,7 +910,7 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-34:
+.. _section-35:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
@@ -907,7 +923,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
 '''''''''
@@ -917,7 +933,7 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-35:
+.. _section-36:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
@@ -939,7 +955,7 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-36:
+.. _section-37:
 
 0.19.0 - 2019-02-20
 ~~~~~~~~~~~~~~~~~~~
@@ -983,7 +999,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug Fixes
 '''''''''
@@ -1000,7 +1016,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-37:
+.. _section-38:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -1010,7 +1026,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-38:
+.. _section-39:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1031,7 +1047,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-39:
+.. _section-40:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -1041,7 +1057,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-40:
+.. _section-41:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -1051,7 +1067,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-41:
+.. _section-42:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1067,7 +1083,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-42:
+.. _section-43:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1078,7 +1094,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-43:
+.. _section-44:
 
 0.18.0 - 2019-01-31
 ~~~~~~~~~~~~~~~~~~~
@@ -1115,7 +1131,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-44:
+.. _section-45:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1123,7 +1139,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-45:
+.. _section-46:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -1135,7 +1151,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-46:
+.. _section-47:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1143,7 +1159,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-47:
+.. _section-48:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -1154,7 +1170,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-48:
+.. _section-49:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1171,7 +1187,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-49:
+.. _section-50:
 
 0.17.0 - 2019-01-11
 ~~~~~~~~~~~~~~~~~~~
@@ -1192,7 +1208,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-50:
+.. _section-51:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1200,7 +1216,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-51:
+.. _section-52:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1211,14 +1227,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-52:
+.. _section-53:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-53:
+.. _section-54:
 
 0.16.0 - 2019-01-01
 ~~~~~~~~~~~~~~~~~~~
@@ -1254,7 +1270,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-54:
+.. _section-55:
 
 0.15.4
 ^^^^^^
@@ -1262,14 +1278,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-55:
+.. _section-56:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-56:
+.. _section-57:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1280,7 +1296,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-57:
+.. _section-58:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1289,7 +1305,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-58:
+.. _section-59:
 
 0.15.0 - 2018-11-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1360,7 +1376,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-59:
+.. _section-60:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1368,7 +1384,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-60:
+.. _section-61:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1376,7 +1392,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-61:
+.. _section-62:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1393,7 +1409,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-62:
+.. _section-63:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1405,7 +1421,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-63:
+.. _section-64:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1413,7 +1429,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-64:
+.. _section-65:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1431,7 +1447,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-65:
+.. _section-66:
 
 0.14.0 - 2018-03-03
 ~~~~~~~~~~~~~~~~~~~
@@ -1453,7 +1469,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-66:
+.. _section-67:
 
 0.13.0 - 2017-12-22
 ~~~~~~~~~~~~~~~~~~~
@@ -1482,7 +1498,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-67:
+.. _section-68:
 
 0.12.0
 ~~~~~~
@@ -1499,7 +1515,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-68:
+.. _section-69:
 
 0.11.3
 ^^^^^^
@@ -1511,7 +1527,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-69:
+.. _section-70:
 
 0.11.2
 ^^^^^^
@@ -1519,14 +1535,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-70:
+.. _section-71:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-71:
+.. _section-72:
 
 0.11.0 - 2017-06-21
 ~~~~~~~~~~~~~~~~~~~
@@ -1540,14 +1556,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-72:
+.. _section-73:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-73:
+.. _section-74:
 
 0.10.0
 ~~~~~~
@@ -1562,7 +1578,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-74:
+.. _section-75:
 
 0.9.4
 ^^^^^
@@ -1585,7 +1601,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-75:
+.. _section-76:
 
 0.9.2
 ^^^^^
@@ -1594,7 +1610,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-76:
+.. _section-77:
 
 0.9.1
 ^^^^^
@@ -1602,7 +1618,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-77:
+.. _section-78:
 
 0.9.0
 ~~~~~
@@ -1618,7 +1634,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-78:
+.. _section-79:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -1635,7 +1651,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-79:
+.. _section-80:
 
 0.8.0
 ~~~~~
@@ -1654,7 +1670,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-80:
+.. _section-81:
 
 0.7.1
 ^^^^^
@@ -1673,7 +1689,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-81:
+.. _section-82:
 
 0.7.0 - 2015-03-01
 ~~~~~~~~~~~~~~~~~~
@@ -1692,7 +1708,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-82:
+.. _section-83:
 
 0.6.1
 ^^^^^
@@ -1704,7 +1720,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-83:
+.. _section-84:
 
 0.6.0 - 2015-02-04
 ~~~~~~~~~~~~~~~~~~
@@ -1727,7 +1743,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-84:
+.. _section-85:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1748,7 +1764,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-85:
+.. _section-86:
 
 0.5.0 - 2014-12-07
 ~~~~~~~~~~~~~~~~~~
@@ -1761,7 +1777,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-86:
+.. _section-87:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1773,7 +1789,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-87:
+.. _section-88:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -1794,7 +1810,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-88:
+.. _section-89:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -1814,7 +1830,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-89:
+.. _section-90:
 
 0.4.1.1
 ^^^^^^^
@@ -1827,7 +1843,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-90:
+.. _section-91:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -1846,7 +1862,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-91:
+.. _section-92:
 
 0.4.0 - 2014-06-08
 ~~~~~~~~~~~~~~~~~~

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1757,7 +1757,7 @@ class ParametricRegressionFitter(RegressionFitter):
             if self.robust:
                 se = np.sqrt(self._compute_sandwich_errors(Ts, E, weights, entries, Xs).diagonal())
             else:
-                se = np.sqrt(self.variance_matrix_.values.diagonal())
+                se = np.sqrt(self.variance_matrix_.diagonal())
             return pd.Series(se, name="se", index=self.params_.index)
 
     def _compute_sandwich_errors(self, Ts, E, weights, entries, Xs):

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -916,9 +916,6 @@ class ParametricUnivariateFitter(UnivariateFitter):
                 )
                 warnings.warn(warning_text, utils.StatisticalWarning)
 
-        self.variance_matrix_ = pd.DataFrame(
-            self.variance_matrix_, index=_fitted_parameter_names, cols=_fitted_parameter_names
-        )
         self._update_docstrings()
 
         self.survival_function_ = self.survival_function_at_times(self.timeline).to_frame()
@@ -1619,7 +1616,7 @@ class ParametricRegressionFitter(RegressionFitter):
         _params = np.concatenate([_params[k] for k in self.regressors.keys()])
         self.params_ = _params / self._norm_std
 
-        self.variance_matrix_ = pd.DataFrame(self._compute_variance_matrix(), index=_index, columns=_index)
+        self.variance_matrix_ = self._compute_variance_matrix()
         self.standard_errors_ = self._compute_standard_errors(
             Ts, E.values, weights.values, entries.values, self._create_Xs_dict(df)
         )

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1500,7 +1500,7 @@ class TestParametricRegressionFitter:
         cb.fit(rossi, "week", "arrest", regressors={"lambda_": rossi.columns, "rho_": ["_int"]})
         wf.fit(rossi, "week", "arrest")
 
-        assert_frame_equal(cb.summary.loc["lambda_"], wf.summary.loc["lambda_"], check_less_precise=2)
+        assert_frame_equal(cb.summary.loc["lambda_"], wf.summary.loc["lambda_"], check_less_precise=1)
         npt.assert_allclose(cb.log_likelihood_, wf.log_likelihood_)
 
         cb.fit_left_censoring(rossi, "week", "arrest", regressors={"lambda_": rossi.columns, "rho_": ["_int"]})
@@ -1561,14 +1561,14 @@ class TestCustomRegressionModel:
 
     def test_reparameterization_flips_the_sign(self, rossi):
 
-        covariates = {"lambda_": rossi.columns, "rho_": ["intercept"], "beta_": ["intercept", "fin"]}
+        regressors = {"lambda_": rossi.columns, "rho_": ["intercept"], "beta_": ["intercept", "fin"]}
 
         cmA = CureModelA()
         cmB = CureModelB()
         cmC = CureModelC()
 
-        cmA.fit(rossi, "week", event_col="arrest", regressors=covariates)
-        cmB.fit(rossi, "week", event_col="arrest", regressors=covariates)
+        cmA.fit(rossi, "week", event_col="arrest", regressors=regressors)
+        cmB.fit(rossi, "week", event_col="arrest", regressors=regressors)
         cmC.fit(
             rossi,
             "week",
@@ -1577,7 +1577,7 @@ class TestCustomRegressionModel:
         )
         assert_frame_equal(cmA.summary.loc["lambda_"], cmB.summary.loc["lambda_"])
         assert_frame_equal(cmA.summary.loc["rho_"], cmB.summary.loc["rho_"])
-        assert_frame_equal(cmC.summary.loc["beta_"], cmB.summary.loc["beta_"])
+        assert_frame_equal(cmC.summary, cmB.summary)
         assert_series_equal(cmA.params_.loc["beta_"], -cmB.params_.loc["beta_"])
 
 

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1548,7 +1548,7 @@ class CureModelB(ParametricRegressionFitter):
 
 
 class CureModelC(CureModelB):
-    # notice the c vs 1-c in the return statement
+    # shuffle these parameter names - shouldn't change anything.
     _fitted_parameter_names = ["lambda_", "rho_", "beta_"]
 
 

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.23.8"
+__version__ = "0.23.9"


### PR DESCRIPTION
#### 0.23.9 - 2020-01-28

##### Bug fixes
 - fixed important error when a parametric regression model would not assign the correct labels to fitted
parameters' variances. See more here: https://github.com/CamDavidsonPilon/lifelines/issues/931. Users of `GeneralizedGammaRegressionFitter` and any custom regression models should update their code as soon as possible.

closes #931 again