### PR TITLE
Remove nested rst formatting from contributing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,8 +34,8 @@ There are 3 different ways to format your code.
    * `make lint`
 2. Call `black` directly and pass the correct line length.
    * `black . -l 120`
-3. Have you code formatted automatically during commit with the `pre-commit` hook.
-   * stage and commit your unformatted changes: `git commit -m "your_commit_message"`
+3. Have your code formatted automatically during commit with the `pre-commit` hook.
+   * Stage and commit your unformatted changes: `git commit -m "your_commit_message"`
    * Code that needs to be formatted will "fail" the commit hooks and be formatted for you.
    * Stage the newly formatted python code: `git add *.py`
    * Recall your original commit command and commit again: `git commit -m "your_commit_message"`

--- a/docs/Contributing.rst
+++ b/docs/Contributing.rst
@@ -44,29 +44,40 @@ Setting up a lifelines development environment
    environment <https://realpython.com/python-virtual-environments-a-primer/>`__
    (if you plan to use one).
 2. Install the development requirements and
-   ```pre-commit`` <https://pre-commit.com>`__ hooks. If you are on Mac,
+   `pre-commit <https://pre-commit.com>`__ hooks. If you are on Mac,
    Linux, or `Windows
-   ``WSL`` <https://docs.microsoft.com/en-us/windows/wsl/faq>`__ you can
+   WSL <https://docs.microsoft.com/en-us/windows/wsl/faq>`__ you can
    use the provided
-   ```Makefile`` <https://github.com/CamDavidsonPilon/lifelines/blob/master/Makefile>`__.
+   `Makefile <https://github.com/CamDavidsonPilon/lifelines/blob/master/Makefile>`__.
    Just type ``make`` into the console and you’re ready to start
    developing. This will also install the dev-requirements.
 
 Formatting
 ~~~~~~~~~~
 
-``lifelines`` uses the ```black`` <https://github.com/ambv/black>`__
-python formatter. There are 3 different ways to format your code. 1. Use
-the
-```Makefile`` <https://github.com/CamDavidsonPilon/lifelines/blob/master/Makefile>`__.
-\* ``make lint`` 2. Call ``black`` directly and pass the correct line
-length. \* ``black . -l 120`` 3. Have you code formatted automatically
-during commit with the ``pre-commit`` hook. \* stage and commit your
-unformatted changes: ``git commit -m "your_commit_message"`` \* Code
-that needs to be formatted will “fail” the commit hooks and be formatted
-for you. \* Stage the newly formatted python code: ``git add *.py`` \*
-Recall your original commit command and commit again:
-``git commit -m "your_commit_message"``
+``lifelines`` uses the `black <https://github.com/ambv/black>`__
+python formatter. There are 3 different ways to format your code.
+
+1. Use the
+   `Makefile <https://github.com/CamDavidsonPilon/lifelines/blob/master/Makefile>`__.
+
+   * ``make lint``
+
+2. Call ``black`` directly and pass the correct line
+   length.
+
+   * ``black . -l 120``
+3. Have your code formatted automatically
+   during commit with the ``pre-commit`` hook.
+
+   * Stage and commit your unformatted changes:
+     ``git commit -m "your_commit_message"``
+   * Code that needs to be formatted will “fail” the commit hooks and be
+     formatted for you.
+   * Stage the newly formatted python code:
+     ``git add *.py``
+   * Recall your original commit command and commit again:
+     ``git commit -m "your_commit_message"``
 
 Running the tests
 ~~~~~~~~~~~~~~~~~

--- a/docs/Contributing.rst
+++ b/docs/Contributing.rst
@@ -61,29 +61,33 @@ python formatter. There are 3 different ways to format your code.
 1. Use the
    `Makefile <https://github.com/CamDavidsonPilon/lifelines/blob/master/Makefile>`__.
 
-   * ``make lint``
+    ``make lint``
 
 2. Call ``black`` directly and pass the correct line
    length.
 
-   * ``black . -l 120``
+    ``black . -l 120``
+
 3. Have your code formatted automatically
    during commit with the ``pre-commit`` hook.
 
    * Stage and commit your unformatted changes:
-     ``git commit -m "your_commit_message"``
+
+      ``git commit -m "your_commit_message"``
+
    * Code that needs to be formatted will “fail” the commit hooks and be
      formatted for you.
    * Stage the newly formatted python code:
-     ``git add *.py``
+
+      ``git add *.py``
+
    * Recall your original commit command and commit again:
-     ``git commit -m "your_commit_message"``
+
+      ``git commit -m "your_commit_message"``
 
 Running the tests
 ~~~~~~~~~~~~~~~~~
 
 You can optionally run the test suite after install with
 
-::
-
-   py.test
+ ``py.test``


### PR DESCRIPTION
The formatting in the bottom sections of the ['Contributing' page on readthedocs](https://lifelines.readthedocs.io/en/latest/Contributing.html#setting-up-a-lifelines-development-environment) is broken, resulting in the display of formatting characters and full urls. The contents should instead mirror the [github contributing page](https://github.com/CamDavidsonPilon/lifelines/blob/master/.github/CONTRIBUTING.md). The problems mostly stem from the fact that (unlike markdown) rst formatting cannot be nested, so you can't have something that's both italic and a link.

This PR is an example in one possible way to restructure things such that the contents appear more in line with the github based 'contributing' page, plus a couple of minor typo fixes.