### PR TITLE
V0.24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+[ ] tests for infs in GGregresssion
+[ ] test warning is thrown in GGregresssion.predict_median
+[ ] .score() for interval censored models
+[ ] compare interval tests again
+[ ] .fit_interval_censoring(df, ancillary_df=True) vs .fit_interval_censoring(df, ancillary_df=df)
+
 #### 0.24.3 - 2020-03-25
 
 ##### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Changelog
 
-[ ] tests for infs in GGregresssion
-[ ] test warning is thrown in GGregresssion.predict_median
-[ ] .score() for interval censored models
-[ ] compare interval tests again
-[ ] .fit_interval_censoring(df, ancillary_df=True) vs .fit_interval_censoring(df, ancillary_df=df)
+#### 0.24.4 - 2020-04-13
+
+##### Bug fixes
+ - Improved stability of interval censoring in parametric models.
+ - setting a dataframe in `ancillary_df` works for interval censoring
+ - `.score` works for interval censored models
 
 #### 0.24.3 - 2020-03-25
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.24.4 - 2020-04-13
+^^^^^^^^^^^^^^^^^^^
+
+Bug fixes
+'''''''''
+
+-  Improved stability of interval censoring in parametric models.
+-  setting a dataframe in ``ancillary_df`` works for interval censoring
+-  ``.score`` works for interval censored models
+
+.. _section-1:
+
 0.24.3 - 2020-03-25
 ^^^^^^^^^^^^^^^^^^^
 
@@ -12,18 +24,20 @@ New features
    the hazard ratio would be at previous times. This is useful because
    the final hazard ratio is some weighted average of these.
 
+.. _bug-fixes-1:
+
 Bug fixes
 '''''''''
 
 -  Fixed error in HTML printer that was hiding concordance index
    information.
 
-.. _section-1:
+.. _section-2:
 
 0.24.2 - 2020-03-15
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -35,7 +49,7 @@ Bug fixes
 -  Fixed a keyword bug in ``plot_covariate_groups`` for parametric
    models.
 
-.. _section-2:
+.. _section-3:
 
 0.24.1 - 2020-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -48,14 +62,14 @@ New features
 -  Stability improvements for GeneralizedGammaRegressionFitter and
    CoxPHFitter with spline estimation.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
 
 -  Fixed bug with plotting hazards in NelsonAalenFitter.
 
-.. _section-3:
+.. _section-4:
 
 0.24.0 - 2020-02-20
 ^^^^^^^^^^^^^^^^^^^
@@ -114,7 +128,7 @@ API Changes
    to ``scoring_method``.
 -  removed ``_score_`` and ``path`` from Cox model.
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -127,12 +141,12 @@ Bug fixes
 -  Cox models now incorporate any penalizers in their
    ``log_likelihood_``
 
-.. _section-4:
+.. _section-5:
 
 0.23.9 - 2020-01-28
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -143,12 +157,12 @@ Bug fixes
    of ``GeneralizedGammaRegressionFitter`` and any custom regression
    models should update their code as soon as possible.
 
-.. _section-5:
+.. _section-6:
 
 0.23.8 - 2020-01-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
@@ -159,14 +173,14 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-6:
+.. _section-7:
 
 0.23.7 - 2020-01-14
 ^^^^^^^^^^^^^^^^^^^
 
 Bug fixes for py3.5.
 
-.. _section-7:
+.. _section-8:
 
 0.23.6 - 2020-01-07
 ^^^^^^^^^^^^^^^^^^^
@@ -185,7 +199,7 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-8:
+.. _section-9:
 
 0.23.5 - 2020-01-05
 ^^^^^^^^^^^^^^^^^^^
@@ -199,7 +213,7 @@ New features
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -209,14 +223,14 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-9:
+.. _section-10:
 
 0.23.4 - 2019-12-15
 ^^^^^^^^^^^^^^^^^^^
 
 -  Bug fix for PyPI
 
-.. _section-10:
+.. _section-11:
 
 0.23.3 - 2019-12-11
 ^^^^^^^^^^^^^^^^^^^
@@ -228,7 +242,7 @@ New features
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
@@ -236,7 +250,7 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-11:
+.. _section-12:
 
 0.23.2 - 2019-12-07
 ^^^^^^^^^^^^^^^^^^^
@@ -253,7 +267,7 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
@@ -262,7 +276,7 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-12:
+.. _section-13:
 
 0.23.1 - 2019-11-27
 ^^^^^^^^^^^^^^^^^^^
@@ -277,7 +291,7 @@ New features
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
@@ -289,7 +303,7 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-13:
+.. _section-14:
 
 0.23.0 - 2019-11-17
 ^^^^^^^^^^^^^^^^^^^
@@ -303,7 +317,7 @@ New features
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
@@ -325,7 +339,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-14:
+.. _section-15:
 
 0.22.10 - 2019-11-08
 ^^^^^^^^^^^^^^^^^^^^
@@ -333,7 +347,7 @@ API Changes
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
@@ -343,12 +357,12 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-15:
+.. _section-16:
 
 0.22.9 - 2019-10-30
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
@@ -360,7 +374,7 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-16:
+.. _section-17:
 
 0.22.8 - 2019-10-06
 ^^^^^^^^^^^^^^^^^^^
@@ -375,14 +389,14 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-17:
+.. _section-18:
 
 0.22.7 - 2019-09-29
 ^^^^^^^^^^^^^^^^^^^
@@ -395,7 +409,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 '''''''''
@@ -414,7 +428,7 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-18:
+.. _section-19:
 
 0.22.6 - 2019-09-25
 ^^^^^^^^^^^^^^^^^^^
@@ -426,7 +440,7 @@ New features
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 '''''''''
@@ -442,7 +456,7 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-19:
+.. _section-20:
 
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
@@ -456,7 +470,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 '''''''''
@@ -473,7 +487,7 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-20:
+.. _section-21:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
@@ -497,7 +511,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 '''''''''
@@ -505,7 +519,7 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-21:
+.. _section-22:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
@@ -534,7 +548,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 '''''''''
@@ -546,7 +560,7 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-22:
+.. _section-23:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
@@ -558,7 +572,7 @@ New features
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 '''''''''
@@ -569,7 +583,7 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-23:
+.. _section-24:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
@@ -602,7 +616,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
 '''''''''
@@ -612,7 +626,7 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-24:
+.. _section-25:
 
 0.22.0 - 2019-07-03
 ^^^^^^^^^^^^^^^^^^^
@@ -651,7 +665,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
 '''''''''
@@ -660,7 +674,7 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-25:
+.. _section-26:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
@@ -674,7 +688,7 @@ New features
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
 '''''''''
@@ -684,7 +698,7 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-26:
+.. _section-27:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
@@ -703,14 +717,14 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
 '''''''''
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-27:
+.. _section-28:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
@@ -739,12 +753,12 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
 '''''''''
 
-.. _section-28:
+.. _section-29:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
@@ -766,14 +780,14 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
 '''''''''
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-29:
+.. _section-30:
 
 0.21.0 - 2019-04-12
 ^^^^^^^^^^^^^^^^^^^
@@ -803,7 +817,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
 '''''''''
@@ -813,7 +827,7 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-30:
+.. _section-31:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
@@ -835,7 +849,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
 '''''''''
@@ -844,7 +858,7 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-31:
+.. _section-32:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
@@ -868,7 +882,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug fixes
 '''''''''
@@ -877,7 +891,7 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-32:
+.. _section-33:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
@@ -895,7 +909,7 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-33:
+.. _section-34:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
@@ -924,7 +938,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-29:
+.. _bug-fixes-30:
 
 Bug fixes
 '''''''''
@@ -940,7 +954,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-34:
+.. _section-35:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -964,7 +978,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-35:
+.. _section-36:
 
 0.20.0 - 2019-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -993,14 +1007,14 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-30:
+.. _bug-fixes-31:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-36:
+.. _section-37:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
@@ -1015,19 +1029,19 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-37:
+.. _section-38:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-31:
+.. _bug-fixes-32:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-38:
+.. _section-39:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1044,7 +1058,7 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-39:
+.. _section-40:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1057,7 +1071,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-32:
+.. _bug-fixes-33:
 
 Bug fixes
 '''''''''
@@ -1067,7 +1081,7 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-40:
+.. _section-41:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
@@ -1089,7 +1103,7 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-41:
+.. _section-42:
 
 0.19.0 - 2019-02-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1133,7 +1147,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-33:
+.. _bug-fixes-34:
 
 Bug Fixes
 '''''''''
@@ -1150,7 +1164,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-42:
+.. _section-43:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -1160,7 +1174,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-43:
+.. _section-44:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1181,7 +1195,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-44:
+.. _section-45:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -1191,7 +1205,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-45:
+.. _section-46:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -1201,7 +1215,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-46:
+.. _section-47:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1217,7 +1231,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-47:
+.. _section-48:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1228,7 +1242,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-48:
+.. _section-49:
 
 0.18.0 - 2019-01-31
 ^^^^^^^^^^^^^^^^^^^
@@ -1265,7 +1279,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-49:
+.. _section-50:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1273,7 +1287,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-50:
+.. _section-51:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -1285,7 +1299,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-51:
+.. _section-52:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1293,7 +1307,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-52:
+.. _section-53:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -1304,7 +1318,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-53:
+.. _section-54:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1321,7 +1335,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-54:
+.. _section-55:
 
 0.17.0 - 2019-01-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1342,7 +1356,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-55:
+.. _section-56:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1350,7 +1364,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-56:
+.. _section-57:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1361,14 +1375,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-57:
+.. _section-58:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-58:
+.. _section-59:
 
 0.16.0 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1404,7 +1418,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-59:
+.. _section-60:
 
 0.15.4
 ^^^^^^
@@ -1412,14 +1426,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-60:
+.. _section-61:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-61:
+.. _section-62:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1430,7 +1444,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-62:
+.. _section-63:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1439,7 +1453,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-63:
+.. _section-64:
 
 0.15.0 - 2018-11-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1510,7 +1524,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-64:
+.. _section-65:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1518,7 +1532,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-65:
+.. _section-66:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1526,7 +1540,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-66:
+.. _section-67:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1543,7 +1557,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-67:
+.. _section-68:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1555,7 +1569,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-68:
+.. _section-69:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1563,7 +1577,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-69:
+.. _section-70:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1581,7 +1595,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-70:
+.. _section-71:
 
 0.14.0 - 2018-03-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1603,7 +1617,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-71:
+.. _section-72:
 
 0.13.0 - 2017-12-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1632,7 +1646,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-72:
+.. _section-73:
 
 0.12.0
 ^^^^^^
@@ -1649,7 +1663,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-73:
+.. _section-74:
 
 0.11.3
 ^^^^^^
@@ -1661,7 +1675,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-74:
+.. _section-75:
 
 0.11.2
 ^^^^^^
@@ -1669,14 +1683,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-75:
+.. _section-76:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-76:
+.. _section-77:
 
 0.11.0 - 2017-06-21
 ^^^^^^^^^^^^^^^^^^^
@@ -1690,14 +1704,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-77:
+.. _section-78:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-78:
+.. _section-79:
 
 0.10.0
 ^^^^^^
@@ -1712,7 +1726,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-79:
+.. _section-80:
 
 0.9.4
 ^^^^^
@@ -1735,7 +1749,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-80:
+.. _section-81:
 
 0.9.2
 ^^^^^
@@ -1744,7 +1758,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-81:
+.. _section-82:
 
 0.9.1
 ^^^^^
@@ -1752,7 +1766,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-82:
+.. _section-83:
 
 0.9.0
 ^^^^^
@@ -1768,7 +1782,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-83:
+.. _section-84:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -1785,7 +1799,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-84:
+.. _section-85:
 
 0.8.0
 ^^^^^
@@ -1804,7 +1818,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-85:
+.. _section-86:
 
 0.7.1
 ^^^^^
@@ -1823,7 +1837,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-86:
+.. _section-87:
 
 0.7.0 - 2015-03-01
 ^^^^^^^^^^^^^^^^^^
@@ -1842,7 +1856,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-87:
+.. _section-88:
 
 0.6.1
 ^^^^^
@@ -1854,7 +1868,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-88:
+.. _section-89:
 
 0.6.0 - 2015-02-04
 ^^^^^^^^^^^^^^^^^^
@@ -1877,7 +1891,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-89:
+.. _section-90:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1898,7 +1912,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-90:
+.. _section-91:
 
 0.5.0 - 2014-12-07
 ^^^^^^^^^^^^^^^^^^
@@ -1911,7 +1925,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-91:
+.. _section-92:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1923,7 +1937,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-92:
+.. _section-93:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -1944,7 +1958,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-93:
+.. _section-94:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -1964,7 +1978,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-94:
+.. _section-95:
 
 0.4.1.1
 ^^^^^^^
@@ -1977,7 +1991,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-95:
+.. _section-96:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -1996,7 +2010,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-96:
+.. _section-97:
 
 0.4.0 - 2014-06-08
 ^^^^^^^^^^^^^^^^^^

--- a/docs/Examples.rst
+++ b/docs/Examples.rst
@@ -190,9 +190,9 @@ If using *lifelines* for prediction work, it's ideal that you perform some type 
     aaf_2 = AalenAdditiveFitter(coef_penalizer=10)
     cph = CoxPHFitter()
 
-    print(np.mean(k_fold_cross_validation(cph, df, duration_col='T', event_col='E')))
-    print(np.mean(k_fold_cross_validation(aaf_1, df, duration_col='T', event_col='E')))
-    print(np.mean(k_fold_cross_validation(aaf_2, df, duration_col='T', event_col='E')))
+    print(np.mean(k_fold_cross_validation(cph, df, duration_col='T', event_col='E', scoring_method="concordance_index")))
+    print(np.mean(k_fold_cross_validation(aaf_1, df, duration_col='T', event_col='E', scoring_method="concordance_index")))
+    print(np.mean(k_fold_cross_validation(aaf_2, df, duration_col='T', event_col='E', scoring_method="concordance_index")))
 
 From these results, Aalen's Additive model with a penalizer of 10 is best model of predicting future survival times.
 

--- a/lifelines/datasets/__init__.py
+++ b/lifelines/datasets/__init__.py
@@ -548,7 +548,8 @@ def load_lymph_node(**kwargs):
 
 def load_c_botulinum_lag_phase(**kwargs):
     """
-    A dataset from [1] that represents the duration of the lag phase for C. botulinum, measured in days. The data is left and right censored.
+    A dataset from [1] that represents the duration of the lag phase for C. botulinum, measured in days, at 30C. The data is left and right censored.
+    Note that the table does not have 6% NaCl, but the authors mention no growth occurred (we can infer lag time > 85D then)
 
     References
     -----------

--- a/lifelines/datasets/c_botulinum_lag_phase.csv
+++ b/lifelines/datasets/c_botulinum_lag_phase.csv
@@ -19,3 +19,8 @@ NaCl %,pH,lower_bound_days,upper_bound_days
 4,6.0,3.0,3.0
 4,5.5,7.0,7.0
 4,5.0,85.0,inf
+6,7.0,85.0,inf
+6,6.5,85.0,inf
+6,6.0,85.0,inf
+6,5.5,85.0,inf
+6,5.0,85.0,inf

--- a/lifelines/fitters/generalized_gamma_regression_fitter.py
+++ b/lifelines/fitters/generalized_gamma_regression_fitter.py
@@ -119,7 +119,7 @@ class GeneralizedGammaRegressionFitter(ParametricRegressionFitter):
             if utils.CensoringType.is_right_censoring(self):
                 uni_model.fit_right_censoring(Ts[0], event_observed=E, entry=entries, weights=weights)
             elif utils.CensoringType.is_interval_censoring(self):
-                uni_model.fit_interval_censoring(Ts[0], Ts[1], event_observed=E, entry=entries, weights=weights)
+                uni_model.fit_interval_censoring(Ts[0], Ts[1], entry=entries, weights=weights)
             elif utils.CensoringType.is_left_censoring(self):
                 uni_model.fit_left_censoring(Ts[1], event_observed=E, entry=entries, weights=weights)
 

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -99,7 +99,13 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter, ProportionalHazardMixin):
         rho_params = params["rho_"]
         rho_ = safe_exp(Xs["rho_"] @ rho_params)
 
-        return safe_exp(rho_ * (np.log(np.clip(T, 1e-25, np.inf)) - log_lambda_))
+        return safe_exp(rho_ * (np.log(np.clip(T, 1e-100, np.inf)) - log_lambda_))
+
+    def _survival_function(
+        self, params: Union[DictBox, Dict[str, np.array]], T: Union[float, np.array], Xs: DataframeSliceDict
+    ) -> Union[np.array, ArrayBox]:
+        ch = self._cumulative_hazard(params, T, Xs)
+        return safe_exp(-ch)
 
     def _log_hazard(
         self, params: Union[DictBox, Dict[str, np.array]], T: Union[float, np.array], Xs: DataframeSliceDict

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -38,6 +38,7 @@ from lifelines.utils import (
     ConvergenceError,
     median_survival_times,
     StatisticalWarning,
+    ApproximationWarning,
     qth_survival_time,
 )
 
@@ -77,6 +78,7 @@ from lifelines.datasets import (
     load_regression_dataset,
     load_stanford_heart_transplants,
     load_multicenter_aids_cohort_study,
+    load_c_botulinum_lag_phase,
     load_diabetes,
 )
 from lifelines.generate_datasets import (
@@ -1585,6 +1587,39 @@ class TestCustomRegressionModel:
         assert_frame_equal(cmC.summary, cmB.summary)
         assert_series_equal(cmA.params_.loc["beta_"], -cmB.params_.loc["beta_"])
 
+    def test_custom_regression_model_accepts_infs_in_interval_censoring(self):
+        df = load_c_botulinum_lag_phase()
+        df.loc[df["lower_bound_days"] == 0, "lower_bound_days"] += 0.0001
+
+        df["constant"] = 1.0
+
+        regressors = {"lambda_": ["constant"], "mu_": ["NaCl %", "pH", "constant"], "sigma_": ["constant"]}
+        gg = GeneralizedGammaRegressionFitter()
+        gg.fit_interval_censoring(df, "lower_bound_days", "upper_bound_days", regressors=regressors)
+        gg.print_summary()
+
+    def test_warning_is_thrown_in_predict_median(self, rossi):
+
+        rossi["constant"] = 1.0
+        regressors = {"lambda_": ["constant"], "mu_": ["age", "fin", "constant"], "sigma_": ["constant"]}
+
+        gg = GeneralizedGammaRegressionFitter()
+        gg.fit(rossi, "week", "arrest", regressors=regressors)
+
+        with pytest.warns(ApproximationWarning, match="Approximating"):
+            gg.predict_median(rossi)
+
+    def test_score_works_for_interval_censoring(self, rossi):
+        df = load_c_botulinum_lag_phase()
+        df.loc[df["lower_bound_days"] == 0, "lower_bound_days"] += 0.0001
+
+        df["constant"] = 1.0
+
+        regressors = {"lambda_": ["constant"], "mu_": ["NaCl %", "pH", "constant"], "sigma_": ["constant"]}
+        gg = GeneralizedGammaRegressionFitter()
+        gg.fit_interval_censoring(df, "lower_bound_days", "upper_bound_days", regressors=regressors)
+        gg.score(df)
+
 
 class TestRegressionFitters:
     @pytest.fixture
@@ -2445,6 +2480,12 @@ class TestWeibullAFTFitter:
 
         with pytest.raises(AssertionError):
             npt.assert_allclose(aft.summary.loc[("rho_", "gender"), "coef"], 0.1670, rtol=1e-4)
+
+    def test_interval_censoring_with_ancillary_df(self, aft):
+        df = load_c_botulinum_lag_phase()
+
+        aft.fit_interval_censoring(df, "lower_bound_days", "upper_bound_days", ancillary_df=df)
+        aft.fit_interval_censoring(df, "lower_bound_days", "upper_bound_days", ancillary_df=True)
 
     def test_aft_weibull_with_weights(self, rossi, aft):
         """

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -2447,7 +2447,7 @@ class TestWeibullAFTFitter:
         aft.fit_right_censoring(rossi, "week", event_col="arrest")
         right_censored_results = aft.summary.copy()
 
-        assert_frame_equal(interval_censored_results, right_censored_results, check_less_precise=3)
+        assert_frame_equal(interval_censored_results, right_censored_results, check_less_precise=2)
 
     def test_weibull_interval_censoring_inference_on_known_R_output(self, aft):
         """

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.24.3"
+__version__ = "0.24.4"


### PR DESCRIPTION
#### 0.24.4 - 2020-04-13

##### Bug fixes
 - Improved stability of interval censoring in parametric models.
 - setting a dataframe in `ancillary_df` works for interval censoring
 - `.score` works for interval censored models