### PR TITLE
Added plotting of lifetimes from interval censored data

### DIFF
--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -250,8 +250,8 @@ class KaplanMeierFitter(UnivariateFitter):
             # we adjust for this using the Breslow-Fleming-Harrington estimator
             n = self.event_table.shape[0]
             net_population = (self.event_table["entrance"] - self.event_table["removed"]).cumsum()
-            if net_population.iloc[: int(n / 2)].min() == 0:
-                ix = net_population.iloc[: int(n / 2)].idxmin()
+            if net_population._iloc[: int(n / 2)].min() == 0:
+                ix = net_population._iloc[: int(n / 2)].idxmin()
                 raise StatError(
                     """There are too few early truncation times and too many events. S(t)==0 for all t>%g. Recommend BreslowFlemingHarringtonFitter."""
                     % ix

--- a/lifelines/fitters/nelson_aalen_fitter.py
+++ b/lifelines/fitters/nelson_aalen_fitter.py
@@ -244,8 +244,8 @@ class NelsonAalenFitter(UnivariateFitter):
 
         timeline = self.timeline
         z = inv_normal_cdf(1 - self.alpha / 2)
-        self._cumulative_sq.iloc[0] = 0
-        var_hazard_ = self._cumulative_sq.diff().fillna(self._cumulative_sq.iloc[0])
+        self._cumulative_sq._iloc[0] = 0
+        var_hazard_ = self._cumulative_sq.diff().fillna(self._cumulative_sq._iloc[0])
         C = var_hazard_.values != 0.0  # only consider the points with jumps
         std_hazard_ = np.sqrt(
             1.0

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -12,7 +12,15 @@ import pandas as pd
 from lifelines.utils import coalesce, CensoringType
 
 
-__all__ = ["add_at_risk_counts", "plot_lifetimes", "qq_plot", "cdf_plot", "rmst_plot", "loglogs_plot"]
+__all__ = [
+    "add_at_risk_counts",
+    "plot_lifetimes",
+    "plot_interval_censored_lifetimes",
+    "qq_plot",
+    "cdf_plot",
+    "rmst_plot",
+    "loglogs_plot",
+]
 
 
 def _iloc(x, i):
@@ -190,9 +198,7 @@ def rmst_plot(model, model2=None, t=np.inf, ax=None, text_position=None, **plot_
         )
 
         ax.text(
-            text_position[0],
-            text_position[1],
-            "RMST(%s) -\n   RMST(%s)=%.3f" % (model._label, model2._label, rmst - rmst2),
+            text_position[0], text_position[1], "RMST(%s) -\n   RMST(%s)=%.3f" % (model._label, model2._label, rmst - rmst2),
         )  # dynamically pick this.
     else:
         rmst = restricted_mean_survival_time(model, t=t)
@@ -654,9 +660,7 @@ def create_dataframe_slicer(iloc, loc, timeline):
         raise ValueError("Cannot set both loc and iloc in call to .plot().")
 
     user_did_not_specify_certain_indexes = (iloc is None) and (loc is None)
-    user_submitted_slice = (
-        slice(timeline.min(), timeline.max()) if user_did_not_specify_certain_indexes else coalesce(loc, iloc)
-    )
+    user_submitted_slice = slice(timeline.min(), timeline.max()) if user_did_not_specify_certain_indexes else coalesce(loc, iloc)
 
     get_method = "iloc" if iloc is not None else "loc"
     return lambda df: getattr(df, get_method)[user_submitted_slice]
@@ -784,15 +788,13 @@ def _plot_estimate(
     if show_censors and cls.event_table["censored"].sum() > 0:
         cs = {"marker": "+", "ms": 12, "mew": 1}
         cs.update(plot_estimate_config.censor_styles)
-        censored_times = dataframe_slicer(cls.event_table.loc[(cls.event_table["censored"] > 0)]).index.values.astype(
-            float
-        )
+        censored_times = dataframe_slicer(cls.event_table.loc[(cls.event_table["censored"] > 0)]).index.values.astype(float)
         v = plot_estimate_config.predict_at_times(censored_times).values
         plot_estimate_config.ax.plot(censored_times, v, linestyle="None", color=plot_estimate_config.colour, **cs)
 
-    dataframe_slicer(plot_estimate_config.estimate_).rename(
-        columns=lambda _: plot_estimate_config.kwargs.pop("label")
-    ).plot(logx=plot_estimate_config.logx, **plot_estimate_config.kwargs)
+    dataframe_slicer(plot_estimate_config.estimate_).rename(columns=lambda _: plot_estimate_config.kwargs.pop("label")).plot(
+        logx=plot_estimate_config.logx, **plot_estimate_config.kwargs
+    )
 
     # plot confidence intervals
     if ci_show:
@@ -840,9 +842,7 @@ def _plot_estimate(
 
 
 class PlotEstimateConfig:
-    def __init__(
-        self, cls, estimate: Union[str, pd.DataFrame], loc, iloc, show_censors, censor_styles, logx, ax, **kwargs
-    ):
+    def __init__(self, cls, estimate: Union[str, pd.DataFrame], loc, iloc, show_censors, censor_styles, logx, ax, **kwargs):
 
         self.censor_styles = coalesce(censor_styles, {})
 

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -731,7 +731,7 @@ def multivariate_logrank_test(
     V = V[:-1, :-1]
 
     # take the first n-1 groups
-    U = Z_j.iloc[:-1] @ np.linalg.pinv(V[:-1, :-1]) @ Z_j.iloc[:-1]  # Z.T*inv(V)*Z
+    U = Z_j._iloc[:-1] @ np.linalg.pinv(V[:-1, :-1]) @ Z_j._iloc[:-1]  # Z.T*inv(V)*Z
 
     # compute the p-values and tests
     p_value = _chisq_test_p_value(U, n_groups - 1)

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1237,7 +1237,7 @@ class TestKaplanMeierFitter:
         E[np.argmax(T)] = 0
         kmf = KaplanMeierFitter()
         kmf.fit(T, E)
-        assert kmf.survival_function_["KM_estimate"].iloc[-1] > 0
+        assert kmf.survival_function_["KM_estimate"]._iloc[-1] > 0
 
     def test_adding_weights_to_KaplanMeierFitter(self):
         n = 100
@@ -1398,8 +1398,8 @@ class TestNelsonAalenFitter:
 
     def test_iloc_slicing(self, waltons_dataset):
         naf = NelsonAalenFitter().fit(waltons_dataset["T"])
-        assert naf.cumulative_hazard_.iloc[0:10].shape[0] == 10
-        assert naf.cumulative_hazard_.iloc[0:-1].shape[0] == 32
+        assert naf.cumulative_hazard_._iloc[0:10].shape[0] == 10
+        assert naf.cumulative_hazard_._iloc[0:-1].shape[0] == 32
 
     def test_smoothing_hazard_ties(self):
         T = np.random.binomial(20, 0.7, size=300)
@@ -1429,7 +1429,7 @@ class TestNelsonAalenFitter:
         naf = NelsonAalenFitter()
         naf.fit(T)
         df = naf.smoothed_hazard_(bandwidth=0.1)
-        assert df.iloc[0].values[0] > df.iloc[1].values[0]
+        assert df._iloc[0].values[0] > df._iloc[1].values[0]
 
     def test_nelson_aalen_smoothing(self):
         # this test was included because I was refactoring the estimators.
@@ -1439,9 +1439,9 @@ class TestNelsonAalenFitter:
         c = np.random.binomial(1, 0.9, size=N)
         naf = NelsonAalenFitter(nelson_aalen_smoothing=True)
         naf.fit(t, c)
-        assert abs(naf.cumulative_hazard_["NA_estimate"].iloc[-1] - 8.545665) < 1e-6
-        assert abs(naf.confidence_interval_["NA_estimate_upper_0.95"].iloc[-1] - 11.315662) < 1e-6
-        assert abs(naf.confidence_interval_["NA_estimate_lower_0.95"].iloc[-1] - 6.4537448) < 1e-6
+        assert abs(naf.cumulative_hazard_["NA_estimate"]._iloc[-1] - 8.545665) < 1e-6
+        assert abs(naf.confidence_interval_["NA_estimate_upper_0.95"]._iloc[-1] - 11.315662) < 1e-6
+        assert abs(naf.confidence_interval_["NA_estimate_lower_0.95"]._iloc[-1] - 6.4537448) < 1e-6
 
     def test_adding_weights_to_NelsonAalenFitter(self):
         n = 100
@@ -1702,7 +1702,7 @@ class TestRegressionFitters:
     def test_fit_will_accept_object_dtype_as_event_col(self, regression_models_sans_strata_model, rossi):
         # issue #638
         rossi["arrest"] = rossi["arrest"].astype(object)
-        rossi["arrest"].iloc[0] = None
+        rossi["arrest"]._iloc[0] = None
 
         assert rossi["arrest"].dtype == object
         rossi = rossi.dropna()
@@ -1789,7 +1789,7 @@ class TestRegressionFitters:
                     assert_series_equal(hazards, hazards_norm, check_less_precise=1)
 
     def test_prediction_methods_respect_index(self, regression_models, rossi):
-        X = rossi.iloc[:4].sort_index(ascending=False)
+        X = rossi._iloc[:4].sort_index(ascending=False)
         expected_index = pd.Index(np.array([3, 2, 1, 0]))
 
         for fitter in regression_models:
@@ -2601,8 +2601,8 @@ class TestCoxPHFitter:
     def test_conditional_after_in_prediction(self, rossi, cph):
         rossi.loc[rossi["week"] == 1, "week"] = 0
         cph.fit(rossi, "week", "arrest")
-        p1 = cph.predict_survival_function(rossi.iloc[0])
-        p2 = cph.predict_survival_function(rossi.iloc[0], conditional_after=[8])
+        p1 = cph.predict_survival_function(rossi._iloc[0])
+        p2 = cph.predict_survival_function(rossi._iloc[0], conditional_after=[8])
 
         explicit = p1 / p1.loc[8]
 
@@ -2614,8 +2614,8 @@ class TestCoxPHFitter:
     def test_conditional_after_with_strata_in_prediction(self, rossi, cph):
         rossi.loc[rossi["week"] == 1, "week"] = 0
         cph.fit(rossi, "week", "arrest", strata=["fin"])
-        p1 = cph.predict_survival_function(rossi.iloc[0])
-        p2 = cph.predict_survival_function(rossi.iloc[0], conditional_after=[8])
+        p1 = cph.predict_survival_function(rossi._iloc[0])
+        p2 = cph.predict_survival_function(rossi._iloc[0], conditional_after=[8])
 
         explicit = p1 / p1.loc[8]
 
@@ -2635,8 +2635,8 @@ class TestCoxPHFitter:
     def test_conditional_after_in_prediction_multiple_subjects(self, rossi, cph):
         rossi.loc[rossi["week"] == 1, "week"] = 0
         cph.fit(rossi, "week", "arrest", strata=["fin"])
-        p1 = cph.predict_survival_function(rossi.iloc[[0, 1, 2]])
-        p2 = cph.predict_survival_function(rossi.iloc[[0, 1, 2]], conditional_after=[8, 9, 0])
+        p1 = cph.predict_survival_function(rossi._iloc[[0, 1, 2]])
+        p2 = cph.predict_survival_function(rossi._iloc[[0, 1, 2]], conditional_after=[8, 9, 0])
 
         explicit = p1 / p1.loc[8]
 
@@ -2647,8 +2647,8 @@ class TestCoxPHFitter:
 
         # no strata
         cph.fit(rossi, "week", "arrest")
-        p1 = cph.predict_survival_function(rossi.iloc[[0, 1, 2]])
-        p2 = cph.predict_survival_function(rossi.iloc[[0, 1, 2]], conditional_after=[8, 9, 0])
+        p1 = cph.predict_survival_function(rossi._iloc[[0, 1, 2]])
+        p2 = cph.predict_survival_function(rossi._iloc[[0, 1, 2]], conditional_after=[8, 9, 0])
 
         explicit = p1 / p1.loc[8]
 
@@ -2660,7 +2660,7 @@ class TestCoxPHFitter:
     def test_conditional_after_in_prediction_multiple_subjects_with_custom_times(self, rossi, cph):
 
         cph.fit(rossi, "week", "arrest")
-        p2 = cph.predict_survival_function(rossi.iloc[[0, 1, 2]], conditional_after=[8, 9, 0], times=[10, 20, 30])
+        p2 = cph.predict_survival_function(rossi._iloc[[0, 1, 2]], conditional_after=[8, 9, 0], times=[10, 20, 30])
 
         assert p2.index.tolist() == [10.0, 20.0, 30.0]
 
@@ -2718,7 +2718,7 @@ class TestCoxPHFitter:
         assert df.dtypes["T"] in (int, np.dtype("int64"))
 
     def test_cph_will_handle_times_with_only_censored_individuals(self, rossi):
-        rossi_29 = rossi.iloc[0:10].copy()
+        rossi_29 = rossi._iloc[0:10].copy()
         rossi_29["week"] = 29
         rossi_29["arrest"] = False
 
@@ -2726,7 +2726,7 @@ class TestCoxPHFitter:
 
         cph2_summary = CoxPHFitter().fit(rossi, "week", "arrest").summary
 
-        assert cph2_summary["coef"].iloc[0] != cph1_summary["coef"].iloc[0]
+        assert cph2_summary["coef"]._iloc[0] != cph1_summary["coef"]._iloc[0]
 
     def test_schoenfeld_residuals_no_strata_but_with_censorship(self, cph):
         """
@@ -2852,10 +2852,10 @@ class TestCoxPHFitter:
         cph.fit(regression_dataset, "T", "E")
 
         results = cph.compute_residuals(regression_dataset, "scaled_schoenfeld") - cph.params_.values
-        npt.assert_allclose(results.iloc[0].values, [0.785518935413, 0.862926592959, 2.479586809860], rtol=5)
-        npt.assert_allclose(results.iloc[1].values, [-0.888580165064, -1.037904485796, -0.915334612372], rtol=5)
+        npt.assert_allclose(results._iloc[0].values, [0.785518935413, 0.862926592959, 2.479586809860], rtol=5)
+        npt.assert_allclose(results._iloc[1].values, [-0.888580165064, -1.037904485796, -0.915334612372], rtol=5)
         npt.assert_allclose(
-            results.iloc[results.shape[0] - 1].values, [0.222207366875, 0.050957334886, 0.218314242931], rtol=5
+            results._iloc[results.shape[0] - 1].values, [0.222207366875, 0.050957334886, 0.218314242931], rtol=5
         )
 
     def test_original_index_is_respected_in_all_residual_tests(self, cph):
@@ -3080,7 +3080,7 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
 
     def test_fit_method(self, data_nus, cph):
         cph.fit(data_nus, duration_col="t", event_col="E")
-        assert np.abs(cph.params_.iloc[0] - -0.0335) < 0.0001
+        assert np.abs(cph.params_._iloc[0] - -0.0335) < 0.0001
 
     def test_using_dataframes_vs_numpy_arrays(self, data_pred2, cph):
         cph.fit(data_pred2, "t", "E")
@@ -3999,8 +3999,8 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
         cp2.fit(df_demeaned, event_col="E", duration_col="T")
 
         assert_frame_equal(
-            cp1.predict_survival_function(df.iloc[[0]][["var1", "var2", "var3"]]),
-            cp2.predict_survival_function(df_demeaned.iloc[[0]][["var1", "var2", "var3"]]),
+            cp1.predict_survival_function(df._iloc[[0]][["var1", "var2", "var3"]]),
+            cp2.predict_survival_function(df_demeaned._iloc[[0]][["var1", "var2", "var3"]]),
         )
 
     def test_baseline_survival_is_the_same_indp_of_scale(self, regression_dataset):
@@ -4035,8 +4035,8 @@ Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
         cp2.fit(df_scaled, event_col="E", duration_col="T")
 
         assert_frame_equal(
-            cp1.predict_survival_function(df.iloc[[0]][["var1", "var2", "var3"]]),
-            cp2.predict_survival_function(df_scaled.iloc[[0]][["var1", "var2", "var3"]]),
+            cp1.predict_survival_function(df._iloc[[0]][["var1", "var2", "var3"]]),
+            cp2.predict_survival_function(df_scaled._iloc[[0]][["var1", "var2", "var3"]]),
         )
 
     def test_warning_is_raised_if_df_has_a_near_constant_column(self, rossi):
@@ -4306,7 +4306,7 @@ class TestAalenAdditiveFitter:
     def test_predict_cumulative_hazard_inputs(self, data_pred1):
         aaf = AalenAdditiveFitter(coef_penalizer=0.001)
         aaf.fit(data_pred1, duration_col="t", event_col="E")
-        x = data_pred1.iloc[:5].drop(["t", "E"], axis=1)
+        x = data_pred1._iloc[:5].drop(["t", "E"], axis=1)
         y_df = aaf.predict_cumulative_hazard(x)
         y_np = aaf.predict_cumulative_hazard(x.values)
         assert_frame_equal(y_df, y_np)
@@ -4331,9 +4331,9 @@ class TestAalenAdditiveFitter:
         with pytest.warns(StatisticalWarning, match="weights are not integers"):
             aaf.fit(regression_dataset, "T", "E", weights_col="var3")
         actual = aaf.hazards_
-        npt.assert_allclose(actual.iloc[:3]["var1"].tolist(), [1.301523e-02, -4.925302e-04, 2.304792e-02], rtol=1e-06)
+        npt.assert_allclose(actual._iloc[:3]["var1"].tolist(), [1.301523e-02, -4.925302e-04, 2.304792e-02], rtol=1e-06)
         npt.assert_allclose(
-            actual.iloc[:3]["_intercept"].tolist(), [-9.672957e-03, 1.439187e-03, 1.838915e-03], rtol=1e-06
+            actual._iloc[:3]["_intercept"].tolist(), [-9.672957e-03, 1.439187e-03, 1.838915e-03], rtol=1e-06
         )
 
     def test_cumulative_hazards_versus_R(self, aaf, regression_dataset):
@@ -4346,7 +4346,7 @@ class TestAalenAdditiveFitter:
         regression_dataset["E"] = 1
 
         aaf.fit(regression_dataset, "T", "E")
-        actual = aaf.cumulative_hazards_.iloc[-1]
+        actual = aaf.cumulative_hazards_._iloc[-1]
         npt.assert_allclose(actual["_intercept"], 2.1675130235, rtol=1e-06)
         npt.assert_allclose(actual["var1"], 0.6820086125, rtol=1e-06)
         npt.assert_allclose(actual["var2"], -0.0776583514, rtol=1e-06)

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -38,7 +38,7 @@ from lifelines.generate_datasets import cumulative_integral
 
 @pytest.fixture()
 def waltons():
-    return load_waltons()[["T", "E"]].iloc[:50]
+    return load_waltons()[["T", "E"]]._iloc[:50]
 
 
 @pytest.mark.skipif("DISPLAY" not in os.environ, reason="requires display")
@@ -193,7 +193,7 @@ class TestPlotting:
         # fit the aaf, no intercept as it is already built into X, X[2] is ones
         aaf = AalenAdditiveFitter(coef_penalizer=0.1, fit_intercept=False)
         aaf.fit(X, "T", "E")
-        ax = aaf.smoothed_hazards_(1).iloc[0 : aaf.cumulative_hazards_.shape[0] - 500].plot()
+        ax = aaf.smoothed_hazards_(1)._iloc[0 : aaf.cumulative_hazards_.shape[0] - 500].plot()
         ax.set_xlabel("time")
         ax.set_title("test_aalen_additive_smoothed_plot")
         self.plt.show(block=block)

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -537,7 +537,7 @@ class TestLongDataFrameUtils(object):
         seed_df = seed_df[seed_df["id"] == 1]
 
         new_value_at_time_0 = 1.0
-        old_value_at_time_0 = seed_df["var1"].iloc[0]
+        old_value_at_time_0 = seed_df["var1"]._iloc[0]
         cv = pd.DataFrame.from_records([{"id": 1, "t": 0, "var1": new_value_at_time_0, "var2": 2.0}])
 
         df = seed_df.pipe(utils.add_covariate_to_timeline, cv, "id", "t", "E", overwrite=False)

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -150,7 +150,7 @@ def qth_survival_times(q, survival_functions) -> Union[pd.DataFrame, float]:
         # If you add print statements to `qth_survival_time`, you'll see it's called
         # once too many times. This is expected Pandas behavior
         # https://stackoverflow.com/questions/21635915/why-does-pandas-apply-calculate-twice
-        return survival_functions.apply(lambda s: qth_survival_time(q, s)).iloc[0]
+        return survival_functions.apply(lambda s: qth_survival_time(q, s))._iloc[0]
     else:
         d = {_q: survival_functions.apply(lambda s: qth_survival_time(_q, s)) for _q in q}
         survival_times = pd.DataFrame(d).T
@@ -885,7 +885,7 @@ def _additive_estimate(events, timeline, _additive_f, _additive_var, reverse):
         # the population should not have the late entrants. The only exception to this rule
         # is the first period, where entrants happen _prior_ to deaths.
         entrances = events["entrance"].copy()
-        entrances.iloc[0] = 0
+        entrances._iloc[0] = 0
         population = events["at_risk"] - entrances
 
         estimate_ = np.cumsum(_additive_f(population, deaths))
@@ -1402,8 +1402,8 @@ def add_covariate_to_timeline(
         except KeyError:
             return df
 
-        final_state = bool(df[event_col].iloc[-1])
-        final_stop_time = df[stop_col].iloc[-1]
+        final_state = bool(df[event_col]._iloc[-1])
+        final_stop_time = df[stop_col]._iloc[-1]
         df = df.drop([id_col, event_col, stop_col], axis=1).set_index(start_col)
 
         # we subtract a small time because of 1) pandas slicing is _inclusive_, and 2) the degeneracy


### PR DESCRIPTION
Added plot_interval_censored_lifetimes function - similar to plot_lifetimes but for interval censored data. Example from doc string:
![lifetimes_plot](https://user-images.githubusercontent.com/19431229/80837608-0aa12900-8bef-11ea-869e-ffda768323b4.png)

