### PR TITLE
Use fit options from base fitter

### DIFF
--- a/lifelines/fitters/mixture_cure_fitter.py
+++ b/lifelines/fitters/mixture_cure_fitter.py
@@ -82,6 +82,7 @@ class MixtureCureFitter(ParametricUnivariateFitter):
 
         self._fitted_parameter_names = [self._CURED_FRACTION_PARAMETER_NAME] + base_fitter._fitted_parameter_names
         self._bounds = [(0, 1)] + base_fitter._bounds
+        self._scipy_fit_options = base_fitter._scipy_fit_options
         super().__init__(*args, **kwargs)
 
     def _fit(self, *args, **kwargs):


### PR DESCRIPTION
The MixtureCureFitter did not use the fit options of the base fitter. It should do so, so that it can take advantage of any necessary settings. The most obvious example of this is when the base_fitter=WeibullFitter - see new test for the rest.