### PR TITLE
Updated printer.py (LaTeX table with proper decimals)

### DIFF
--- a/lifelines/utils/printer.py
+++ b/lifelines/utils/printer.py
@@ -47,7 +47,8 @@ class Printer:
         print(self.to_latex())
 
     def to_latex(self):
-        return self.model.summary.to_latex()
+        decimals = self.decimals
+        return self.model.summary.to_latex(float_format="%." + str(decimals) + "f")
 
     def html_print_inside_jupyter(self):
         from IPython.display import HTML, display


### PR DESCRIPTION
Printing a CPH coefficient table is done using [`.to_latex()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_latex.html) (with no parameters). However, this means that the printed number have all decimals. With this fix, the number of printed decimals corresponds to the defined parameter `decimals`.