### PR TITLE
Refactor CoxPHFitter

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Contents:
   :caption: Additional documentation
 
   Examples
-  References
+  references
 
 .. toctree::
   :maxdepth: 1

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -48,83 +48,8 @@ from lifelines import utils
 
 __all__ = ["CoxPHFitter"]
 
-CONVERGENCE_DOCS = "Please see the following tips in the lifelines documentation: https://lifelines.readthedocs.io/en/latest/Examples.html#problems-with-convergence-in-the-cox-proportional-hazard-model"
 
-
-class _PHSplineFitter(ParametricRegressionFitter, SplineFitterMixin, ProportionalHazardMixin):
-    """
-    Proportional Hazard model with cubic splines.
-
-    References
-    ------------
-    Royston, P., & Parmar, M. K. B. (2002). Flexible parametric proportional-hazards and proportional-odds models for censored survival data, with application to prognostic modelling and estimation of treatment effects. Statistics in Medicine, 21(15), 2175–2197. doi:10.1002/sim.1203 
-    """
-
-    _KNOWN_MODEL = True
-    _scipy_fit_method = "SLSQP"
-    _scipy_fit_options = {"maxiter": 1000, "iprint": 100}
-
-    def __init__(self, n_baseline_knots=1, *args, **kwargs):
-        self.n_baseline_knots = n_baseline_knots
-        self._fitted_parameter_names = ["beta_"] + ["phi%d_" % i for i in range(1, self.n_baseline_knots + 2)]
-        super(_PHSplineFitter, self).__init__(*args, **kwargs)
-
-    def set_knots(self, T, E):
-        self.knots = np.percentile(T[E.astype(bool).values], np.linspace(5, 95, self.n_baseline_knots + 2))
-        return
-
-    def _pre_fit_model(self, Ts, E, df):
-        self.set_knots(Ts[0], E)
-
-    def _create_initial_point(self, Ts, E, entries, weights, Xs):
-        return [
-            {
-                **{"beta_": np.zeros(len(Xs.mappings["beta_"])), "phi1_": np.array([0.05]), "phi2_": np.array([-0.05])},
-                **{"phi%d_" % i: np.array([0.0]) for i in range(3, self.n_baseline_knots + 2)},
-            }
-        ]
-
-    def _cumulative_hazard(self, params, T, Xs):
-        lT = anp.log(T)
-        H = safe_exp(anp.dot(Xs["beta_"], params["beta_"]) + params["phi1_"] * lT)
-
-        for i in range(2, self.n_baseline_knots + 2):
-            H *= safe_exp(
-                params["phi%d_" % i] * self.basis(lT, anp.log(self.knots[i - 1]), anp.log(self.knots[0]), anp.log(self.knots[-1]))
-            )
-        return H
-
-
-class _BatchVsSingle:
-
-    BATCH = "batch"
-    SINGLE = "single"
-
-    def decide(self, batch_mode: Optional[bool], n_unique: int, n_total: int, n_vars: int) -> str:
-        frac_dups = n_unique / n_total
-        if batch_mode or (
-            # https://github.com/CamDavidsonPilon/lifelines/issues/591 for original issue.
-            # new values from from perf/batch_vs_single script.
-            (batch_mode is None)
-            and (
-                (
-                    6.153_952e-01
-                    + -3.927_241e-06 * n_total
-                    + 2.544_118e-11 * n_total ** 2
-                    + 2.071_377e00 * frac_dups
-                    + -9.724_922e-01 * frac_dups ** 2
-                    + 9.138_711e-06 * n_total * frac_dups
-                    + -5.617_844e-03 * n_vars
-                    + -4.402_736e-08 * n_vars * n_total
-                )
-                < 1
-            )
-        ):
-            return self.BATCH
-        return self.SINGLE
-
-
-class CoxPHFitter(SemiParametricRegressionFittter, ProportionalHazardMixin):
+class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
     r"""
     This class implements fitting Cox's proportional hazard model using Efron's method for ties.
 
@@ -207,7 +132,7 @@ class CoxPHFitter(SemiParametricRegressionFittter, ProportionalHazardMixin):
         penalizer: Union[float, np.ndarray] = 0.0,
         strata: Optional[Union[List[str], str]] = None,
         l1_ratio: float = 0.0,
-        n_baseline_knots: int = 1,
+        n_baseline_knots: Optional[int] = None,
         **kwargs,
     ) -> None:
 
@@ -217,10 +142,385 @@ class CoxPHFitter(SemiParametricRegressionFittter, ProportionalHazardMixin):
             raise ValueError("l1_ratio parameter must in [0, 1].")
 
         self.penalizer = penalizer
-        self.strata = strata
+        self._strata = strata
         self.l1_ratio = l1_ratio
         self.baseline_estimation_method = baseline_estimation_method
         self.n_baseline_knots = n_baseline_knots
+
+    @utils.CensoringType.right_censoring
+    def fit(
+        self,
+        df: pd.DataFrame,
+        duration_col: Optional[str] = None,
+        event_col: Optional[str] = None,
+        show_progress: bool = False,
+        initial_point: Optional[ndarray] = None,
+        strata: Optional[Union[str, List[str]]] = None,
+        step_size: Optional[float] = None,
+        weights_col: Optional[str] = None,
+        cluster_col: Optional[str] = None,
+        robust: bool = False,
+        batch_mode: Optional[bool] = None,
+    ) -> "CoxPHFitter":
+        """
+        Fit the Cox proportional hazard model to a dataset.
+
+        Parameters
+        ----------
+        df: DataFrame
+            a Pandas DataFrame with necessary columns `duration_col` and
+            `event_col` (see below), covariates columns, and special columns (weights, strata).
+            `duration_col` refers to
+            the lifetimes of the subjects. `event_col` refers to whether
+            the 'death' events was observed: 1 if observed, 0 else (censored).
+
+        duration_col: string
+            the name of the column in DataFrame that contains the subjects'
+            lifetimes.
+
+        event_col: string, optional
+            the  name of the column in DataFrame that contains the subjects' death
+            observation. If left as None, assume all individuals are uncensored.
+
+        weights_col: string, optional
+            an optional column in the DataFrame, df, that denotes the weight per subject.
+            This column is expelled and not used as a covariate, but as a weight in the
+            final regression. Default weight is 1.
+            This can be used for case-weights. For example, a weight of 2 means there were two subjects with
+            identical observations.
+            This can be used for sampling weights. In that case, use ``robust=True`` to get more accurate standard errors.
+
+        show_progress: bool, optional (default=False)
+            since the fitter is iterative, show convergence
+            diagnostics. Useful if convergence is failing.
+
+        initial_point: (d,) numpy array, optional
+            initialize the starting point of the iterative
+            algorithm. Default is the zero vector.
+
+        strata: list or string, optional
+            specify a column or list of columns n to use in stratification. This is useful if a
+            categorical covariate does not obey the proportional hazard assumption. This
+            is used similar to the ``strata`` expression in R.
+            See http://courses.washington.edu/b515/l17.pdf.
+
+        step_size: float, optional
+            set an initial step size for the fitting algorithm. Setting to 1.0 may improve performance, but could also hurt convergence.
+
+        robust: bool, optional (default=False)
+            Compute the robust errors using the Huber sandwich estimator, aka Wei-Lin estimate. This does not handle
+            ties, so if there are high number of ties, results may significantly differ. See
+            "The Robust Inference for the Cox Proportional Hazards Model", Journal of the American Statistical Association, Vol. 84, No. 408 (Dec., 1989), pp. 1074- 1078
+
+        cluster_col: string, optional
+            specifies what column has unique identifiers for clustering covariances. Using this forces the sandwich estimator (robust variance estimator) to
+            be used.
+
+        batch_mode: bool, optional
+            enabling batch_mode can be faster for datasets with a large number of ties. If left as None, lifelines will choose the best option.
+
+        Returns
+        -------
+        self: CoxPHFitter
+            self with additional new properties: ``print_summary``, ``hazards_``, ``confidence_intervals_``, ``baseline_survival_``, etc.
+
+
+        Note
+        ----
+        Tied survival times are handled using Efron's tie-method.
+
+
+        Examples
+        --------
+        .. code:: python
+
+            from lifelines import CoxPHFitter
+
+            df = pd.DataFrame({
+                'T': [5, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+                'E': [1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0],
+                'var': [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2],
+                'age': [4, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+            })
+
+            cph = CoxPHFitter()
+            cph.fit(df, 'T', 'E')
+            cph.print_summary()
+            cph.predict_median(df)
+
+        .. code:: python
+
+            from lifelines import CoxPHFitter
+
+            df = pd.DataFrame({
+                'T': [5, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+                'E': [1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0],
+                'var': [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2],
+                'weights': [1.1, 0.5, 2.0, 1.6, 1.2, 4.3, 1.4, 4.5, 3.0, 3.2, 0.4, 6.2],
+                'month': [10, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+                'age': [4, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+            })
+
+            cph = CoxPHFitter()
+            cph.fit(df, 'T', 'E', strata=['month', 'age'], robust=True, weights_col='weights')
+            cph.print_summary()
+            cph.predict_median(df)
+
+        """
+        self._model = self._fit_model(
+            df,
+            duration_col,
+            event_col=event_col,
+            show_progress=show_progress,
+            initial_point=initial_point,
+            strata=utils.coalesce(strata, self._strata),
+            step_size=step_size,
+            weights_col=weights_col,
+            cluster_col=cluster_col,
+            robust=robust,
+            batch_mode=batch_mode,
+        )
+        return self
+
+    def __getattr__(self, attr):
+        if attr == "_model":
+            raise AttributeError("Must call fit first.")
+
+        try:
+            return getattr(self._model, attr)
+        except AttributeError:
+            raise AttributeError("%s has no attribute '%s'" % (self._class_name, attr))
+
+    def __dir__(self):
+        return self._model.__dir__() + ["print_summary", "baseline_estimation_method"]
+
+    def _fit_model(self, *args, **kwargs):
+        if self.baseline_estimation_method == "breslow":
+            return self._fit_model_breslow(*args, **kwargs)
+        elif self.baseline_estimation_method == "spline":
+            return self._fit_model_spline(*args, **kwargs)
+        else:
+            raise ValueError("Invalid baseline estimate supplied.")
+
+    def _fit_model_breslow(self, *args, **kwargs):
+        model = SemiParametricPHFitter(penalizer=self.penalizer, l1_ratio=self.l1_ratio, strata=self._strata)
+        model.fit(*args, **kwargs)
+        return model
+
+    def _fit_model_spline(self, *args, **kwargs):
+        # handle strata and cluster_col
+        if kwargs["strata"] is not None:
+            raise ValueError("strata is not available for this baseline estimation method")
+        if kwargs["cluster_col"] is not None:
+            raise ValueError("cluster_col is not available for this baseline estimation method")
+
+        kwargs.pop("strata")
+        kwargs.pop("cluster_col")
+        kwargs.pop("step_size")
+        kwargs.pop("batch_mode")
+        df = args[0].copy()
+        df["constant"] = 1
+
+        regressors = {
+            **{"beta_": df.columns.difference(["T", "E", "weights"]), "phi1_": ["constant"]},
+            **{"phi%d_" % i: ["constant"] for i in range(2, self.n_baseline_knots + 2)},
+        }
+
+        model = ParametricSplinePHFitter(penalizer=self.penalizer, l1_ratio=self.l1_ratio, n_baseline_knots=self.n_baseline_knots)
+        model.fit(df, *args[1:], regressors=regressors, **kwargs)
+        return model
+
+    def print_summary(self, decimals: int = 2, style: Optional[str] = None, **kwargs) -> None:
+        """
+        Print summary statistics describing the fit, the coefficients, and the error bounds.
+
+        Parameters
+        -----------
+        decimals: int, optional (default=2)
+            specify the number of decimal places to show
+        style: string
+            {html, ascii, latex}
+        kwargs:
+            print additional metadata in the output (useful to provide model names, dataset names, etc.) when comparing
+            multiple outputs.
+
+        """
+
+        # Print information about data first
+        justify = string_justify(25)
+
+        headers: List[Tuple[str, Any]] = []
+        headers.append(("duration col", "'%s'" % self.duration_col))
+
+        if self.event_col:
+            headers.append(("event col", "'%s'" % self.event_col))
+        if self.weights_col:
+            headers.append(("weights col", "'%s'" % self.weights_col))
+        if self.cluster_col:
+            headers.append(("cluster col", "'%s'" % self.cluster_col))
+        if isinstance(self.penalizer, np.ndarray) or self.penalizer > 0:
+            headers.append(("penalizer", self.penalizer))
+            headers.append(("l1 ratio", self.l1_ratio))
+        if self.robust or self.cluster_col:
+            headers.append(("robust variance", True))
+        if self.strata:
+            headers.append(("strata", self.strata))
+        if self.baseline_estimation_method == "spline":
+            headers.append(("number of baseline knots", self.n_baseline_knots))
+
+        headers.extend(
+            [
+                ("baseline estimation", self.baseline_estimation_method),
+                ("number of observations", "{:g}".format(self.weights.sum())),
+                ("number of events observed", "{:g}".format(self.weights[self.event_observed > 0].sum())),
+                (
+                    "partial log-likelihood" if self.baseline_estimation_method == "breslow" else "log-likelihood",
+                    "{:.{prec}f}".format(self.log_likelihood_, prec=decimals),
+                ),
+                ("time fit was run", self._time_fit_was_called),
+            ]
+        )
+
+        footers = []
+        sr = self.log_likelihood_ratio_test()
+
+        if self.baseline_estimation_method == "breslow":
+            footers.extend(
+                [
+                    ("Concordance", "{:.{prec}f}".format(self.concordance_index_, prec=decimals)),
+                    ("Partial AIC", "{:.{prec}f}".format(self.AIC_partial_, prec=decimals)),
+                ]
+            )
+        elif self.baseline_estimation_method == "spline":
+            footers.append(("AIC", "{:.{prec}f}".format(self.AIC_, prec=decimals)))
+
+        footers.append(
+            ("log-likelihood ratio test", "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals))
+        )
+        footers.append(("-log2(p) of ll-ratio test", "{:.{prec}f}".format(-utils.safe_log2(sr.p_value), prec=decimals)))
+
+        p = Printer(self, headers, footers, justify, decimals, kwargs)
+        p.print(style=style)
+
+    def compute_followup_hazard_ratios(self, training_df: DataFrame, followup_times: Iterable) -> DataFrame:
+        """
+        Recompute the hazard ratio at different follow-up times (lifelines handles accounting for updated censoring and updated durations).
+        This is useful because we need to remember that the hazard ratio is actually a weighted-average of period-specific hazard ratios.
+
+        Parameters
+        ----------
+
+        training_df: pd.DataFrame
+            The same dataframe used to train the model
+        followup_times: Iterable
+            a list/array of follow-up times to recompute the hazard ratio at.
+
+
+        """
+        results = {}
+        for t in sorted(followup_times):
+            assert t <= training_df[self.duration_col].max(), "all follow-up times must be less than max observed duration"
+            df = training_df.copy()
+            # if we "rollback" the df to time t, who is dead and who is censored
+            df[self.event_col] = (df[self.duration_col] <= t) & df[self.event_col]
+            df[self.duration_col] = np.minimum(df[self.duration_col], t)
+
+            model = self.__class__(
+                penalizer=self.penalizer,
+                l1_ratio=self.l1_ratio,
+                strata=self._strata,
+                baseline_estimation_method=self.baseline_estimation_method,
+                n_baseline_knots=self.n_baseline_knots,
+            ).fit(df, self.duration_col, self.event_col, weights_col=self.weights_col, cluster_col=self.cluster_col)
+            results[t] = model.hazard_ratios_
+        return DataFrame(results).T
+
+
+class SemiParametricPHFitter(ProportionalHazardMixin, SemiParametricRegressionFittter):
+    r"""
+    This class implements fitting Cox's proportional hazard model using Efron's method for ties.
+
+    .. math::  h(t|x) = h_0(t) \exp((x - \overline{x})' \beta)
+
+    The baseline hazard, :math:`h_0(t)` is modeled non-parametrically (using Breslow's method).
+
+    Parameters
+    ----------
+
+      alpha: float, optional (default=0.05)
+        the level in the confidence intervals.
+
+      penalizer: float or array, optional (default=0.0)
+        Attach a penalty to the size of the coefficients during regression. This improves
+        stability of the estimates and controls for high correlation between covariates.
+        For example, this shrinks the magnitude value of :math:`\beta_i`. See ``l1_ratio`` below.
+        The penalty term is :math:`\frac{1}{2} \text{penalizer} \left( (1-\text{l1_ratio}) ||\beta||_2^2 + \text{l1_ratio}||\beta||_1\right)`.
+
+        Alternatively, penalizer is an array equal in size to the number of parameters, with penalty coefficients for specific variables. For
+        example, `penalizer=0.01 * np.ones(p)` is the same as `penalizer=0.01`
+
+      l1_ratio: float, optional (default=0.0)
+        Specify what ratio to assign to a L1 vs L2 penalty. Same as scikit-learn. See ``penalizer`` above.
+
+      strata: list, optional
+        specify a list of columns to use in stratification. This is useful if a
+        categorical covariate does not obey the proportional hazard assumption. This
+        is used similar to the `strata` expression in R.
+        See http://courses.washington.edu/b515/l17.pdf.
+
+    Examples
+    --------
+    .. code:: python
+
+        from lifelines.datasets import load_rossi
+        from lifelines import CoxPHFitter
+        rossi = load_rossi()
+        cph = CoxPHFitter()
+        cph.fit(rossi, 'week', 'arrest')
+        cph.print_summary()
+
+    Attributes
+    ----------
+    params_ : Series
+        The estimated coefficients. Changed in version 0.22.0: use to be ``.hazards_``
+    hazard_ratios_ : Series
+        The exp(coefficients)
+    confidence_intervals_ : DataFrame
+        The lower and upper confidence intervals for the hazard coefficients
+    durations: Series
+        The durations provided
+    event_observed: Series
+        The event_observed variable provided
+    weights: Series
+        The event_observed variable provided
+    variance_matrix_ : numpy array
+        The variance matrix of the coefficients
+    strata: list
+        the strata provided
+    standard_errors_: Series
+        the standard errors of the estimates
+    baseline_hazard_: DataFrame
+    baseline_cumulative_hazard_: DataFrame
+    baseline_survival_: DataFrame
+    """
+    _KNOWN_MODEL = True
+
+    def __init__(
+        self,
+        penalizer: Union[float, np.ndarray] = 0.0,
+        strata: Optional[Union[List[str], str]] = None,
+        l1_ratio: float = 0.0,
+        **kwargs,
+    ) -> None:
+
+        super(SemiParametricPHFitter, self).__init__(**kwargs)
+
+        if l1_ratio < 0 or l1_ratio > 1:
+            raise ValueError("l1_ratio parameter must in [0, 1].")
+
+        self.penalizer = penalizer
+        self.strata = strata
+        self.l1_ratio = l1_ratio
 
     @utils.CensoringType.right_censoring
     def fit(
@@ -374,11 +674,12 @@ class CoxPHFitter(SemiParametricRegressionFittter, ProportionalHazardMixin):
             normalize(X.values, self._norm_mean.values, self._norm_std.values), index=X.index, columns=X.columns
         )
 
-        params_, ll_, variance_matrix_, baseline_hazard_, baseline_cumulative_hazard_ = self._fit_model(
+        params_, ll_, variance_matrix_, baseline_hazard_, baseline_cumulative_hazard_, model = self._fit_model(
             X_norm, T, E, weights=weights, initial_point=initial_point, show_progress=show_progress, step_size=step_size
         )
 
         self.log_likelihood_ = ll_
+        self.model = model
         self.variance_matrix_ = variance_matrix_
         self.params_ = pd.Series(params_, index=X.columns, name="coef")
         self.baseline_hazard_ = baseline_hazard_
@@ -467,15 +768,7 @@ estimate the variances. See paper "Variance estimation when using inverse probab
             if (W <= 0).any():
                 raise ValueError("values in weight column %s must be positive." % self.weights_col)
 
-    def _fit_model(self, *args, **kwargs):
-        if self.baseline_estimation_method == "breslow":
-            return self._fit_model_breslow(*args, **kwargs)
-        elif self.baseline_estimation_method == "spline":
-            return self._fit_model_spline(*args, **kwargs)
-        else:
-            raise ValueError("Invalid baseline estimate supplied.")
-
-    def _fit_model_breslow(
+    def _fit_model(
         self,
         X: DataFrame,
         T: Series,
@@ -505,7 +798,7 @@ estimate the variances. See paper "Variance estimation when using inverse probab
         else:
             variance_matrix_ = pd.DataFrame(index=X.columns, columns=X.columns)
 
-        return params_, ll_, variance_matrix_, baseline_hazard_, baseline_cumulative_hazard_
+        return params_, ll_, variance_matrix_, baseline_hazard_, baseline_cumulative_hazard_, None
 
     def _newton_rhapson_for_efron_model(
         self,
@@ -549,6 +842,8 @@ estimate the variances. See paper "Variance estimation when using inverse probab
         -------
         beta: (1,d) numpy array.
         """
+        CONVERGENCE_DOCS = "Please see the following tips in the lifelines documentation: https://lifelines.readthedocs.io/en/latest/Examples.html#problems-with-convergence-in-the-cox-proportional-hazard-model"
+
         n, d = X.shape
 
         # soft penalizer functions, from https://www.cs.ubc.ca/cgi-bin/tr/2009/TR-2009-19.pdf
@@ -700,45 +995,6 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
             warnings.warn("Newton-Rhaphson failed to converge sufficiently in %d steps.\n" % max_steps, ConvergenceWarning)
 
         return beta, ll_, hessian
-
-    def _fit_model_spline(
-        self,
-        X: DataFrame,
-        T: Series,
-        E: Series,
-        weights: Series,
-        initial_point: Optional[ndarray] = None,
-        show_progress: bool = True,
-        **kwargs,
-    ):
-        if self.strata is not None:
-            raise NotImplementedError("Spline estimation cannot be used with strata yet.")
-
-        df = X.copy()
-        df["T"] = T
-        df["E"] = E
-        df["weights"] = weights
-        df["constant"] = 1.0
-
-        regressors = {
-            **{"beta_": df.columns.difference(["T", "E", "weights"]), "phi1_": ["constant"]},
-            **{"phi%d_" % i: ["constant"] for i in range(2, self.n_baseline_knots + 2)},
-        }
-
-        cph = _PHSplineFitter(n_baseline_knots=self.n_baseline_knots, penalizer=self.penalizer, l1_ratio=self.l1_ratio)
-        cph.fit(df, "T", "E", weights_col="weights", show_progress=show_progress, robust=self.robust, regressors=regressors)
-        self._ll_null_ = cph._ll_null
-        baseline_hazard_ = cph.predict_hazard(df.mean()).rename(columns={0: "baseline hazard"})
-        baseline_cumulative_hazard_ = cph.predict_cumulative_hazard(df.mean()).rename(columns={0: "baseline cumulative hazard"})
-
-        return (
-            cph.params_.loc["beta_"].drop("constant") / self._norm_std,
-            cph.log_likelihood_,
-            cph.variance_matrix_.loc["beta_", "beta_"].drop("constant").drop("constant", axis=1)
-            / np.outer(self._norm_std, self._norm_std),
-            baseline_hazard_,
-            baseline_cumulative_hazard_,
-        )
 
     def _get_efron_values_single(
         self, X: ndarray, T: ndarray, E: ndarray, weights: ndarray, beta: ndarray
@@ -1298,74 +1554,6 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
             df["-log2(p)"] = -utils.safe_log2(df["p"])
             return df
 
-    def print_summary(self, decimals: int = 2, style: Optional[str] = None, **kwargs) -> None:
-        """
-        Print summary statistics describing the fit, the coefficients, and the error bounds.
-
-        Parameters
-        -----------
-        decimals: int, optional (default=2)
-            specify the number of decimal places to show
-        style: string
-            {html, ascii, latex}
-        kwargs:
-            print additional metadata in the output (useful to provide model names, dataset names, etc.) when comparing
-            multiple outputs.
-
-        """
-
-        # Print information about data first
-        justify = string_justify(25)
-
-        headers: List[Tuple[str, Any]] = []
-        headers.append(("duration col", "'%s'" % self.duration_col))
-
-        if self.event_col:
-            headers.append(("event col", "'%s'" % self.event_col))
-        if self.weights_col:
-            headers.append(("weights col", "'%s'" % self.weights_col))
-        if self.cluster_col:
-            headers.append(("cluster col", "'%s'" % self.cluster_col))
-        if isinstance(self.penalizer, np.ndarray) or self.penalizer > 0:
-            headers.append(("penalizer", self.penalizer))
-            headers.append(("l1 ratio", self.l1_ratio))
-        if self.robust or self.cluster_col:
-            headers.append(("robust variance", True))
-        if self.strata:
-            headers.append(("strata", self.strata))
-        if self.baseline_estimation_method == "spline":
-            headers.append(("number of baseline knots", self.n_baseline_knots))
-
-        headers.extend(
-            [
-                ("baseline estimation", self.baseline_estimation_method),
-                ("number of observations", "{:g}".format(self.weights.sum())),
-                ("number of events observed", "{:g}".format(self.weights[self.event_observed > 0].sum())),
-                (
-                    "partial log-likelihood" if self.baseline_estimation_method == "breslow" else "log-likelihood",
-                    "{:.{prec}f}".format(self.log_likelihood_, prec=decimals),
-                ),
-                ("time fit was run", self._time_fit_was_called),
-            ]
-        )
-
-        sr = self.log_likelihood_ratio_test()
-        footers = []
-        footers.extend(
-            [
-                ("Concordance", "{:.{prec}f}".format(self.concordance_index_, prec=decimals)),
-                ("Partial AIC", "{:.{prec}f}".format(self.AIC_partial_, prec=decimals)),
-                (
-                    "log-likelihood ratio test",
-                    "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals),
-                ),
-                ("-log2(p) of ll-ratio test", "{:.{prec}f}".format(-utils.safe_log2(sr.p_value), prec=decimals)),
-            ]
-        )
-
-        p = Printer(self, headers, footers, justify, decimals, kwargs)
-        p.print(style=style)
-
     def _trivial_log_likelihood(self):
         df = pd.DataFrame({"T": self.durations, "E": self.event_observed, "W": self.weights})
         trivial_model = self.__class__().fit(df, "E", weights_col="W", batch_mode=self.batch_mode)
@@ -1887,7 +2075,7 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
             if covariate not in self.params_.index:
                 raise KeyError("covariate `%s` is not present in the original dataset" % covariate)
 
-        drawstyle = "steps-post" if self.baseline_estimation_method == "breslow" else "default"
+        drawstyle = "steps-post"
         set_kwargs_drawstyle(kwargs, drawstyle)
 
         if self.strata is None:
@@ -1962,10 +2150,6 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
             cph.score(rossi_test)
 
         """
-
-        if self.baseline_estimation_method != "breslow":
-            raise NotImplementedError("Only breslow implemented atm.")
-
         df = df.copy()
 
         if self.strata:
@@ -2043,34 +2227,128 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
             return self.concordance_index_
         return self._concordance_index_
 
-    def compute_followup_hazard_ratios(self, training_df: DataFrame, followup_times: Iterable) -> DataFrame:
+
+class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, ProportionalHazardMixin):
+    r"""
+    Proportional hazard model with cubic splines model for the baseline hazard.
+
+    .. math::  h(t|x) = h_0(t) \exp((x - \overline{x})' \beta)
+
+    where
+
+    .. math:: h_0(t) = \exp{\left( \phi_0 + \phi_1\log{t} + \sum_{j=2}^N \phi_j v_j\(\log{t})\right)}
+
+    where :math:`v_j` are our cubic basis functions at predetermined knots. See references for exact definition.
+
+    References
+    ------------
+    Royston, P., & Parmar, M. K. B. (2002). Flexible parametric proportional-hazards and proportional-odds models for censored survival data, with application to prognostic modelling and estimation of treatment effects. Statistics in Medicine, 21(15), 2175–2197. doi:10.1002/sim.1203 
+    """
+
+    _scipy_fit_method = "SLSQP"
+    _scipy_fit_options = {"maxiter": 1000, "iprint": 100}
+
+    _KNOWN_MODEL = True
+    _FAST_MEDIAN_PREDICT = False
+
+    cluster_col = None
+    strata = None
+
+    def __init__(self, n_baseline_knots=1, *args, **kwargs):
+        assert n_baseline_knots is not None, "n_baseline_knots must be a positive integer. Set in class instantiation"
+        self.n_baseline_knots = n_baseline_knots
+        self._fitted_parameter_names = ["beta_"] + ["phi%d_" % i for i in range(1, self.n_baseline_knots + 2)]
+        super(ParametricSplinePHFitter, self).__init__(*args, **kwargs)
+
+    def _set_knots(self, T, E):
+        self.knots = np.percentile(T[E.astype(bool).values], np.linspace(5, 95, self.n_baseline_knots + 2))
+        return
+
+    def _pre_fit_model(self, Ts, E, df):
+        self._set_knots(Ts[0], E)
+
+    def _create_initial_point(self, Ts, E, entries, weights, Xs):
+        return [
+            {
+                **{"beta_": np.zeros(len(Xs.mappings["beta_"])), "phi1_": np.array([0.05]), "phi2_": np.array([-0.05])},
+                **{"phi%d_" % i: np.array([0.0]) for i in range(3, self.n_baseline_knots + 2)},
+            }
+        ]
+
+    def _cumulative_hazard(self, params, T, Xs):
+        lT = anp.log(T)
+        H = safe_exp(anp.dot(Xs["beta_"], params["beta_"]) + params["phi1_"] * lT)
+
+        for i in range(2, self.n_baseline_knots + 2):
+            H *= safe_exp(
+                params["phi%d_" % i] * self.basis(lT, anp.log(self.knots[i - 1]), anp.log(self.knots[0]), anp.log(self.knots[-1]))
+            )
+        return H
+
+    @property
+    def baseline_hazard_(self):
+        return self.baseline_hazard_at_times()
+
+    @property
+    def baseline_survival_(self):
+        return self.baseline_survival_at_times()
+
+    @property
+    def baseline_cumulative_hazard_(self):
+        return self.baseline_cumulative_hazard_at_times()
+
+    def baseline_hazard_at_times(self, times=None):
         """
-        Recompute the hazard ratio at different follow-up times (lifelines handles accounting for updated censoring and updated durations).
-        This is useful because we need to remember that the hazard ratio is actually a weighted-average of period-specific hazard ratios.
-
-        Parameters
-        ----------
-
-        training_df: pd.DataFrame
-            The same dataframe used to train the model
-        followup_times: Iterable
-            a list/array of follow-up times to recompute the hazard ratio at.
-
-
+        Predict the baseline hazard at times (Defaults to observed durations)
         """
-        results = {}
-        for t in sorted(followup_times):
-            assert t <= training_df[self.duration_col].max(), "all follow-up times must be less than max observed duration"
-            df = training_df.copy()
-            # if we "rollback" the df to time t, who is dead and who is censored
-            df[self.event_col] = (df[self.duration_col] <= t) & df[self.event_col]
-            df[self.duration_col] = np.minimum(df[self.duration_col], t)
+        times = utils.coalesce(times, np.unique(self.durations))
+        v = self.predict_hazard(self._norm_mean, times=times)
+        v.columns = ["baseline hazard"]
+        return v
 
-            model = self.__class__(
-                penalizer=self.penalizer,
-                l1_ratio=self.l1_ratio,
-                strata=self.strata,
-                baseline_estimation_method=self.baseline_estimation_method,
-            ).fit(df, self.duration_col, self.event_col, weights_col=self.weights_col, cluster_col=self.cluster_col)
-            results[t] = model.hazard_ratios_
-        return DataFrame(results).T
+    def baseline_survival_at_times(self, times=None):
+        """
+        Predict the baseline survival at times (Defaults to observed durations)
+        """
+        times = utils.coalesce(times, np.unique(self.durations))
+        v = self.predict_survival_function(self._norm_mean, times=times)
+        v.columns = ["baseline survival"]
+        return v
+
+    def baseline_cumulative_hazard_at_times(self, times=None):
+        """
+        Predict the baseline cumulative hazard at times (Defaults to observed durations)
+        """
+        times = utils.coalesce(times, np.unique(self.durations))
+        v = self.predict_cumulative_hazard(self._norm_mean, times=times)
+        v.columns = ["baseline cumulative hazard"]
+        return v
+
+
+class _BatchVsSingle:
+
+    BATCH = "batch"
+    SINGLE = "single"
+
+    def decide(self, batch_mode: Optional[bool], n_unique: int, n_total: int, n_vars: int) -> str:
+        frac_dups = n_unique / n_total
+        if batch_mode or (
+            # https://github.com/CamDavidsonPilon/lifelines/issues/591 for original issue.
+            # new values from from perf/batch_vs_single script.
+            (batch_mode is None)
+            and (
+                (
+                    6.153_952e-01
+                    + -3.927_241e-06 * n_total
+                    + 2.544_118e-11 * n_total ** 2
+                    + 2.071_377e00 * frac_dups
+                    + -9.724_922e-01 * frac_dups ** 2
+                    + 9.138_711e-06 * n_total * frac_dups
+                    + -5.617_844e-03 * n_vars
+                    + -4.402_736e-08 * n_vars * n_total
+                )
+                < 1
+            )
+        ):
+            return self.BATCH
+        return self.SINGLE

--- a/lifelines/fitters/spline_fitter.py
+++ b/lifelines/fitters/spline_fitter.py
@@ -11,9 +11,7 @@ class SplineFitter(KnownModelParametricUnivariateFitter, SplineFitterMixin):
     r"""
     Model the cumulative hazard using :math:`N` cubic splines. This offers great flexibility and smoothness of the cumulative hazard.
 
-    .. math::
-
-        H(t) = \exp{\left( \phi_0 + \phi_1\log{t} + \sum_{j=2}^N \phi_j v_j\(\log{t})\right)}
+    .. math:: H(t) = \exp{\left( \phi_0 + \phi_1\log{t} + \sum_{j=2}^N \phi_j v_j\(\log{t})\right)}
 
     where :math:`v_j` are our cubic basis functions at predetermined knots. See references for exact definition.
 

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -29,7 +29,6 @@ __all__ = [
     "proportional_hazard_test",
     "power_under_cph",
     "sample_size_necessary_under_cph",
-    "somers_d",
 ]
 
 

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -43,6 +43,7 @@ from lifelines.utils import (
 )
 
 from lifelines.fitters import BaseFitter, ParametricUnivariateFitter, ParametricRegressionFitter
+from lifelines.fitters.coxph_fitter import SemiParametricPHFitter
 
 from lifelines import (
     WeibullFitter,
@@ -2656,6 +2657,101 @@ class TestWeibullAFTFitter:
         aft.print_summary()
 
 
+class TestCoxPHFitter_SemiParametric:
+    @pytest.fixture
+    def cph(self):
+        return SemiParametricPHFitter()
+
+    def test_single_efron_computed_by_hand_examples(self, data_nus, cph):
+        X = data_nus["x"][:, None]
+        T = data_nus["t"]
+        E = data_nus["E"]
+        weights = np.ones_like(T)
+
+        # Enforce numpy arrays
+        X = np.array(X)
+        T = np.array(T)
+        E = np.array(E)
+
+        # Want as bools
+        E = E.astype(bool)
+
+        # tests from http://courses.nus.edu.sg/course/stacar/internet/st3242/handouts/notes3.pdf
+        beta = np.array([0])
+
+        l, u, _ = cph._get_efron_values_single(X, T, E, weights, beta)
+        l = -l
+
+        assert np.abs(u[0] - -2.51) < 0.05
+        assert np.abs(l[0][0] - 77.13) < 0.05
+        beta = beta + u / l[0]
+        assert np.abs(beta - -0.0326) < 0.05
+
+        l, u, _ = cph._get_efron_values_single(X, T, E, weights, beta)
+        l = -l
+
+        assert np.abs(l[0][0] - 72.83) < 0.05
+        assert np.abs(u[0] - -0.069) < 0.05
+        beta = beta + u / l[0]
+        assert np.abs(beta - -0.0325) < 0.01
+
+        l, u, _ = cph._get_efron_values_single(X, T, E, weights, beta)
+        l = -l
+
+        assert np.abs(l[0][0] - 72.70) < 0.01
+        assert np.abs(u[0] - -0.000061) < 0.01
+        beta = beta + u / l[0]
+        assert np.abs(beta - -0.0335) < 0.01
+
+    def test_batch_efron_computed_by_hand_examples(self, data_nus, cph):
+        X = data_nus["x"][:, None]
+        T = data_nus["t"]
+        E = data_nus["E"]
+        weights = np.ones_like(T)
+
+        # Enforce numpy arrays
+        X = np.array(X)
+        T = np.array(T)
+        E = np.array(E)
+
+        # Want as bools
+        E = E.astype(bool)
+
+        # tests from http://courses.nus.edu.sg/course/stacar/internet/st3242/handouts/notes3.pdf
+        beta = np.array([0])
+
+        l, u, _ = cph._get_efron_values_batch(X, T, E, weights, beta)
+        l = -l
+
+        assert np.abs(u[0] - -2.51) < 0.05
+        assert np.abs(l[0][0] - 77.13) < 0.05
+        beta = beta + u / l[0]
+        assert np.abs(beta - -0.0326) < 0.05
+
+        l, u, _ = cph._get_efron_values_batch(X, T, E, weights, beta)
+        l = -l
+
+        assert np.abs(l[0][0] - 72.83) < 0.05
+        assert np.abs(u[0] - -0.069) < 0.05
+        beta = beta + u / l[0]
+        assert np.abs(beta - -0.0325) < 0.01
+
+        l, u, _ = cph._get_efron_values_batch(X, T, E, weights, beta)
+        l = -l
+
+        assert np.abs(l[0][0] - 72.70) < 0.01
+        assert np.abs(u[0] - -0.000061) < 0.01
+        beta = beta + u / l[0]
+        assert np.abs(beta - -0.0335) < 0.01
+
+    def test_efron_newtons_method(self, data_nus, cph):
+        cph._batch_mode = False
+        newton = cph._newton_rhapson_for_efron_model
+        X, T, E, W = (data_nus[["x"]], data_nus["t"], data_nus["E"], pd.Series(np.ones_like(data_nus["t"])))
+
+        assert np.abs(newton(X, T, E, W)[0] - -0.0335) < 0.0001
+
+
 class TestCoxPHFitter:
     @pytest.fixture
     def cph(self):
@@ -2663,7 +2759,7 @@ class TestCoxPHFitter:
 
     @pytest.fixture
     def cph_spline(self):
-        return CoxPHFitter(baseline_estimation_method="spline")
+        return CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=1)
 
     def test_penalizer_can_be_an_array(self, rossi):
 
@@ -2711,7 +2807,18 @@ class TestCoxPHFitter:
 
         cph_sp = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=1)
         cph_sp.fit(test_data, duration_col="Days")
+
+        # check survival is always decreasing
         assert np.all(cph_sp.baseline_survival_.diff().dropna() < 0)
+
+    def test_spline_and_breslow_models_offer_very_comparible_baseline_survivals(self, rossi):
+        cph_breslow = CoxPHFitter().fit(rossi, "week", "arrest")
+        cph_spline = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2).fit(rossi, "week", "arrest")
+
+        bh_spline = cph_spline.baseline_survival_at_times()
+        bh_breslow = cph_breslow.baseline_survival_
+
+        assert (bh_breslow["baseline survival"] - bh_spline["baseline survival"]).std() < 0.005
 
     def test_penalty_term_is_used_in_log_likelihood_value(self, rossi):
         assert (
@@ -2720,9 +2827,15 @@ class TestCoxPHFitter:
             < CoxPHFitter(penalizer=0).fit(rossi, "week", "arrest").log_likelihood_
         )
         assert (
-            CoxPHFitter(penalizer=1e-6, baseline_estimation_method="spline").fit(rossi, "week", "arrest").log_likelihood_
-            < CoxPHFitter(penalizer=1e-8, baseline_estimation_method="spline").fit(rossi, "week", "arrest").log_likelihood_
-            < CoxPHFitter(penalizer=0, baseline_estimation_method="spline").fit(rossi, "week", "arrest").log_likelihood_
+            CoxPHFitter(penalizer=1e-6, baseline_estimation_method="spline", n_baseline_knots=1)
+            .fit(rossi, "week", "arrest")
+            .log_likelihood_
+            < CoxPHFitter(penalizer=1e-8, baseline_estimation_method="spline", n_baseline_knots=1)
+            .fit(rossi, "week", "arrest")
+            .log_likelihood_
+            < CoxPHFitter(penalizer=0, baseline_estimation_method="spline", n_baseline_knots=1)
+            .fit(rossi, "week", "arrest")
+            .log_likelihood_
         )
 
     def test_baseline_estimation_for_spline(self, rossi, cph_spline):
@@ -3147,97 +3260,6 @@ log-likelihood ratio test = 33.27 on 7 df
     def test_log_likelihood(self, data_nus, cph):
         cph.fit(data_nus, duration_col="t", event_col="E")
         assert abs(cph.log_likelihood_ - -12.7601409152) < 0.001
-
-    def test_single_efron_computed_by_hand_examples(self, data_nus, cph):
-
-        X = data_nus["x"][:, None]
-        T = data_nus["t"]
-        E = data_nus["E"]
-        weights = np.ones_like(T)
-
-        # Enforce numpy arrays
-        X = np.array(X)
-        T = np.array(T)
-        E = np.array(E)
-
-        # Want as bools
-        E = E.astype(bool)
-
-        # tests from http://courses.nus.edu.sg/course/stacar/internet/st3242/handouts/notes3.pdf
-        beta = np.array([0])
-
-        l, u, _ = cph._get_efron_values_single(X, T, E, weights, beta)
-        l = -l
-
-        assert np.abs(u[0] - -2.51) < 0.05
-        assert np.abs(l[0][0] - 77.13) < 0.05
-        beta = beta + u / l[0]
-        assert np.abs(beta - -0.0326) < 0.05
-
-        l, u, _ = cph._get_efron_values_single(X, T, E, weights, beta)
-        l = -l
-
-        assert np.abs(l[0][0] - 72.83) < 0.05
-        assert np.abs(u[0] - -0.069) < 0.05
-        beta = beta + u / l[0]
-        assert np.abs(beta - -0.0325) < 0.01
-
-        l, u, _ = cph._get_efron_values_single(X, T, E, weights, beta)
-        l = -l
-
-        assert np.abs(l[0][0] - 72.70) < 0.01
-        assert np.abs(u[0] - -0.000061) < 0.01
-        beta = beta + u / l[0]
-        assert np.abs(beta - -0.0335) < 0.01
-
-    def test_batch_efron_computed_by_hand_examples(self, data_nus, cph):
-
-        X = data_nus["x"][:, None]
-        T = data_nus["t"]
-        E = data_nus["E"]
-        weights = np.ones_like(T)
-
-        # Enforce numpy arrays
-        X = np.array(X)
-        T = np.array(T)
-        E = np.array(E)
-
-        # Want as bools
-        E = E.astype(bool)
-
-        # tests from http://courses.nus.edu.sg/course/stacar/internet/st3242/handouts/notes3.pdf
-        beta = np.array([0])
-
-        l, u, _ = cph._get_efron_values_batch(X, T, E, weights, beta)
-        l = -l
-
-        assert np.abs(u[0] - -2.51) < 0.05
-        assert np.abs(l[0][0] - 77.13) < 0.05
-        beta = beta + u / l[0]
-        assert np.abs(beta - -0.0326) < 0.05
-
-        l, u, _ = cph._get_efron_values_batch(X, T, E, weights, beta)
-        l = -l
-
-        assert np.abs(l[0][0] - 72.83) < 0.05
-        assert np.abs(u[0] - -0.069) < 0.05
-        beta = beta + u / l[0]
-        assert np.abs(beta - -0.0325) < 0.01
-
-        l, u, _ = cph._get_efron_values_batch(X, T, E, weights, beta)
-        l = -l
-
-        assert np.abs(l[0][0] - 72.70) < 0.01
-        assert np.abs(u[0] - -0.000061) < 0.01
-        beta = beta + u / l[0]
-        assert np.abs(beta - -0.0335) < 0.01
-
-    def test_efron_newtons_method(self, data_nus, cph):
-        cph._batch_mode = False
-        newton = cph._newton_rhapson_for_efron_model
-        X, T, E, W = (data_nus[["x"]], data_nus["t"], data_nus["E"], pd.Series(np.ones_like(data_nus["t"])))
-
-        assert np.abs(newton(X, T, E, W)[0] - -0.0335) < 0.0001
 
     def test_fit_method(self, data_nus, cph):
         cph.fit(data_nus, duration_col="t", event_col="E")

--- a/lifelines/utils/printer.py
+++ b/lifelines/utils/printer.py
@@ -165,4 +165,3 @@ class Printer:
             print("---")
             for string, value in self.footers:
                 print("{} = {}".format(string, value))
-        print()


### PR DESCRIPTION
So this refactor places CoxPHFitter as a shell that calls out to two different models: SemiParametricPHFitter (new) and ParametricSplinePHFitter (renamed). These do almost all of the work. This abstraction, hopefully totally hidden from the end user, allows us to add new PH models in the future under this facade, and corrects the prediction and baseline problems users were having (#1032)