### PR TITLE
v0.24.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Changelog
 
+#### 0.24.7
+
+##### New features
+ - `find_best_parametric_model` can handle left and interval censoring. Also allows for more fitting options.
+ - `AIC_` is a property on parametric models, and `AIC_partial_` is a property on Cox models.
+ - `penalizer` in all regression models can now be an array instead of a float. This enables new functionality and better
+ control over penalization. This is similar (but not identical) to `penalty.factors` in glmnet in R.
+ - some convergence tweaks which should help recent performance regressions.
+
+##### Bug fixes
+ - fixed bug where `cdf_plot` and `qq_plot` were not factoring in the weights correctly.
+
+
+
 #### 0.24.6 - 2020-05-05
 
 ##### New features

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,16 +1,22 @@
 Changelog
 ---------
 
-0.24.6 - 2020-05-05
-^^^^^^^^^^^^^^^^^^^
+0.24.7
+^^^^^^
 
 New features
 ''''''''''''
 
--  At the cost of some performance, convergence is improved in many
-   models.
--  New ``lifelines.plotting.plot_interval_censored_lifetimes`` for
-   plotting interval censored data - thanks @sean-reed!
+-  ``find_best_parametric_model`` can handle left and interval
+   censoring. Also allows for more fitting options.
+-  ``AIC_`` is a property on parametric models, and ``AIC_partial_`` is
+   a property on Cox models.
+-  ``penalizer`` in all regression models can now be an array instead of
+   a float. This enables new functionality and better control over
+   penalization. This is similar (but not identical) to
+   ``penalty.factors`` in glmnet in R.
+-  some convergence tweaks which should help recent performance
+   regressions.
 
 Bug fixes
 '''''''''
@@ -20,7 +26,7 @@ Bug fixes
 
 .. _section-1:
 
-0.24.5 - 2020-05-01
+0.24.6 - 2020-05-05
 ^^^^^^^^^^^^^^^^^^^
 
 .. _new-features-1:
@@ -28,9 +34,32 @@ Bug fixes
 New features
 ''''''''''''
 
--  ``plot_lifetimes`` accepts pandas Series.
+-  At the cost of some performance, convergence is improved in many
+   models.
+-  New ``lifelines.plotting.plot_interval_censored_lifetimes`` for
+   plotting interval censored data - thanks @sean-reed!
 
 .. _bug-fixes-1:
+
+Bug fixes
+'''''''''
+
+-  fixed bug where ``cdf_plot`` and ``qq_plot`` were not factoring in
+   the weights correctly.
+
+.. _section-2:
+
+0.24.5 - 2020-05-01
+^^^^^^^^^^^^^^^^^^^
+
+.. _new-features-2:
+
+New features
+''''''''''''
+
+-  ``plot_lifetimes`` accepts pandas Series.
+
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -40,12 +69,12 @@ Bug fixes
 -  Improved ``at_risk_counts`` for subplots.
 -  More data validation checks for ``CoxTimeVaryingFitter``
 
-.. _section-2:
+.. _section-3:
 
 0.24.4 - 2020-04-13
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
@@ -54,12 +83,12 @@ Bug fixes
 -  setting a dataframe in ``ancillary_df`` works for interval censoring
 -  ``.score`` works for interval censored models
 
-.. _section-3:
+.. _section-4:
 
 0.24.3 - 2020-03-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ''''''''''''
@@ -69,7 +98,7 @@ New features
    the hazard ratio would be at previous times. This is useful because
    the final hazard ratio is some weighted average of these.
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -77,12 +106,12 @@ Bug fixes
 -  Fixed error in HTML printer that was hiding concordance index
    information.
 
-.. _section-4:
+.. _section-5:
 
 0.24.2 - 2020-03-15
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -94,12 +123,12 @@ Bug fixes
 -  Fixed a keyword bug in ``plot_covariate_groups`` for parametric
    models.
 
-.. _section-5:
+.. _section-6:
 
 0.24.1 - 2020-03-05
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ''''''''''''
@@ -107,14 +136,14 @@ New features
 -  Stability improvements for GeneralizedGammaRegressionFitter and
    CoxPHFitter with spline estimation.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
 
 -  Fixed bug with plotting hazards in NelsonAalenFitter.
 
-.. _section-6:
+.. _section-7:
 
 0.24.0 - 2020-02-20
 ^^^^^^^^^^^^^^^^^^^
@@ -123,7 +152,7 @@ This version and future versions of lifelines no longer support py35.
 Pandas 1.0 is fully supported, along with previous versions. Minimum
 Scipy has been bumped to 1.2.0.
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ''''''''''''
@@ -173,7 +202,7 @@ API Changes
    to ``scoring_method``.
 -  removed ``_score_`` and ``path`` from Cox model.
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -186,12 +215,12 @@ Bug fixes
 -  Cox models now incorporate any penalizers in their
    ``log_likelihood_``
 
-.. _section-7:
+.. _section-8:
 
 0.23.9 - 2020-01-28
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
@@ -202,12 +231,12 @@ Bug fixes
    of ``GeneralizedGammaRegressionFitter`` and any custom regression
    models should update their code as soon as possible.
 
-.. _section-8:
+.. _section-9:
 
 0.23.8 - 2020-01-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
@@ -218,19 +247,19 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-9:
+.. _section-10:
 
 0.23.7 - 2020-01-14
 ^^^^^^^^^^^^^^^^^^^
 
 Bug fixes for py3.5.
 
-.. _section-10:
+.. _section-11:
 
 0.23.6 - 2020-01-07
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ''''''''''''
@@ -244,12 +273,12 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-11:
+.. _section-12:
 
 0.23.5 - 2020-01-05
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ''''''''''''
@@ -258,7 +287,7 @@ New features
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
@@ -268,26 +297,26 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-12:
+.. _section-13:
 
 0.23.4 - 2019-12-15
 ^^^^^^^^^^^^^^^^^^^
 
 -  Bug fix for PyPI
 
-.. _section-13:
+.. _section-14:
 
 0.23.3 - 2019-12-11
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ''''''''''''
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
@@ -295,12 +324,12 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-14:
+.. _section-15:
 
 0.23.2 - 2019-12-07
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-8:
+.. _new-features-9:
 
 New features
 ''''''''''''
@@ -312,7 +341,7 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
@@ -321,12 +350,12 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-15:
+.. _section-16:
 
 0.23.1 - 2019-11-27
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-9:
+.. _new-features-10:
 
 New features
 ''''''''''''
@@ -336,7 +365,7 @@ New features
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
@@ -348,12 +377,12 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-16:
+.. _section-17:
 
 0.23.0 - 2019-11-17
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-10:
+.. _new-features-11:
 
 New features
 ''''''''''''
@@ -362,7 +391,7 @@ New features
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
@@ -384,7 +413,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-17:
+.. _section-18:
 
 0.22.10 - 2019-11-08
 ^^^^^^^^^^^^^^^^^^^^
@@ -392,7 +421,7 @@ API Changes
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 '''''''''
@@ -402,12 +431,12 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-18:
+.. _section-19:
 
 0.22.9 - 2019-10-30
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 '''''''''
@@ -419,12 +448,12 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-19:
+.. _section-20:
 
 0.22.8 - 2019-10-06
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-11:
+.. _new-features-12:
 
 New features
 ''''''''''''
@@ -434,19 +463,19 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 '''''''''
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-20:
+.. _section-21:
 
 0.22.7 - 2019-09-29
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-12:
+.. _new-features-13:
 
 New features
 ''''''''''''
@@ -454,7 +483,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 '''''''''
@@ -473,19 +502,19 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-21:
+.. _section-22:
 
 0.22.6 - 2019-09-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-13:
+.. _new-features-14:
 
 New features
 ''''''''''''
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 '''''''''
@@ -501,12 +530,12 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-22:
+.. _section-23:
 
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-14:
+.. _new-features-15:
 
 New features
 ''''''''''''
@@ -515,7 +544,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 '''''''''
@@ -532,12 +561,12 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-23:
+.. _section-24:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-15:
+.. _new-features-16:
 
 New features
 ''''''''''''
@@ -556,7 +585,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
 '''''''''
@@ -564,12 +593,12 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-24:
+.. _section-25:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-16:
+.. _new-features-17:
 
 New features
 ''''''''''''
@@ -593,7 +622,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
 '''''''''
@@ -605,19 +634,19 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-25:
+.. _section-26:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-17:
+.. _new-features-18:
 
 New features
 ''''''''''''
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
 '''''''''
@@ -628,12 +657,12 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-26:
+.. _section-27:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-18:
+.. _new-features-19:
 
 New features
 ''''''''''''
@@ -661,7 +690,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
 '''''''''
@@ -671,12 +700,12 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-27:
+.. _section-28:
 
 0.22.0 - 2019-07-03
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-19:
+.. _new-features-20:
 
 New features
 ''''''''''''
@@ -710,7 +739,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
 '''''''''
@@ -719,21 +748,21 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-28:
+.. _section-29:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 I’m skipping 0.21.4 version because of deployment issues.
 
-.. _new-features-20:
+.. _new-features-21:
 
 New features
 ''''''''''''
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
 '''''''''
@@ -743,12 +772,12 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-29:
+.. _section-30:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-21:
+.. _new-features-22:
 
 New features
 ''''''''''''
@@ -762,19 +791,19 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
 '''''''''
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-30:
+.. _section-31:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-22:
+.. _new-features-23:
 
 New features
 ''''''''''''
@@ -798,17 +827,17 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
 '''''''''
 
-.. _section-31:
+.. _section-32:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-23:
+.. _new-features-24:
 
 New features
 ''''''''''''
@@ -825,19 +854,19 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug fixes
 '''''''''
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-32:
+.. _section-33:
 
 0.21.0 - 2019-04-12
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-24:
+.. _new-features-25:
 
 New features
 ''''''''''''
@@ -862,7 +891,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-29:
+.. _bug-fixes-30:
 
 Bug fixes
 '''''''''
@@ -872,12 +901,12 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-33:
+.. _section-34:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-25:
+.. _new-features-26:
 
 New features
 ''''''''''''
@@ -894,7 +923,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-30:
+.. _bug-fixes-31:
 
 Bug fixes
 '''''''''
@@ -903,12 +932,12 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-34:
+.. _section-35:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-26:
+.. _new-features-27:
 
 New features
 ''''''''''''
@@ -927,7 +956,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-31:
+.. _bug-fixes-32:
 
 Bug fixes
 '''''''''
@@ -936,12 +965,12 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-35:
+.. _section-36:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-27:
+.. _new-features-28:
 
 New features
 ''''''''''''
@@ -954,12 +983,12 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-36:
+.. _section-37:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-28:
+.. _new-features-29:
 
 New features
 ''''''''''''
@@ -983,7 +1012,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-32:
+.. _bug-fixes-33:
 
 Bug fixes
 '''''''''
@@ -999,7 +1028,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-37:
+.. _section-38:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -1023,7 +1052,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-38:
+.. _section-39:
 
 0.20.0 - 2019-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1032,7 +1061,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-29:
+.. _new-features-30:
 
 New features
 ''''''''''''
@@ -1052,19 +1081,19 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-33:
+.. _bug-fixes-34:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-39:
+.. _section-40:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-30:
+.. _new-features-31:
 
 New features
 ''''''''''''
@@ -1074,24 +1103,24 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-40:
+.. _section-41:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-34:
+.. _bug-fixes-35:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-41:
+.. _section-42:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-31:
+.. _new-features-32:
 
 New features
 ''''''''''''
@@ -1103,12 +1132,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-42:
+.. _section-43:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-32:
+.. _new-features-33:
 
 New features
 ''''''''''''
@@ -1116,7 +1145,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-35:
+.. _bug-fixes-36:
 
 Bug fixes
 '''''''''
@@ -1126,12 +1155,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-43:
+.. _section-44:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-33:
+.. _new-features-34:
 
 New features
 ''''''''''''
@@ -1148,12 +1177,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-44:
+.. _section-45:
 
 0.19.0 - 2019-02-20
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-34:
+.. _new-features-35:
 
 New features
 ''''''''''''
@@ -1192,7 +1221,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-36:
+.. _bug-fixes-37:
 
 Bug Fixes
 '''''''''
@@ -1209,7 +1238,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-45:
+.. _section-46:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -1219,7 +1248,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-46:
+.. _section-47:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1240,7 +1269,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-47:
+.. _section-48:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -1250,7 +1279,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-48:
+.. _section-49:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -1260,7 +1289,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-49:
+.. _section-50:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1276,7 +1305,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-50:
+.. _section-51:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1287,7 +1316,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-51:
+.. _section-52:
 
 0.18.0 - 2019-01-31
 ^^^^^^^^^^^^^^^^^^^
@@ -1324,7 +1353,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-52:
+.. _section-53:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1332,7 +1361,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-53:
+.. _section-54:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -1344,7 +1373,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-54:
+.. _section-55:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1352,7 +1381,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-55:
+.. _section-56:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -1363,7 +1392,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-56:
+.. _section-57:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1380,7 +1409,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-57:
+.. _section-58:
 
 0.17.0 - 2019-01-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1401,7 +1430,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-58:
+.. _section-59:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1409,7 +1438,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-59:
+.. _section-60:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1420,14 +1449,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-60:
+.. _section-61:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-61:
+.. _section-62:
 
 0.16.0 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1463,7 +1492,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-62:
+.. _section-63:
 
 0.15.4
 ^^^^^^
@@ -1471,14 +1500,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-63:
+.. _section-64:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-64:
+.. _section-65:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1489,7 +1518,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-65:
+.. _section-66:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1498,7 +1527,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-66:
+.. _section-67:
 
 0.15.0 - 2018-11-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1569,7 +1598,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-67:
+.. _section-68:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1577,7 +1606,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-68:
+.. _section-69:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1585,7 +1614,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-69:
+.. _section-70:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1602,7 +1631,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-70:
+.. _section-71:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1614,7 +1643,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-71:
+.. _section-72:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1622,7 +1651,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-72:
+.. _section-73:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1640,7 +1669,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-73:
+.. _section-74:
 
 0.14.0 - 2018-03-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1662,7 +1691,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-74:
+.. _section-75:
 
 0.13.0 - 2017-12-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1691,7 +1720,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-75:
+.. _section-76:
 
 0.12.0
 ^^^^^^
@@ -1708,7 +1737,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-76:
+.. _section-77:
 
 0.11.3
 ^^^^^^
@@ -1720,7 +1749,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-77:
+.. _section-78:
 
 0.11.2
 ^^^^^^
@@ -1728,14 +1757,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-78:
+.. _section-79:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-79:
+.. _section-80:
 
 0.11.0 - 2017-06-21
 ^^^^^^^^^^^^^^^^^^^
@@ -1749,14 +1778,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-80:
+.. _section-81:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-81:
+.. _section-82:
 
 0.10.0
 ^^^^^^
@@ -1771,7 +1800,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-82:
+.. _section-83:
 
 0.9.4
 ^^^^^
@@ -1794,7 +1823,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-83:
+.. _section-84:
 
 0.9.2
 ^^^^^
@@ -1803,7 +1832,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-84:
+.. _section-85:
 
 0.9.1
 ^^^^^
@@ -1811,7 +1840,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-85:
+.. _section-86:
 
 0.9.0
 ^^^^^
@@ -1827,7 +1856,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-86:
+.. _section-87:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -1844,7 +1873,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-87:
+.. _section-88:
 
 0.8.0
 ^^^^^
@@ -1863,7 +1892,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-88:
+.. _section-89:
 
 0.7.1
 ^^^^^
@@ -1882,7 +1911,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-89:
+.. _section-90:
 
 0.7.0 - 2015-03-01
 ^^^^^^^^^^^^^^^^^^
@@ -1901,7 +1930,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-90:
+.. _section-91:
 
 0.6.1
 ^^^^^
@@ -1913,7 +1942,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-91:
+.. _section-92:
 
 0.6.0 - 2015-02-04
 ^^^^^^^^^^^^^^^^^^
@@ -1936,7 +1965,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-92:
+.. _section-93:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -1957,7 +1986,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-93:
+.. _section-94:
 
 0.5.0 - 2014-12-07
 ^^^^^^^^^^^^^^^^^^
@@ -1970,7 +1999,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-94:
+.. _section-95:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -1982,7 +2011,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-95:
+.. _section-96:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -2003,7 +2032,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-96:
+.. _section-97:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -2023,7 +2052,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-97:
+.. _section-98:
 
 0.4.1.1
 ^^^^^^^
@@ -2036,7 +2065,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-98:
+.. _section-99:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -2055,7 +2084,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-99:
+.. _section-100:
 
 0.4.0 - 2014-06-08
 ^^^^^^^^^^^^^^^^^^

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -295,7 +295,7 @@ class ParametricUnivariateFitter(UnivariateFitter):
 
     @property
     def AIC_(self) -> float:
-        return -2 * self.log_likelihood_ + 2 * self.params_.shape[0]
+        return -2 * self.log_likelihood_ + 2 * self._fitted_parameters_.shape[0]
 
     def _check_cumulative_hazard_is_monotone_and_positive(self, durations, values):
         class_name = self._class_name
@@ -1940,7 +1940,7 @@ class ParametricRegressionFitter(RegressionFitter):
                 Some ways to possible ways fix this:
 
                 0. Are there any lifelines warnings outputted during the `fit`?
-                1. Inspect your DataFrame: does everything look as expected?
+                1. Inspect your DataFrame: does everything look as expected? Do you need to add/drop a constant (intercept) column?
                 2. Is there high-collinearity in the dataset? Try using the variance inflation factor (VIF) to find redundant variables.
                 3. Trying adding a small penalizer (or changing it, if already present). Example: `%s(penalizer=0.01).fit(...)`.
                 4. Are there any extreme outliers? Try modeling them or dropping them to see if it helps convergence.
@@ -2130,8 +2130,8 @@ class ParametricRegressionFitter(RegressionFitter):
         sr = self.log_likelihood_ratio_test()
         footers = []
 
-        if CensoringType.is_right_censoring(self):
-            footers.apoend(("Concordance", "{:.{prec}f}".format(self.concordance_index_, prec=decimals)))
+        if utils.CensoringType.is_right_censoring(self):
+            footers.append(("Concordance", "{:.{prec}f}".format(self.concordance_index_, prec=decimals)))
 
         footers.extend(
             [

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1214,6 +1214,15 @@ class RegressionFitter(BaseFitter):
         raise NotImplementedError()
 
 
+class SemiParametricRegressionFittter(RegressionFitter):
+    @property
+    def AIC_partial_(self) -> float:
+        """
+        "partial" because the log-likelihood is partial
+        """
+        return -2 * self.log_likelihood_ + 2 * self.params_.shape[0]
+
+
 class ParametricRegressionFitter(RegressionFitter):
 
     _scipy_fit_method = "BFGS"
@@ -2481,6 +2490,10 @@ class ParametricRegressionFitter(RegressionFitter):
             del self._predicted_median
             return self.concordance_index_
         return self._concordance_index_
+
+    @property
+    def AIC_(self) -> float:
+        return -2 * self.log_likelihood_ + 2 * self.params_.shape[0]
 
 
 class ParametericAFTRegressionFitter(ParametricRegressionFitter):

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -494,7 +494,8 @@ class ParametricUnivariateFitter(UnivariateFitter):
 
             minimizing_results, previous_results, minimizing_ll = None, None, np.inf
             for method, option in zip(
-                ["Nelder-Mead", self._scipy_fit_method], [{"maxiter": 25}, {**{"disp": show_progress}, **self._scipy_fit_options}]
+                ["Nelder-Mead", self._scipy_fit_method],
+                [{"maxiter": 100}, {**{"disp": show_progress}, **self._scipy_fit_options}],
             ):
 
                 initial_value = self._initial_values if previous_results is None else utils._to_1d_array(previous_results.x)

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -2115,7 +2115,21 @@ class ParametricRegressionFitter(RegressionFitter):
             ]
         )
 
-        p = Printer(self, headers, justify, decimals, kwargs)
+        sr = self.log_likelihood_ratio_test()
+        footers = []
+        footers.extend(
+            [
+                ("Concordance", "{:.{prec}f}".format(self.concordance_index_, prec=decimals)),
+                ("AIC", "{:.{prec}f}".format(self.AIC_, prec=decimals)),
+                (
+                    "log-likelihood ratio test",
+                    "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals),
+                ),
+                ("-log2(p) of ll-ratio test", "{:.{prec}f}".format(-np.log2(sr.p_value), prec=decimals)),
+            ]
+        )
+
+        p = Printer(self, headers, footers, justify, decimals, kwargs)
 
         p.print(style=style)
 

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -293,6 +293,10 @@ class ParametricUnivariateFitter(UnivariateFitter):
         if "alpha" in self._fitted_parameter_names:
             raise NameError("'alpha' in _fitted_parameter_names is a lifelines reserved word. Try 'alpha_' instead.")
 
+    @property
+    def AIC_(self) -> float:
+        return -2 * self.log_likelihood_ + 2 * self.params_.shape[0]
+
     def _check_cumulative_hazard_is_monotone_and_positive(self, durations, values):
         class_name = self._class_name
 

--- a/lifelines/fitters/aalen_additive_fitter.py
+++ b/lifelines/fitters/aalen_additive_fitter.py
@@ -201,9 +201,7 @@ class AalenAdditiveFitter(RegressionFitter):
 
         hazards = pd.DataFrame(hazards_, columns=columns, index=index).iloc[:stop]
         cumulative_hazards_ = hazards.cumsum()
-        cumulative_variance_hazards_ = (
-            pd.DataFrame(variance_hazards_, columns=columns, index=index).iloc[:stop].cumsum()
-        )
+        cumulative_variance_hazards_ = pd.DataFrame(variance_hazards_, columns=columns, index=index).iloc[:stop].cumsum()
 
         return hazards, cumulative_hazards_, cumulative_variance_hazards_
 
@@ -299,9 +297,7 @@ It's important to know that the naive variance estimates of the coefficients are
         self._check_values(df, T, E)
 
         if self.fit_intercept:
-            assert (
-                "_intercept" not in df.columns
-            ), "_intercept is an internal lifelines column, please rename your column first."
+            assert "_intercept" not in df.columns, "_intercept is an internal lifelines column, please rename your column first."
             X["_intercept"] = 1.0
 
         return X, T, E, W
@@ -333,9 +329,7 @@ It's important to know that the naive variance estimates of the coefficients are
         X_ = X_ if not self.fit_intercept else np.c_[X_, np.ones((n, 1))]
 
         timeline = self._index
-        individual_cumulative_hazards_ = pd.DataFrame(
-            np.dot(self.cumulative_hazards_, X_.T), index=timeline, columns=cols
-        )
+        individual_cumulative_hazards_ = pd.DataFrame(np.dot(self.cumulative_hazards_, X_.T), index=timeline, columns=cols)
 
         return individual_cumulative_hazards_
 
@@ -490,7 +484,7 @@ It's important to know that the naive variance estimates of the coefficients are
         )
 
     @property
-    def score_(self):
+    def concordance_index_(self):
         """
         The concordance score (also known as the c-index) of the fit.  The c-index is a generalization of the ROC AUC
         to survival data, including censorships.
@@ -572,7 +566,8 @@ It's important to know that the naive variance estimates of the coefficients are
             ]
         )
 
-        p = Printer(self, headers, justify, decimals, kwargs)
+        footers = [("Concordance", "{:.{prec}f}".format(self.concordance_index_, prec=decimals))]
+        p = Printer(self, headers, footers, justify, decimals, kwargs)
 
         p.print(style=style)
 

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -670,7 +670,6 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         footers = []
         footers.extend(
             [
-                ("Concordance", "{:.{prec}f}".format(self.concordance_index_, prec=decimals)),
                 ("Partial AIC", "{:.{prec}f}".format(self.AIC_partial_, prec=decimals)),
                 (
                     "log-likelihood ratio test",

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -666,8 +666,21 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             ]
         )
 
-        p = Printer(self, headers, justify, decimals, kwargs)
+        sr = self.log_likelihood_ratio_test()
+        footers = []
+        footers.extend(
+            [
+                ("Concordance", "{:.{prec}f}".format(self.concordance_index_, prec=decimals)),
+                ("Partial AIC", "{:.{prec}f}".format(self.AIC_partial_, prec=decimals)),
+                (
+                    "log-likelihood ratio test",
+                    "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals),
+                ),
+                ("-log2(p) of ll-ratio test", "{:.{prec}f}".format(-np.log2(sr.p_value), prec=decimals)),
+            ]
+        )
 
+        p = Printer(self, headers, footers, justify, decimals, kwargs)
         p.print(style=style)
 
     def log_likelihood_ratio_test(self):

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1350,8 +1350,21 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
             ]
         )
 
-        p = Printer(self, headers, justify, decimals, kwargs)
+        sr = self.log_likelihood_ratio_test()
+        footers = []
+        footers.extend(
+            [
+                ("Concordance", "{:.{prec}f}".format(self.concordance_index_, prec=decimals)),
+                ("Partial AIC", "{:.{prec}f}".format(self.AIC_partial_, prec=decimals)),
+                (
+                    "log-likelihood ratio test",
+                    "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals),
+                ),
+                ("-log2(p) of ll-ratio test", "{:.{prec}f}".format(-np.log2(sr.p_value), prec=decimals)),
+            ]
+        )
 
+        p = Printer(self, headers, footers, justify, decimals, kwargs)
         p.print(style=style)
 
     def _trivial_log_likelihood(self):

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -15,7 +15,7 @@ from pandas import DataFrame, Series, Index
 from autograd import numpy as anp
 from autograd import elementwise_grad
 
-from lifelines.fitters import RegressionFitter, ParametricRegressionFitter
+from lifelines.fitters import RegressionFitter, SemiParametricRegressionFittter, ParametricRegressionFitter
 from lifelines.fitters.mixins import SplineFitterMixin, ProportionalHazardMixin
 from lifelines.plotting import set_kwargs_drawstyle
 from lifelines.statistics import _chisq_test_p_value, StatisticalResult
@@ -125,7 +125,7 @@ class _BatchVsSingle:
         return self.SINGLE
 
 
-class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
+class CoxPHFitter(SemiParametricRegressionFittter, ProportionalHazardMixin):
     r"""
     This class implements fitting Cox's proportional hazard model using Efron's method for ties.
 

--- a/lifelines/fitters/generalized_gamma_fitter.py
+++ b/lifelines/fitters/generalized_gamma_fitter.py
@@ -115,7 +115,7 @@ class GeneralizedGammaFitter(KnownModelParametricUnivariateFitter):
             log_data = log(Ts[1])
         elif CensoringType.is_interval_censoring(self):
             # this fails if Ts[1] == Ts[0], so we add a some fudge factors.
-            log_data = log(Ts[1] - Ts[0] + 0.01)
+            log_data = log(Ts[1] - Ts[0] + 0.1)
         return np.array([log_data.mean(), log(log_data.std() + 0.01), 0.1])
 
     def _cumulative_hazard(self, params, times):

--- a/lifelines/fitters/generalized_gamma_regression_fitter.py
+++ b/lifelines/fitters/generalized_gamma_regression_fitter.py
@@ -58,7 +58,10 @@ class GeneralizedGammaRegressionFitter(ParametricRegressionFitter):
     -----------
     alpha: float, optional (default=0.05)
         the level in the confidence intervals.
-
+    penalizer: float or array, optional (default=0.0)
+        the penalizer coefficient to the size of the coefficients. See `l1_ratio`. Must be equal to or greater than 0.
+        Alternatively, penalizer is an array equal in size to the number of parameters, with penalty coefficients for specific variables. For
+        example, `penalizer=0.01 * np.ones(p)` is the same as `penalizer=0.01`
 
     Examples
     --------
@@ -126,9 +129,7 @@ class GeneralizedGammaRegressionFitter(ParametricRegressionFitter):
             # we may use this later in print_summary
             self._ll_null_ = uni_model.log_likelihood_
 
-            default_point = super(GeneralizedGammaRegressionFitter, self)._create_initial_point(
-                Ts, E, entries, weights, Xs
-            )
+            default_point = super(GeneralizedGammaRegressionFitter, self)._create_initial_point(Ts, E, entries, weights, Xs)
             nested_point = {}
 
             nested_point["mu_"] = np.array([0.0] * (len(Xs.mappings["mu_"])))

--- a/lifelines/fitters/log_logistic_aft_fitter.py
+++ b/lifelines/fitters/log_logistic_aft_fitter.py
@@ -35,8 +35,11 @@ class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
     fit_intercept: boolean, optional (default=True)
         Allow lifelines to add an intercept column of 1s to df, and ancillary_df if applicable.
 
-    penalizer: float, optional (default=0.0)
+    penalizer: float or array, optional (default=0.0)
         the penalizer coefficient to the size of the coefficients. See `l1_ratio`. Must be equal to or greater than 0.
+        Alternatively, penalizer is an array equal in size to the number of parameters, with penalty coefficients for specific variables. For
+        example, `penalizer=0.01 * np.ones(p)` is the same as `penalizer=0.01`
+
 
     l1_ratio: float, optional (default=0.0)
         how much of the penalizer should be attributed to an l1 penalty (otherwise an l2 penalty). The penalty function looks like

--- a/lifelines/fitters/log_normal_aft_fitter.py
+++ b/lifelines/fitters/log_normal_aft_fitter.py
@@ -37,8 +37,10 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
     fit_intercept: bool, optional (default=True)
         Allow lifelines to add an intercept column of 1s to df, and ancillary_df if applicable.
 
-    penalizer: float, optional (default=0.0)
+    penalizer: float or array, optional (default=0.0)
         the penalizer coefficient to the size of the coefficients. See `l1_ratio`. Must be equal to or greater than 0.
+        Alternatively, penalizer is an array equal in size to the number of parameters, with penalty coefficients for specific variables. For
+        example, `penalizer=0.01 * np.ones(p)` is the same as `penalizer=0.01`
 
     l1_ratio: float, optional (default=0.0)
         how much of the penalizer should be attributed to an l1 penalty (otherwise an l2 penalty). The penalty function looks like
@@ -158,8 +160,7 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
             S = norm.sf(Z)
 
             return pd.Series(
-                exp_mu_ * np.exp(np.sqrt(2) * sigma_ * erfinv(2 * (1 - p * S) - 1)) - conditional_after,
-                index=_get_index(df),
+                exp_mu_ * np.exp(np.sqrt(2) * sigma_ * erfinv(2 * (1 - p * S) - 1)) - conditional_after, index=_get_index(df)
             )
 
     def predict_expectation(self, df: pd.DataFrame, ancillary_df: Optional[pd.DataFrame] = None) -> pd.Series:

--- a/lifelines/fitters/npmle.py
+++ b/lifelines/fitters/npmle.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+from collections import defaultdict, namedtuple
+import numpy as np
+from numpy.linalg import norm
+import pandas as pd
+
+interval = namedtuple("Interval", ["left", "right"])
+
+
+def E_step_M_step(observation_intervals, p_old, turnball_interval_lookup):
+
+    N = len(observation_intervals)
+    T = p_old.shape[0]
+
+    p_new = np.zeros_like(p_old)
+
+    for observation_interval in observation_intervals:
+        p_temp = np.zeros_like(p_old)
+
+        # find all turnball intervals, t, that are contained in (ol, or). Call this set T
+        # the denominator is sum of p_old[T] probabilities
+        # the numerator is p_old[t]
+        for ix_t in turnball_interval_lookup[observation_interval]:
+            t_p = p_old[ix_t]
+            p_temp[ix_t] = t_p
+
+        p_new = p_new + p_temp / p_temp.sum()
+
+    return p_new / N
+
+
+def create_turnball_intervals(left, right):
+    """
+    TIHI X 10000
+    """
+
+    left = [[l, 0, "1l"] for l in left]
+    right = [[r, 0, "0r"] for r in right]
+
+    for l, r in zip(left, right):
+        if l[0] == r[0]:
+            l[1] -= 0.01
+            r[1] += 0.01
+
+    import copy
+
+    union = sorted(list(left) + list(right))
+
+    """
+    # fix ties
+    for k in range(len(union)-1):
+        e_, e__ = union[k], union[k+1]
+        if e_[2] == "1l" and e__[2] == "0r" and e_[0] == e__[0]:
+            union_[k][1] += 0.01
+    """
+    intervals = []
+
+    for k in range(len(union) - 1):
+        e_, e__ = union[k], union[k + 1]
+        if e_[2] == "1l" and e__[2] == "0r":
+            intervals.append(interval(e_[0], e__[0]))
+
+    return sorted(set(intervals))
+
+
+def is_subset(query_interval, super_interval):
+    return super_interval.left <= query_interval.left and query_interval.right <= super_interval.right
+
+
+def create_turnball_lookup(turnball_intervals, observation_intervals):
+
+    turnball_lookup = defaultdict(set)
+
+    for i, turnball_interval in enumerate(turnball_intervals):
+        # ask: which observations is this t_interval part of?
+        for observation_interval in observation_intervals:
+            # since left and right are sorted by left, we can stop after left > turnball_interval[1] value
+            if observation_interval.left > turnball_interval.right:
+                break
+            if is_subset(turnball_interval, observation_interval):
+                turnball_lookup[observation_interval].add(i)
+
+    return turnball_lookup
+
+
+def check_convergence(p_new, p_old, tol, i, verbose=False):
+    if verbose:
+        print("Iteration %d: norm(p_new - p_old): %.6f" % (i, norm(p_new - p_old)))
+    if norm(p_new - p_old) < tol:
+        return True
+    return False
+
+
+def create_observation_intervals(left, right):
+    return [interval(l, r) for l, r in zip(left, right)]
+
+
+def npmle(left, right, tol=1e-5, verbose=False):
+
+    left, right = np.asarray(left, dtype=float), np.asarray(right, dtype=float)
+    assert left.shape == right.shape
+
+    # sort left, right arrays by (left, right).
+    ix = np.lexsort((right, left))
+    left = left[ix]
+    right = right[ix]
+
+    turnball_intervals = list(create_turnball_intervals(left, right))
+    observation_intervals = create_observation_intervals(left, right)
+    turnball_lookup = create_turnball_lookup(turnball_intervals, sorted(set(observation_intervals)))
+
+    T = len(turnball_intervals)
+
+    converged = False
+
+    # initialize to equal weight
+    p = 1 / T * np.ones(T)
+    i = 0
+    while not converged:
+        i += 1
+        p_new = E_step_M_step(observation_intervals, p, turnball_lookup)
+        converged = check_convergence(p_new, p, tol, i, verbose=verbose)
+        p = p_new
+
+    return p, turnball_intervals
+
+
+def reconstruct_survival_function(probabilities, turnball_intervals, timeline, label="NPMLE"):
+    index = [0.0]
+    values = [1.0]
+
+    for p, interval in zip(probabilities, turnball_intervals):
+        if interval.left != index[-1]:
+            index.append(interval.left)
+            values.append(values[-1])
+
+        if interval.left == interval.right:
+            values[-1] -= p
+        else:
+            index.append(interval.right)
+            values.append(values[-1] - p)
+
+    full_dataframe = pd.DataFrame(index=timeline, columns=[label + "_upper"])
+
+    turnball_dataframe = pd.DataFrame(values, index=index, columns=[label + "_upper"])
+
+    dataframe = full_dataframe.combine_first(turnball_dataframe).ffill()
+    dataframe[label + "_lower"] = dataframe[label + "_upper"].shift(1).fillna(1)
+    return dataframe
+
+
+def npmle_compute_confidence_intervals(left, right, mle_, alpha=0.05, samples=1000):
+    """
+    uses basic bootstrap
+    """
+    left, right = np.asarray(left, dtype=float), np.asarray(right, dtype=float)
+    all_times = np.unique(np.concatenate((left, right, [0])))
+
+    N = left.shape[0]
+
+    bootstrapped_samples = np.empty((all_times.shape[0], samples))
+
+    for i in range(samples):
+        ix = np.random.randint(low=0, high=N, size=N)
+        left_ = left[ix]
+        right_ = right[ix]
+
+        bootstrapped_samples[:, i] = reconstruct_survival_function(*npmle(left_, right_), all_times).values[:, 0]
+
+    return (
+        2 * mle_.squeeze() - pd.Series(np.percentile(bootstrapped_samples, (alpha / 2) * 100, axis=1), index=all_times),
+        2 * mle_.squeeze() - pd.Series(np.percentile(bootstrapped_samples, (1 - alpha / 2) * 100, axis=1), index=all_times),
+    )

--- a/lifelines/fitters/piecewise_exponential_regression_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_regression_fitter.py
@@ -53,13 +53,13 @@ class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
         self.breakpoints = breakpoints
         self.n_breakpoints = len(self.breakpoints)
 
+        assert isinstance(self.penalizer, float), "penalizer must be a float"
         self.penalizer = penalizer
         self._fitted_parameter_names = ["lambda_%d_" % i for i in range(self.n_breakpoints + 1)]
 
     def _add_penalty(self, params, neg_ll):
         params_stacked = np.stack(params.values())
         coef_penalty = 0
-
         if self.penalizer > 0:
             for i in range(params_stacked.shape[1]):
                 if not self._constant_cols[i]:

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -43,8 +43,10 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter, ProportionalHazardMixin):
     fit_intercept: boolean, optional (default=True)
         Allow lifelines to add an intercept column of 1s to df, and ancillary_df if applicable.
 
-    penalizer: float, optional (default=0.0)
+    penalizer: float or array, optional (default=0.0)
         the penalizer coefficient to the size of the coefficients. See `l1_ratio`. Must be equal to or greater than 0.
+        Alternatively, penalizer is an array equal in size to the number of parameters, with penalty coefficients for specific variables. For
+        example, `penalizer=0.01 * np.ones(p)` is the same as `penalizer=0.01`
 
     l1_ratio: float, optional (default=0.0)
         how much of the penalizer should be attributed to an l1 penalty (otherwise an l2 penalty). The penalty function looks like

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -95,7 +95,9 @@ def cdf_plot(model, timeline=None, ax=None, **plot_kwargs):
             model.durations, model.event_observed, label=COL_EMP, timeline=timeline, weights=model.weights, entry=model.entry
         )
     elif CensoringType.is_interval_censoring(model):
-        raise NotImplementedError("lifelines does not have a non-parametric interval model yet.")
+        empirical_kmf = KaplanMeierFitter().fit_interval_censoring(
+            model.lower_bound, model.upper_bound, label=COL_EMP, timeline=timeline, weights=model.weights, entry=model.entry
+        )
 
     empirical_kmf.plot_cumulative_density(ax=ax, **plot_kwargs)
 
@@ -258,16 +260,22 @@ def qq_plot(model, ax=None, **plot_kwargs):
         kmf = KaplanMeierFitter().fit_left_censoring(
             model.durations, model.event_observed, label=COL_EMP, weights=model.weights, entry=model.entry
         )
+        sf, cdf = kmf.survival_function_[COL_EMP], kmf.cumulative_density_[COL_EMP]
     elif CensoringType.is_right_censoring(model):
         kmf = KaplanMeierFitter().fit_right_censoring(
             model.durations, model.event_observed, label=COL_EMP, weights=model.weights, entry=model.entry
         )
+        sf, cdf = kmf.survival_function_[COL_EMP], kmf.cumulative_density_[COL_EMP]
+
     elif CensoringType.is_interval_censoring(model):
-        raise NotImplementedError("lifelines does not have a non-parametric interval model yet.")
+        kmf = KaplanMeierFitter().fit_interval_censoring(
+            model.lower_bound, model.upper_bound, label=COL_EMP, weights=model.weights, entry=model.entry
+        )
+        sf, cdf = kmf.survival_function_[COL_EMP + "_lower"], kmf.cumulative_density_[COL_EMP + "_lower"]
 
-    q = np.unique(kmf.cumulative_density_.values[:, 0])
+    q = np.unique(cdf.values)
 
-    quantiles = qth_survival_times(1 - q, kmf.survival_function_)
+    quantiles = qth_survival_times(1 - q, sf)
     quantiles[COL_THEO] = dist_object.ppf(q)
     quantiles = quantiles.replace([-np.inf, 0, np.inf], np.nan).dropna()
 

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -29,6 +29,7 @@ __all__ = [
     "proportional_hazard_test",
     "power_under_cph",
     "sample_size_necessary_under_cph",
+    "somers_d",
 ]
 
 

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1481,6 +1481,21 @@ class TestParametricRegressionFitter:
         rossi["_int"] = 1.0
         return rossi
 
+    def test_penalizer_can_be_an_array(self, rossi):
+
+        wf_array = WeibullAFTFitter(penalizer=0.01 * np.ones(7)).fit(rossi, "week", "arrest")
+        wf_float = WeibullAFTFitter(penalizer=0.01).fit(rossi, "week", "arrest")
+
+        assert_frame_equal(wf_array.summary, wf_float.summary)
+
+    def test_penalizer_can_be_an_array_and_check_it_behaves_as_expected(self, rossi):
+
+        penalty = np.array([0, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01])
+        wf_array = WeibullAFTFitter(penalizer=penalty).fit(rossi, "week", "arrest")
+        wf_float = WeibullAFTFitter(penalizer=0.01).fit(rossi, "week", "arrest")
+
+        assert abs(wf_array.summary.loc[("lambda_", "fin"), "coef"]) > abs(wf_float.summary.loc[("lambda_", "fin"), "coef"])
+
     def test_custom_weibull_model_gives_the_same_data_as_implemented_weibull_model(self, rossi):
         class CustomWeibull(ParametricRegressionFitter):
             _scipy_fit_method = "SLSQP"
@@ -2533,6 +2548,21 @@ class TestCoxPHFitter:
     @pytest.fixture
     def cph_spline(self):
         return CoxPHFitter(baseline_estimation_method="spline")
+
+    def test_penalizer_can_be_an_array(self, rossi):
+
+        cph_array = CoxPHFitter(penalizer=0.01 * np.ones(7)).fit(rossi, "week", "arrest")
+        cph_float = CoxPHFitter(penalizer=0.01).fit(rossi, "week", "arrest")
+
+        assert_frame_equal(cph_array.summary, cph_float.summary)
+
+    def test_penalizer_can_be_an_array_and_check_it_behaves_as_expected(self, rossi):
+
+        penalty = np.array([0, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01])
+        cph_array = CoxPHFitter(penalizer=penalty).fit(rossi, "week", "arrest")
+        cph_float = CoxPHFitter(penalizer=0.01).fit(rossi, "week", "arrest")
+
+        assert abs(cph_array.summary.loc["fin", "coef"]) > abs(cph_float.summary.loc["fin", "coef"])
 
     def test_compute_followup_hazard_ratios(self, cph, cph_spline, rossi):
         cph.fit(rossi, "week", "arrest")
@@ -4352,6 +4382,29 @@ class TestCoxTimeVaryingFitter:
     @pytest.fixture()
     def heart(self):
         return load_stanford_heart_transplants()
+
+    def test_penalizer_can_be_an_array(self, dfcv):
+
+        cph_array = CoxTimeVaryingFitter(penalizer=0.01 * np.ones(2)).fit(
+            dfcv, id_col="id", start_col="start", stop_col="stop", event_col="event"
+        )
+        cph_float = CoxTimeVaryingFitter(penalizer=0.01).fit(
+            dfcv, id_col="id", start_col="start", stop_col="stop", event_col="event"
+        )
+
+        assert_frame_equal(cph_array.summary, cph_float.summary)
+
+    def test_penalizer_can_be_an_array_and_check_it_behaves_as_expected(self, dfcv):
+
+        penalty = np.array([0, 0.01])
+        cph_array = CoxTimeVaryingFitter(penalizer=penalty).fit(
+            dfcv, id_col="id", start_col="start", stop_col="stop", event_col="event"
+        )
+        cph_float = CoxTimeVaryingFitter(penalizer=0.01).fit(
+            dfcv, id_col="id", start_col="start", stop_col="stop", event_col="event"
+        )
+
+        assert abs(cph_array.summary.loc["z", "coef"]) > abs(cph_float.summary.loc["z", "coef"])
 
     def test_model_can_accept_null_covariates(self, ctv, dfcv):
         ctv.fit(dfcv[["id", "start", "stop", "event"]], id_col="id", start_col="start", stop_col="stop", event_col="event")

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -260,6 +260,9 @@ class TestParametricUnivariateFitters:
         T = np.maximum(T1, T2)
 
         for fitter in known_parametric_univariate_fitters:
+            if isinstance(fitter(), PiecewiseExponentialFitterTesting):
+                # not a good model since the "break" is at 5.
+                continue
             fitter().fit_left_censoring(T, E)
 
     def test_parametric_univariate_fitters_can_print_summary(
@@ -383,7 +386,8 @@ class TestUnivariateFitters:
             assert f().alpha == 0.05
 
     def test_univariate_fitters_accept_late_entries(self, positive_sample_lifetimes, univariate_fitters):
-        entries = 0.1 * positive_sample_lifetimes[0]
+        positive_sample_lifetimes = positive_sample_lifetimes
+        entries = positive_sample_lifetimes[0] - 3
         for fitter in univariate_fitters:
             f = fitter().fit(positive_sample_lifetimes[0], entry=entries)
             assert f.entry is not None
@@ -3124,26 +3128,38 @@ class TestCoxPHFitter:
                     repr(cph)
                     + "\n"
                     + """
-      duration col = week
-         event col = arrest
-number of subjects = 432
-  number of events = 114
-    log-likelihood = -658.748
-  time fit was run = 2018-10-23 02:40:45 UTC
+<lifelines.CoxPHFitter: fitted with 432 total observations, 318 right-censored observations>
+             duration col = 'week'
+                event col = 'arrest'
+      baseline estimation = breslow
+   number of observations = 432
+number of events observed = 114
+   partial log-likelihood = -658.75
+         time fit was run = 2018-10-23 02:40:45 UTC
 
 ---
-        coef  exp(coef)  se(coef)       z      p  coef lower 95%  coef upper 95%
-fin  -0.3794     0.6843    0.1914 -1.9826 0.0474     -0.7545     -0.0043
-age  -0.0574     0.9442    0.0220 -2.6109 0.0090     -0.1006     -0.0143
-race  0.3139     1.3688    0.3080  1.0192 0.3081     -0.2898      0.9176
-wexp -0.1498     0.8609    0.2122 -0.7058 0.4803     -0.5657      0.2662
-mar  -0.4337     0.6481    0.3819 -1.1358 0.2561     -1.1821      0.3147
-paro -0.0849     0.9186    0.1958 -0.4336 0.6646     -0.4685      0.2988
-prio  0.0915     1.0958    0.0286  3.1939 0.0014      0.0353      0.1476
----
+       coef  exp(coef)   se(coef)   coef lower 95%   coef upper 95%  exp(coef) lower 95%  exp(coef) upper 95%
+fin   -0.38       0.68       0.19            -0.75            -0.00                 0.47                 1.00
+age   -0.06       0.94       0.02            -0.10            -0.01                 0.90                 0.99
+race   0.31       1.37       0.31            -0.29             0.92                 0.75                 2.50
+wexp  -0.15       0.86       0.21            -0.57             0.27                 0.57                 1.30
+mar   -0.43       0.65       0.38            -1.18             0.31                 0.31                 1.37
+paro  -0.08       0.92       0.20            -0.47             0.30                 0.63                 1.35
+prio   0.09       1.10       0.03             0.04             0.15                 1.04                 1.16
 
-Concordance = 0.640
-Log-likelihood ratio test = 33.27 on 7 df, -log2(p)=15.37
+         z      p   -log2(p)
+fin  -1.98   0.05       4.40
+age  -2.61   0.01       6.79
+race  1.02   0.31       1.70
+wexp -0.71   0.48       1.06
+mar  -1.14   0.26       1.97
+paro -0.43   0.66       0.59
+prio  3.19 <0.005       9.48
+---
+Concordance = 0.64
+Partial AIC = 1331.50
+log-likelihood ratio test = 33.27 on 7 df
+-log2(p) of ll-ratio test = 15.37
 """
                 )
                 .strip()
@@ -4949,22 +4965,30 @@ class TestCoxTimeVaryingFitter:
                     repr(ctv)
                     + "\n"
                     + """
-         event col = event
+<lifelines.CoxTimeVaryingFitter: fitted with 172 periods, 103 subjects, 75 events>
+         event col = 'event'
 number of subjects = 103
  number of periods = 172
   number of events = 75
-    log-likelihood = -290.566
+partial log-likelihood = -290.57
   time fit was run = 2018-10-23 02:41:45 UTC
 
 ---
-              coef  exp(coef)  se(coef)       z      p  coef lower 95%  coef upper 95%
-age         0.0272     1.0275    0.0137  1.9809 0.0476      0.0003      0.0540
-year       -0.1463     0.8639    0.0705 -2.0768 0.0378     -0.2845     -0.0082
-surgery    -0.6372     0.5288    0.3672 -1.7352 0.0827     -1.3570      0.0825
-transplant -0.0103     0.9898    0.3138 -0.0327 0.9739     -0.6252      0.6047
----
+             coef  exp(coef)   se(coef)   coef lower 95%   coef upper 95%  exp(coef) lower 95%  exp(coef) upper 95%
+age          0.03       1.03       0.01             0.00             0.05                 1.00                 1.06
+year        -0.15       0.86       0.07            -0.28            -0.01                 0.75                 0.99
+surgery     -0.64       0.53       0.37            -1.36             0.08                 0.26                 1.09
+transplant  -0.01       0.99       0.31            -0.63             0.60                 0.54                 1.83
 
-Likelihood ratio test = 15.11 on 4 df, -log2(p)=7.80
+               z    p   -log2(p)
+age         1.98 0.05       4.39
+year       -2.08 0.04       4.72
+surgery    -1.74 0.08       3.60
+transplant -0.03 0.97       0.04
+---
+Partial AIC = 589.13
+log-likelihood ratio test = 15.11 on 4 df
+-log2(p) of ll-ratio test = 7.80
 """
                 )
                 .strip()
@@ -5169,4 +5193,4 @@ class TestMixtureCureFitter:
         wmc.fit(T, E)
         mcfitter.fit(T, E)
 
-        assert abs(wmc.c_ - mcfitter.cured_fraction_) < 0.001
+        assert_frame_equal(wmc.summary.reset_index(drop=True), mcfitter.summary.reset_index(drop=True), check_less_precise=0)

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1357,6 +1357,138 @@ class TestKaplanMeierFitter:
         npt.assert_allclose(rf["KM_lifelines_latest"].values, rf["KM_lateenterafter"].values, rtol=10e-2)
         npt.assert_allclose(rf["KM_lifelines_latest"].values, rf["KM_true"].values, rtol=10e-2)
 
+    def test_interval_censoring_to_r_1(self):
+        kmf = KaplanMeierFitter()
+        left = [1, 7, 8, 7, 7, 17, 37, 46, 46, 45]
+        right = [7, 8, 10, 16, 14, 100, 44, 100, 100, 100]
+
+        kmf.fit_interval_censoring(left, right)
+
+        npt.assert_allclose(kmf.survival_function_.loc[7.0].values, np.array([0.9, 1.0]))
+        npt.assert_allclose(kmf.survival_function_.loc[8.0].values, np.array([0.7, 0.9]))
+        npt.assert_allclose(kmf.survival_function_.loc[10.0].values, np.array([0.5, 0.7]))
+        npt.assert_allclose(kmf.survival_function_.loc[44.0].values, np.array([0.375, 0.5]), rtol=1e-3)
+        npt.assert_allclose(kmf.survival_function_.iloc[-1].values, np.array([0.0, 0.375]), atol=1e-3)
+
+    def test_interval_censoring_to_r_2_test_observed_event(self):
+        kmf = KaplanMeierFitter()
+        left = [1, 8, 8, 7, 7, 17, 37, 46, 46, 45]
+        right = [7, 8, 10, 16, 14, 100, 44, 100, 100, 100]
+
+        kmf.fit_interval_censoring(left, right)
+
+        npt.assert_allclose(kmf.survival_function_.loc[7.0].values, np.array([0.9, 1.0]))
+        npt.assert_allclose(kmf.survival_function_.loc[8.0].values, np.array([0.5, 0.9]))
+        npt.assert_allclose(kmf.survival_function_.loc[10.0].values, np.array([0.5, 0.5]))
+        npt.assert_allclose(kmf.survival_function_.loc[44.0].values, np.array([0.375, 0.5]), rtol=1e-3)
+        npt.assert_allclose(kmf.survival_function_.iloc[-1].values, np.array([0.0, 0.375]), atol=1e-3)
+
+    def test_interval_censoring_to_r_3_test_0_and_inf(self):
+        kmf = KaplanMeierFitter()
+        left = [0, 8, 8, 7, 7, 17, 37, 46, 46, 45]
+        right = [7, 8, 10, 16, 14, np.inf, 44, np.inf, np.inf, np.inf]
+
+        kmf.fit_interval_censoring(left, right)
+
+        npt.assert_allclose(kmf.survival_function_.loc[0.0].values, np.array([1.0, 1.0]))
+        npt.assert_allclose(kmf.survival_function_.loc[7.0].values, np.array([0.9, 1.0]))
+        npt.assert_allclose(kmf.survival_function_.loc[8.0].values, np.array([0.5, 0.9]))
+        npt.assert_allclose(kmf.survival_function_.loc[10.0].values, np.array([0.5, 0.5]))
+        npt.assert_allclose(kmf.survival_function_.loc[44.0].values, np.array([0.375, 0.5]), rtol=1e-3)
+        npt.assert_allclose(kmf.survival_function_.iloc[-1].values, np.array([0.0, 0.375]), atol=1e-3)
+
+    def test_interval_censoring_to_r_3_test_ties_and_overlapping_intervals(self):
+        kmf = KaplanMeierFitter()
+        left = [6, 7, 8, 7, 5]
+        right = [7, 8, 10, 16, 20]
+
+        kmf.fit_interval_censoring(left, right)
+
+        npt.assert_allclose(kmf.survival_function_.loc[5.0].values, np.array([1.0, 1.0]))
+        npt.assert_allclose(kmf.survival_function_.loc[6.0].values, np.array([1.0, 1.0]))
+        npt.assert_allclose(kmf.survival_function_.loc[7.0].values, np.array([0.75, 1.0]), rtol=1e-05)
+        npt.assert_allclose(kmf.survival_function_.loc[8.0].values, np.array([0.375, 0.75]), rtol=1e-05)
+        npt.assert_allclose(kmf.survival_function_.loc[10.0].values, np.array([0, 0.375]), rtol=1e-05)
+
+    def test_interval_censoring_with_custom_index(self):
+        kmf = KaplanMeierFitter()
+        left = [6, 7, 8, 7, 5]
+        right = [7, 8, 10, 16, 20]
+
+        kmf.fit_interval_censoring(left, right, timeline=np.arange(10))
+        npt.assert_allclose(kmf.survival_function_.index.values, np.arange(10))
+
+    def test_interval_censoring_fit_with_exact_observations_is_equal_to_km(self):
+        left = np.array([6, 7, 8])
+        right = np.array([6, 7, 8])
+
+        kmf_interval = KaplanMeierFitter()
+        kmf_interval.fit_interval_censoring(left, right)
+
+        kmf_right = KaplanMeierFitter().fit(left, left == right)
+
+        npt.assert_allclose(
+            kmf_interval.survival_function_["NPMLE_estimate_lower"],
+            kmf_right.survival_function_["KM_estimate"],
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+    def test_interval_censoring_fit_with_exact_observations_is_equal_to_km2(self):
+        left = np.array([6, 7, 8, 9])
+        right = np.array([6, 7, 8, np.inf])
+
+        kmf_interval = KaplanMeierFitter()
+        kmf_interval.fit_interval_censoring(left, right)
+
+        kmf_right = KaplanMeierFitter().fit(left, left == right)
+
+        npt.assert_allclose(
+            kmf_interval.survival_function_["NPMLE_estimate_lower"].iloc[:-1],
+            kmf_right.survival_function_["KM_estimate"],
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+    def test_interval_censoring_fit_with_exact_observations_is_equal_to_km3(self):
+        left = np.array([6, 7, 8, 7.5])
+        right = np.array([6, 7, 8, np.inf])
+
+        kmf_interval = KaplanMeierFitter()
+        kmf_interval.fit_interval_censoring(left, right)
+
+        kmf_right = KaplanMeierFitter().fit(left, left == right)
+
+        npt.assert_allclose(
+            kmf_interval.survival_function_["NPMLE_estimate_lower"].iloc[:-1],
+            kmf_right.survival_function_["KM_estimate"],
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+    def test_interval_censoring_fit_with_exact_observations_is_equal_to_km4(self):
+        left = np.array([6, 7, 8, 7.0])
+        right = np.array([6, 7, 8, np.inf])
+
+        kmf_interval = KaplanMeierFitter()
+        kmf_interval.fit_interval_censoring(left, right)
+
+        kmf_right = KaplanMeierFitter().fit(left, left == right)
+
+        npt.assert_allclose(
+            kmf_interval.survival_function_["NPMLE_estimate_lower"].iloc[:-1],
+            kmf_right.survival_function_["KM_estimate"],
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+    def test_interval_model_has_all_attributes_as_non_interval(self):
+        left = [6, 7, 8, 7, 5]
+        right = [7, 8, 10, 16, 20]
+        kmf_interval = KaplanMeierFitter().fit(left, right)
+
+        kmf_right = KaplanMeierFitter().fit(np.arange(10))
+
 
 class TestNelsonAalenFitter:
     def nelson_aalen(self, lifetimes, observed=None):

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -32,6 +32,7 @@ from lifelines.datasets import (
     load_rossi,
     load_multicenter_aids_cohort_study,
     load_nh4,
+    load_diabetes,
 )
 from lifelines.generate_datasets import cumulative_integral
 
@@ -212,6 +213,14 @@ class TestPlotting:
         ax = aaf.plot(iloc=slice(0, aaf.cumulative_hazards_.shape[0] - 100))
         ax.set_xlabel("time")
         ax.set_title("test_aalen_additive_plot")
+        self.plt.show(block=block)
+        return
+
+    def test_kmf_with_interval_censoring_plotting(self, block):
+        kmf = KaplanMeierFitter()
+        left, right = load_diabetes()[["left", "right"]]
+        kmf.fit(left, right)
+        kmf.plot(color="r")
         self.plt.show(block=block)
         return
 

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -218,8 +218,8 @@ class TestPlotting:
 
     def test_kmf_with_interval_censoring_plotting(self, block):
         kmf = KaplanMeierFitter()
-        left, right = load_diabetes()[["left", "right"]]
-        kmf.fit(left, right)
+        left, right = load_diabetes()["left"], load_diabetes()["right"]
+        kmf.fit_interval_censoring(left, right)
         kmf.plot(color="r")
         self.plt.show(block=block)
         return

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -1079,7 +1079,7 @@ def test_find_best_parametric_model_works_for_interval_censoring():
 
 
 def test_find_best_parametric_model_works_with_weights_and_entry():
-    T = np.random.exponential(2, 100)
+    T = np.random.exponential(5, 100)
     W = np.random.randint(1, 5, size=100)
     entry = np.random.exponential(0.01, 100)
     model, score = utils.find_best_parametric_model(T, weights=W, entry=entry, show_progress=True)

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -1065,6 +1065,27 @@ def test_find_best_parametric_model_with_BIC():
     assert True
 
 
+def test_find_best_parametric_model_works_for_left_censoring():
+    T = np.random.exponential(2, 100)
+    model, score = utils.find_best_parametric_model(T, censoring_type="left", show_progress=True)
+    assert True
+
+
+def test_find_best_parametric_model_works_for_interval_censoring():
+    T_1 = np.random.exponential(2, 100)
+    T_2 = T_1 + 1
+    model, score = utils.find_best_parametric_model((T_1, T_2), censoring_type="interval", show_progress=True)
+    assert True
+
+
+def test_find_best_parametric_model_works_with_weights_and_entry():
+    T = np.random.exponential(2, 100)
+    W = np.random.randint(1, 5, size=100)
+    entry = np.random.exponential(0.01, 100)
+    model, score = utils.find_best_parametric_model(T, weights=W, entry=entry, show_progress=True)
+    assert True
+
+
 def test_safe_exp():
     from lifelines.utils.safe_exp import MAX
 

--- a/lifelines/utils/printer.py
+++ b/lifelines/utils/printer.py
@@ -6,11 +6,20 @@ import pandas as pd
 
 
 class Printer:
-    def __init__(self, model, headers: List[Tuple[str, Any]], justify: Callable, decimals: int, header_kwargs: Dict):
+    def __init__(
+        self,
+        model,
+        headers: List[Tuple[str, Any]],
+        footers: List[Tuple[str, Any]],
+        justify: Callable,
+        decimals: int,
+        header_kwargs: Dict,
+    ):
         self.headers = headers
         self.model = model
         self.decimals = decimals
         self.justify = justify
+        self.footers = footers  # TODO: use this variable
 
         for tuple_ in header_kwargs.items():
             self.add_to_headers(tuple_)
@@ -86,17 +95,24 @@ class Printer:
                 pass
 
             try:
+                footers.append(("AIC", "{:.{prec}f}".format(self.model.AIC_, prec=decimals)))
+            except AttributeError:
+                pass
+
+            try:
+                footers.append(("Partial AIC", "{:.{prec}f}".format(self.model.AIC_partial_, prec=decimals)))
+            except AttributeError:
+                pass
+
+            try:
                 sr = self.model.log_likelihood_ratio_test()
-                footers.extend(
-                    [
-                        ("Concordance", "{:.{prec}f}".format(self.model.concordance_index_, prec=decimals)),
-                        (
-                            "Log-likelihood ratio test",
-                            "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals),
-                        ),
-                        ("-log2(p) of ll-ratio test", "{:.{prec}f}".format(-np.log2(sr.p_value), prec=decimals)),
-                    ]
+                footers.append(
+                    (
+                        "Log-likelihood ratio test",
+                        "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals),
+                    )
                 )
+                footers.append(("-log2(p) of ll-ratio test", "{:.{prec}f}".format(-np.log2(sr.p_value), prec=decimals)))
             except AttributeError:
                 pass
 
@@ -177,10 +193,19 @@ class Printer:
 
         with np.errstate(invalid="ignore", divide="ignore"):
 
+            print("---")
             try:
-                print("---")
                 if utils.CensoringType.is_right_censoring(self.model) and self.model._KNOWN_MODEL:
                     print("Concordance = {:.{prec}f}".format(self.model.concordance_index_, prec=decimals))
+            except AttributeError:
+                pass
+            try:
+                print("AIC = {:.{prec}f}".format(self.model.AIC_, prec=decimals))
+            except AttributeError:
+                pass
+
+            try:
+                print("Partial AIC = {:.{prec}f}".format(self.model.AIC_partial_, prec=decimals))
             except AttributeError:
                 pass
 

--- a/lifelines/utils/printer.py
+++ b/lifelines/utils/printer.py
@@ -19,7 +19,7 @@ class Printer:
         self.model = model
         self.decimals = decimals
         self.justify = justify
-        self.footers = footers  # TODO: use this variable
+        self.footers = footers
 
         for tuple_ in header_kwargs.items():
             self.add_to_headers(tuple_)
@@ -85,39 +85,8 @@ class Printer:
             },
         )
 
-        footers = []
-        with np.errstate(invalid="ignore", divide="ignore"):
-
-            try:
-                if utils.CensoringType.is_right_censoring(self.model) and self.model._KNOWN_MODEL:
-                    footers.append(("Concordance", "{:.{prec}f}".format(self.model.score_, prec=decimals)))
-            except AttributeError:
-                pass
-
-            try:
-                footers.append(("AIC", "{:.{prec}f}".format(self.model.AIC_, prec=decimals)))
-            except AttributeError:
-                pass
-
-            try:
-                footers.append(("Partial AIC", "{:.{prec}f}".format(self.model.AIC_partial_, prec=decimals)))
-            except AttributeError:
-                pass
-
-            try:
-                sr = self.model.log_likelihood_ratio_test()
-                footers.append(
-                    (
-                        "Log-likelihood ratio test",
-                        "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals),
-                    )
-                )
-                footers.append(("-log2(p) of ll-ratio test", "{:.{prec}f}".format(-np.log2(sr.p_value), prec=decimals)))
-            except AttributeError:
-                pass
-
-        if footers:
-            footer_df = pd.DataFrame.from_records(footers).set_index(0)
+        if self.footers:
+            footer_df = pd.DataFrame.from_records(self.footers).set_index(0)
             footer_html = footer_df.to_html(header=False, notebook=True, index_names=False)
         else:
             footer_html = ""
@@ -194,28 +163,6 @@ class Printer:
         with np.errstate(invalid="ignore", divide="ignore"):
 
             print("---")
-            try:
-                if utils.CensoringType.is_right_censoring(self.model) and self.model._KNOWN_MODEL:
-                    print("Concordance = {:.{prec}f}".format(self.model.concordance_index_, prec=decimals))
-            except AttributeError:
-                pass
-            try:
-                print("AIC = {:.{prec}f}".format(self.model.AIC_, prec=decimals))
-            except AttributeError:
-                pass
-
-            try:
-                print("Partial AIC = {:.{prec}f}".format(self.model.AIC_partial_, prec=decimals))
-            except AttributeError:
-                pass
-
-            try:
-                sr = self.model.log_likelihood_ratio_test()
-                print(
-                    "Log-likelihood ratio test = {:.{prec}f} on {} df, -log2(p)={:.{prec}f}".format(
-                        sr.test_statistic, sr.degrees_freedom, -np.log2(sr.p_value), prec=decimals
-                    )
-                )
-            except AttributeError:
-                pass
+            for string, value in self.footers:
+                print("{} = {}".format(string, value))
         print()

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.24.6"
+__version__ = "0.24.7"


### PR DESCRIPTION
#### 0.24.7

##### New features
 - `find_best_parametric_model` can handle left and interval censoring. Also allows for more fitting options.
 - `AIC_` is a property on parametric models, and `AIC_partial_` is a property on Cox models.
 - `penalizer` in all regression models can now be an array instead of a float. This enables new functionality and better
 control over penalization. This is similar (but not identical) to `penalty.factors` in glmnet in R.
 - some convergence tweaks which should help recent performance regressions.

##### Bug fixes
 - fixed bug where `cdf_plot` and `qq_plot` were not factoring in the weights correctly.



 - <del>adding NPMLE as part of KaplanMeierFitter</del> this isn't ready for prime time yet. I'll ship as is, with a warning, and iterate on it. I won't be adding it to docs. 
   - [ ] add tests
 - adding AIC
   - [x] add tests
   - [x] docs
 - adding penalty arrays
   - [x] add tests
   - [x] docs


closes #1023 
closes #1022 
closes #982