### PR TITLE
Add Python 3.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
    - "3.5"
    - "3.6"
    - "3.7"
+   - "3.8"
+   - "3.9-dev"
 env:
   matrix:
     - export PANDAS_VERSION=0.23.4     && export NUMPY_VERSION=1.17.3

--- a/lifelines/datasets/__init__.py
+++ b/lifelines/datasets/__init__.py
@@ -90,7 +90,7 @@ def load_holly_molly_polly(**kwargs):
         4  P       1        1            0          20   0   20
 
     """
-    return _load_dataset("holly_molly_polly.tsv", sep="\s", **kwargs)
+    return _load_dataset("holly_molly_polly.tsv", sep=r"\s", **kwargs)
 
 
 def load_leukemia(**kwargs):

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -4,7 +4,8 @@ import warnings
 # pylint: disable=wrong-import-position
 warnings.simplefilter(action="ignore", category=DeprecationWarning)
 
-from collections import Counter, Iterable
+from collections import Counter
+from collections.abc import Iterable
 import os
 import pickle
 from itertools import combinations

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering",
 ]
 LICENSE = "MIT"


### PR DESCRIPTION
* Import collections from ABC instead of collections since it was removed in Python 3.9.
* Use raw string to fix a deprecation warning regrading invalid escape sequences.