### PR TITLE
V0.24.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ python:
    - "3.8"
 env:
   matrix:
-    - export PANDAS_VERSION=0.23.4     && export NUMPY_VERSION=1.19.0
-    - export PANDAS_VERSION=0.25.3     && export NUMPY_VERSION=1.19.0
-    - export NUMPY_VERSION=1.15.4      && export PANDAS_VERSION=1.0.5
-    - export NUMPY_VERSION=1.19.0      && export PANDAS_VERSION=1.0.5
+    - PANDAS_VERSION=0.23.4  && NUMPY_VERSION=1.19.0
+    - PANDAS_VERSION=0.25.3  && NUMPY_VERSION=1.19.0
+    - NUMPY_VERSION=1.15.4   && PANDAS_VERSION=1.0.5
+    - NUMPY_VERSION=1.19.0   && PANDAS_VERSION=1.0.5
 before_install:
   - ls
   # - sudo apt-get update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-#### 0.24.15
+#### 0.24.15 - 2020-07-07
 
 ##### Bug fixes
 - fixed an edge case in `KaplanMeierFitter` where a really late entry would occur after all other population had died.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### 0.24.15
 
 ##### Bug fixes
-- fixed an edge case in `KaplanMeierFitter` where a rally late entry would occur after all other population had died.
+- fixed an edge case in `KaplanMeierFitter` where a really late entry would occur after all other population had died.
 - fixed `plot` in `BreslowFlemingtonHarrisFitter`
 - fixed bug where using `conditional_after` and `times` in `CoxPHFitter("spline")` prediction methods would be ignored.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+#### 0.24.15
+
+##### Bug fixes
+- fixed an edge case in `KaplanMeierFitter` where a rally late entry would occur after all other population had died.
+- fixed `plot` in `BreslowFlemingtonHarrisFitter`
+
+
 #### 0.24.14 - 2020-07-02
 
 ##### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ##### Bug fixes
 - fixed an edge case in `KaplanMeierFitter` where a rally late entry would occur after all other population had died.
 - fixed `plot` in `BreslowFlemingtonHarrisFitter`
+- fixed bug where using `conditional_after` and `times` in `CoxPHFitter("spline")` prediction methods would be ignored.
 
 
 #### 0.24.14 - 2020-07-02

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 init:
 ifeq ($(TRAVIS), true)
-		pip install -r reqs/travis-requirements.txt --upgrade
+		pip install -r reqs/travis-requirements.txt
 		pip install pandas==${PANDAS_VERSION}
 		pip install numpy==${NUMPY_VERSION}
 		pip freeze --local
 else
-		pip install -r reqs/dev-requirements.txt --upgrade
+		pip install -r reqs/dev-requirements.txt
 		pre-commit install
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 init:
 ifeq ($(TRAVIS), true)
-		pip install -r reqs/travis-requirements.txt
+		pip install -r reqs/travis-requirements.txt --upgrade
 		pip install pandas==${PANDAS_VERSION}
 		pip install numpy==${NUMPY_VERSION}
-		pip list --local
+		pip freeze --local
 else
-		pip install -r reqs/dev-requirements.txt
+		pip install -r reqs/dev-requirements.txt --upgrade
 		pre-commit install
 endif
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 [What is survival analysis and why should I learn it?](http://lifelines.readthedocs.org/en/latest/Survival%20Analysis%20intro.html)
  Survival analysis was originally developed and applied heavily by the actuarial and medical community. Its purpose was to answer *why do events occur now versus later* under uncertainty (where *events* might refer to deaths, disease remission, etc.). This is great for researchers who are interested in measuring lifetimes: they can answer questions like *what factors might influence deaths?*
 
-But outside of medicine and actuarial science, there are many other interesting and exciting applications of this survival analysis. For example:
+But outside of medicine and actuarial science, there are many other interesting and exciting applications of survival analysis. For example:
 - SaaS providers are interested in measuring subscriber lifetimes, or time to some first action
 - inventory stock out is a censoring event for true "demand" of a good.
 - sociologists are interested in measuring political parties' lifetimes, or relationships, or marriages
 - A/B tests to determine how long it takes different groups to perform an action.
 
-*lifelines* is a pure Python implementation of the best parts of survival analysis. We'd love to hear if you are using *lifelines*, please leave an Issue and let us know your thoughts on the library.
+*lifelines* is a pure Python implementation of the best parts of survival analysis.
 
 
 ## Documentation and intro to survival analysis

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,8 +1,24 @@
 Changelog
 ---------
 
+0.24.15 - 2020-07-07
+^^^^^^^^^^^^^^^^^^^^
+
+Bug fixes
+'''''''''
+
+-  fixed an edge case in ``KaplanMeierFitter`` where a really late entry
+   would occur after all other population had died.
+-  fixed ``plot`` in ``BreslowFlemingtonHarrisFitter``
+-  fixed bug where using ``conditional_after`` and ``times`` in
+   ``CoxPHFitter("spline")`` prediction methods would be ignored.
+
+.. _section-1:
+
 0.24.14 - 2020-07-02
 ^^^^^^^^^^^^^^^^^^^^
+
+.. _bug-fixes-1:
 
 Bug fixes
 '''''''''
@@ -14,12 +30,12 @@ Bug fixes
 -  fixed a bug where some columns would not be displayed in
    ``print_summary``
 
-.. _section-1:
+.. _section-2:
 
 0.24.13 - 2020-06-22
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -29,7 +45,7 @@ Bug fixes
 -  fixed a bug where ``CoxPHFitter`` would fail with working with
    ``sklearn_adapter``
 
-.. _section-2:
+.. _section-3:
 
 0.24.12 - 2020-06-20
 ^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +55,7 @@ New features
 
 -  improved convergence of ``GeneralizedGamma(Regression)Fitter``.
 
-.. _section-3:
+.. _section-4:
 
 0.24.11 - 2020-06-17
 ^^^^^^^^^^^^^^^^^^^^
@@ -65,7 +81,7 @@ API Changes
    penalized by ``penalizer`` - we now penalizing everything except
    intercept terms in linear relationships.
 
-.. _section-4:
+.. _section-5:
 
 0.24.10 - 2020-06-16
 ^^^^^^^^^^^^^^^^^^^^
@@ -87,7 +103,7 @@ API Changes
 -  Related to above: the fitted spline parameters are now available in
    the ``.summary`` and ``.print_summary`` methods.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
@@ -95,7 +111,7 @@ Bug fixes
 -  fixed a bug in initialization of some interval-censoring models ->
    better convergence.
 
-.. _section-5:
+.. _section-6:
 
 0.24.9 - 2020-06-05
 ^^^^^^^^^^^^^^^^^^^
@@ -110,7 +126,7 @@ New features
    ``tarone-ware``, ``peto``, ``fleming-harrington``. Thanks @sean-reed
 -  new interval censored dataset: ``lifelines.datasets.load_mice``
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -118,7 +134,7 @@ Bug fixes
 -  Cleared up some mislabeling in ``plot_loglogs``. Thanks @sean-reed!
 -  tuples are now able to be used as input in univariate models.
 
-.. _section-6:
+.. _section-7:
 
 0.24.8 - 2020-05-17
 ^^^^^^^^^^^^^^^^^^^
@@ -132,7 +148,7 @@ New features
    Not all edge cases are fully checked, and some features are missing.
    Try it under ``KaplanMeierFitter.fit_interval_censoring``
 
-.. _section-7:
+.. _section-8:
 
 0.24.7 - 2020-05-17
 ^^^^^^^^^^^^^^^^^^^
@@ -153,7 +169,7 @@ New features
 -  some convergence tweaks which should help recent performance
    regressions.
 
-.. _section-8:
+.. _section-9:
 
 0.24.6 - 2020-05-05
 ^^^^^^^^^^^^^^^^^^^
@@ -168,7 +184,7 @@ New features
 -  New ``lifelines.plotting.plot_interval_censored_lifetimes`` for
    plotting interval censored data - thanks @sean-reed!
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -176,7 +192,7 @@ Bug fixes
 -  fixed bug where ``cdf_plot`` and ``qq_plot`` were not factoring in
    the weights correctly.
 
-.. _section-9:
+.. _section-10:
 
 0.24.5 - 2020-05-01
 ^^^^^^^^^^^^^^^^^^^
@@ -188,7 +204,7 @@ New features
 
 -  ``plot_lifetimes`` accepts pandas Series.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
@@ -198,12 +214,12 @@ Bug fixes
 -  Improved ``at_risk_counts`` for subplots.
 -  More data validation checks for ``CoxTimeVaryingFitter``
 
-.. _section-10:
+.. _section-11:
 
 0.24.4 - 2020-04-13
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -212,7 +228,7 @@ Bug fixes
 -  setting a dataframe in ``ancillary_df`` works for interval censoring
 -  ``.score`` works for interval censored models
 
-.. _section-11:
+.. _section-12:
 
 0.24.3 - 2020-03-25
 ^^^^^^^^^^^^^^^^^^^
@@ -227,7 +243,7 @@ New features
    the hazard ratio would be at previous times. This is useful because
    the final hazard ratio is some weighted average of these.
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
@@ -235,12 +251,12 @@ Bug fixes
 -  Fixed error in HTML printer that was hiding concordance index
    information.
 
-.. _section-12:
+.. _section-13:
 
 0.24.2 - 2020-03-15
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
@@ -252,7 +268,7 @@ Bug fixes
 -  Fixed a keyword bug in ``plot_covariate_groups`` for parametric
    models.
 
-.. _section-13:
+.. _section-14:
 
 0.24.1 - 2020-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -265,14 +281,14 @@ New features
 -  Stability improvements for GeneralizedGammaRegressionFitter and
    CoxPHFitter with spline estimation.
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
 
 -  Fixed bug with plotting hazards in NelsonAalenFitter.
 
-.. _section-14:
+.. _section-15:
 
 0.24.0 - 2020-02-20
 ^^^^^^^^^^^^^^^^^^^
@@ -333,7 +349,7 @@ API Changes
    to ``scoring_method``.
 -  removed ``_score_`` and ``path`` from Cox model.
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
@@ -346,12 +362,12 @@ Bug fixes
 -  Cox models now incorporate any penalizers in their
    ``log_likelihood_``
 
-.. _section-15:
+.. _section-16:
 
 0.23.9 - 2020-01-28
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
@@ -362,12 +378,12 @@ Bug fixes
    of ``GeneralizedGammaRegressionFitter`` and any custom regression
    models should update their code as soon as possible.
 
-.. _section-16:
+.. _section-17:
 
 0.23.8 - 2020-01-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
@@ -378,14 +394,14 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-17:
+.. _section-18:
 
 0.23.7 - 2020-01-14
 ^^^^^^^^^^^^^^^^^^^
 
 Bug fixes for py3.5.
 
-.. _section-18:
+.. _section-19:
 
 0.23.6 - 2020-01-07
 ^^^^^^^^^^^^^^^^^^^
@@ -404,7 +420,7 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-19:
+.. _section-20:
 
 0.23.5 - 2020-01-05
 ^^^^^^^^^^^^^^^^^^^
@@ -418,7 +434,7 @@ New features
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
@@ -428,14 +444,14 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-20:
+.. _section-21:
 
 0.23.4 - 2019-12-15
 ^^^^^^^^^^^^^^^^^^^
 
 -  Bug fix for PyPI
 
-.. _section-21:
+.. _section-22:
 
 0.23.3 - 2019-12-11
 ^^^^^^^^^^^^^^^^^^^
@@ -447,7 +463,7 @@ New features
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 '''''''''
@@ -455,7 +471,7 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-22:
+.. _section-23:
 
 0.23.2 - 2019-12-07
 ^^^^^^^^^^^^^^^^^^^
@@ -472,7 +488,7 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 '''''''''
@@ -481,7 +497,7 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-23:
+.. _section-24:
 
 0.23.1 - 2019-11-27
 ^^^^^^^^^^^^^^^^^^^
@@ -496,7 +512,7 @@ New features
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 '''''''''
@@ -508,7 +524,7 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-24:
+.. _section-25:
 
 0.23.0 - 2019-11-17
 ^^^^^^^^^^^^^^^^^^^
@@ -522,7 +538,7 @@ New features
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 '''''''''
@@ -544,7 +560,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-25:
+.. _section-26:
 
 0.22.10 - 2019-11-08
 ^^^^^^^^^^^^^^^^^^^^
@@ -552,7 +568,7 @@ API Changes
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 '''''''''
@@ -562,12 +578,12 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-26:
+.. _section-27:
 
 0.22.9 - 2019-10-30
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 '''''''''
@@ -579,7 +595,7 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-27:
+.. _section-28:
 
 0.22.8 - 2019-10-06
 ^^^^^^^^^^^^^^^^^^^
@@ -594,14 +610,14 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
 '''''''''
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-28:
+.. _section-29:
 
 0.22.7 - 2019-09-29
 ^^^^^^^^^^^^^^^^^^^
@@ -614,7 +630,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
 '''''''''
@@ -633,7 +649,7 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-29:
+.. _section-30:
 
 0.22.6 - 2019-09-25
 ^^^^^^^^^^^^^^^^^^^
@@ -645,7 +661,7 @@ New features
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
 '''''''''
@@ -661,7 +677,7 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-30:
+.. _section-31:
 
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
@@ -675,7 +691,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
 '''''''''
@@ -692,7 +708,7 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-31:
+.. _section-32:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
@@ -716,7 +732,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
 '''''''''
@@ -724,7 +740,7 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-32:
+.. _section-33:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
@@ -753,7 +769,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
 '''''''''
@@ -765,7 +781,7 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-33:
+.. _section-34:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
@@ -777,7 +793,7 @@ New features
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
 '''''''''
@@ -788,7 +804,7 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-34:
+.. _section-35:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
@@ -821,7 +837,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
 '''''''''
@@ -831,7 +847,7 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-35:
+.. _section-36:
 
 0.22.0 - 2019-07-03
 ^^^^^^^^^^^^^^^^^^^
@@ -870,7 +886,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug fixes
 '''''''''
@@ -879,7 +895,7 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-36:
+.. _section-37:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
@@ -893,7 +909,7 @@ New features
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-29:
+.. _bug-fixes-30:
 
 Bug fixes
 '''''''''
@@ -903,7 +919,7 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-37:
+.. _section-38:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
@@ -922,14 +938,14 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-30:
+.. _bug-fixes-31:
 
 Bug fixes
 '''''''''
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-38:
+.. _section-39:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
@@ -958,12 +974,12 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-31:
+.. _bug-fixes-32:
 
 Bug fixes
 '''''''''
 
-.. _section-39:
+.. _section-40:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
@@ -985,14 +1001,14 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-32:
+.. _bug-fixes-33:
 
 Bug fixes
 '''''''''
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-40:
+.. _section-41:
 
 0.21.0 - 2019-04-12
 ^^^^^^^^^^^^^^^^^^^
@@ -1022,7 +1038,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-33:
+.. _bug-fixes-34:
 
 Bug fixes
 '''''''''
@@ -1032,7 +1048,7 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-41:
+.. _section-42:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
@@ -1054,7 +1070,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-34:
+.. _bug-fixes-35:
 
 Bug fixes
 '''''''''
@@ -1063,7 +1079,7 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-42:
+.. _section-43:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
@@ -1087,7 +1103,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-35:
+.. _bug-fixes-36:
 
 Bug fixes
 '''''''''
@@ -1096,7 +1112,7 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-43:
+.. _section-44:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1114,7 +1130,7 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-44:
+.. _section-45:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
@@ -1143,7 +1159,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-36:
+.. _bug-fixes-37:
 
 Bug fixes
 '''''''''
@@ -1159,7 +1175,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-45:
+.. _section-46:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -1183,7 +1199,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-46:
+.. _section-47:
 
 0.20.0 - 2019-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1212,14 +1228,14 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-37:
+.. _bug-fixes-38:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-47:
+.. _section-48:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
@@ -1234,19 +1250,19 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-48:
+.. _section-49:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-38:
+.. _bug-fixes-39:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-49:
+.. _section-50:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1263,7 +1279,7 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-50:
+.. _section-51:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1276,7 +1292,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-39:
+.. _bug-fixes-40:
 
 Bug fixes
 '''''''''
@@ -1286,7 +1302,7 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-51:
+.. _section-52:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
@@ -1308,7 +1324,7 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-52:
+.. _section-53:
 
 0.19.0 - 2019-02-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1352,7 +1368,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-40:
+.. _bug-fixes-41:
 
 Bug Fixes
 '''''''''
@@ -1369,7 +1385,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-53:
+.. _section-54:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -1379,7 +1395,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-54:
+.. _section-55:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1400,7 +1416,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-55:
+.. _section-56:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -1410,7 +1426,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-56:
+.. _section-57:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -1420,7 +1436,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-57:
+.. _section-58:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1436,7 +1452,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-58:
+.. _section-59:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1447,7 +1463,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-59:
+.. _section-60:
 
 0.18.0 - 2019-01-31
 ^^^^^^^^^^^^^^^^^^^
@@ -1484,7 +1500,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-60:
+.. _section-61:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1492,7 +1508,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-61:
+.. _section-62:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -1504,7 +1520,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-62:
+.. _section-63:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1512,7 +1528,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-63:
+.. _section-64:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -1523,7 +1539,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-64:
+.. _section-65:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1540,7 +1556,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-65:
+.. _section-66:
 
 0.17.0 - 2019-01-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1561,7 +1577,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-66:
+.. _section-67:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1569,7 +1585,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-67:
+.. _section-68:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1580,14 +1596,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-68:
+.. _section-69:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-69:
+.. _section-70:
 
 0.16.0 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1623,7 +1639,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-70:
+.. _section-71:
 
 0.15.4
 ^^^^^^
@@ -1631,14 +1647,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-71:
+.. _section-72:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-72:
+.. _section-73:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1649,7 +1665,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-73:
+.. _section-74:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1658,7 +1674,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-74:
+.. _section-75:
 
 0.15.0 - 2018-11-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1729,7 +1745,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-75:
+.. _section-76:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1737,7 +1753,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-76:
+.. _section-77:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1745,7 +1761,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-77:
+.. _section-78:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1762,7 +1778,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-78:
+.. _section-79:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1774,7 +1790,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-79:
+.. _section-80:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1782,7 +1798,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-80:
+.. _section-81:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1800,7 +1816,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-81:
+.. _section-82:
 
 0.14.0 - 2018-03-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1822,7 +1838,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-82:
+.. _section-83:
 
 0.13.0 - 2017-12-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1851,7 +1867,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-83:
+.. _section-84:
 
 0.12.0
 ^^^^^^
@@ -1868,7 +1884,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-84:
+.. _section-85:
 
 0.11.3
 ^^^^^^
@@ -1880,7 +1896,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-85:
+.. _section-86:
 
 0.11.2
 ^^^^^^
@@ -1888,14 +1904,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-86:
+.. _section-87:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-87:
+.. _section-88:
 
 0.11.0 - 2017-06-21
 ^^^^^^^^^^^^^^^^^^^
@@ -1909,14 +1925,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-88:
+.. _section-89:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-89:
+.. _section-90:
 
 0.10.0
 ^^^^^^
@@ -1931,7 +1947,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-90:
+.. _section-91:
 
 0.9.4
 ^^^^^
@@ -1954,7 +1970,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-91:
+.. _section-92:
 
 0.9.2
 ^^^^^
@@ -1963,7 +1979,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-92:
+.. _section-93:
 
 0.9.1
 ^^^^^
@@ -1971,7 +1987,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-93:
+.. _section-94:
 
 0.9.0
 ^^^^^
@@ -1987,7 +2003,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-94:
+.. _section-95:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -2004,7 +2020,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-95:
+.. _section-96:
 
 0.8.0
 ^^^^^
@@ -2023,7 +2039,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-96:
+.. _section-97:
 
 0.7.1
 ^^^^^
@@ -2042,7 +2058,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-97:
+.. _section-98:
 
 0.7.0 - 2015-03-01
 ^^^^^^^^^^^^^^^^^^
@@ -2061,7 +2077,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-98:
+.. _section-99:
 
 0.6.1
 ^^^^^
@@ -2073,7 +2089,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-99:
+.. _section-100:
 
 0.6.0 - 2015-02-04
 ^^^^^^^^^^^^^^^^^^
@@ -2096,7 +2112,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-100:
+.. _section-101:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -2117,7 +2133,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-101:
+.. _section-102:
 
 0.5.0 - 2014-12-07
 ^^^^^^^^^^^^^^^^^^
@@ -2130,7 +2146,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-102:
+.. _section-103:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -2142,7 +2158,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-103:
+.. _section-104:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -2163,7 +2179,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-104:
+.. _section-105:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -2183,7 +2199,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-105:
+.. _section-106:
 
 0.4.1.1
 ^^^^^^^
@@ -2196,7 +2212,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-106:
+.. _section-107:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -2215,7 +2231,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-107:
+.. _section-108:
 
 0.4.0 - 2014-06-08
 ^^^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,19 +11,47 @@
 lifelines
 =====================================
 
-*lifelines* is an implementation of survival analysis in Python. What
-benefits does *lifelines* offer over other survival analysis
-implementations?
+*lifelines* is a complete survival analysis library, written in pure Python. What
+benefits does *lifelines* have?
 
--  built on top of Pandas
--  internal plotting methods
--  simple and intuitive API
--  only focus is survival analysis
--  handles right, left and interval censored data
+- easy installation
+- internal plotting methods
+- simple and intuitive API
+- handles right, left and interval censored data
+- contains the most popular parametric, semi-parametric and non-parametric models
+
+Installation
+------------------------------
 
 
-Contents:
-============
+.. code-block:: console
+
+    pip install lifelines
+
+or
+
+.. code-block:: console
+
+    conda install -c conda-forge lifelines
+
+
+Source code and issue tracker
+------------------------------
+
+Available on Github, `CamDavidsonPilon/lifelines <https://github.com/CamDavidsonPilon/lifelines/>`_.
+Please report bugs, issues and feature extensions there. We also have `Gitter channel <https://gitter.im/python-lifelines/Lobby>`_ available to discuss survival analysis and *lifelines*:
+
+Citing *lifelines*
+------------------------------
+
+The following link will bring you to a page where you can find the latest citation for *lifelines*:
+
+`Citation for lifelines <https://doi.org/10.5281/zenodo.805993>`_
+s
+
+Documentation
+------------------------------
+
 
 .. toctree::
   :maxdepth: 1
@@ -77,41 +105,3 @@ Contents:
   :caption: Developer Documentation
 
   Contributing
-
-
-Installation
-------------------------------
-
-
-.. code-block:: console
-
-    pip install lifelines
-
-or
-
-.. code-block:: console
-
-    conda install -c conda-forge lifelines
-
-
-
-Source code and issue tracker
-------------------------------
-
-Available on Github, `CamDavidsonPilon/lifelines <https://github.com/CamDavidsonPilon/lifelines/>`_.
-Please report bugs, issues and feature extensions there. We also have `Gitter channel <https://gitter.im/python-lifelines/Lobby>`_ available to discuss survival analysis and *lifelines*:
-
-Citing *lifelines*
-------------------------------
-
-The following link will bring you to a page where you can find the latest citation for *lifelines*:
-
-`Citation for lifelines <https://doi.org/10.5281/zenodo.805993>`_
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -3368,6 +3368,7 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         if conditional_after is None:
             return pd.DataFrame(self._hazard(params_dict, np.tile(times, (n, 1)).T, Xs), index=times, columns=df.index)
         else:
+            # TODO
             raise NotImplementedError()
 
     def predict_cumulative_hazard(self, df, *, ancillary_df=None, times=None, conditional_after=None) -> pd.DataFrame:
@@ -3416,7 +3417,8 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         params_dict = {parameter_name: self.params_.loc[parameter_name].values for parameter_name in self._fitted_parameter_names}
 
         if conditional_after is None:
-            return pd.DataFrame(self._cumulative_hazard(params_dict, np.tile(times, (n, 1)).T, Xs), index=times, columns=df.index)
+            times_to_evaluate_at = np.tile(times, (n, 1)).T
+            return pd.DataFrame(self._cumulative_hazard(params_dict, times_to_evaluate_at, Xs), index=times, columns=df.index)
         else:
             conditional_after = np.asarray(conditional_after)
             times_to_evaluate_at = (conditional_after.reshape((n, 1)) + np.tile(times, (n, 1))).T

--- a/lifelines/fitters/breslow_fleming_harrington_fitter.py
+++ b/lifelines/fitters/breslow_fleming_harrington_fitter.py
@@ -28,15 +28,7 @@ class BreslowFlemingHarringtonFitter(UnivariateFitter):
 
     @CensoringType.right_censoring
     def fit(
-        self,
-        durations,
-        event_observed=None,
-        timeline=None,
-        entry=None,
-        label=None,
-        alpha=None,
-        ci_labels=None,
-        weights=None,
+        self, durations, event_observed=None, timeline=None, entry=None, label=None, alpha=None, ci_labels=None, weights=None
     ):  # pylint: disable=too-many-arguments
         """
         Parameters
@@ -69,14 +61,7 @@ class BreslowFlemingHarringtonFitter(UnivariateFitter):
         alpha = coalesce(alpha, self.alpha)
 
         naf = NelsonAalenFitter(alpha=alpha)
-        naf.fit(
-            durations,
-            event_observed=event_observed,
-            timeline=timeline,
-            label=self._label,
-            entry=entry,
-            ci_labels=ci_labels,
-        )
+        naf.fit(durations, event_observed=event_observed, timeline=timeline, label=self._label, entry=entry, ci_labels=ci_labels)
         self.durations, self.event_observed, self.timeline, self.entry, self.event_table, self.weights = (
             naf.durations,
             naf.event_observed,
@@ -89,6 +74,8 @@ class BreslowFlemingHarringtonFitter(UnivariateFitter):
         # estimation
         self.survival_function_ = np.exp(-naf.cumulative_hazard_)
         self.confidence_interval_ = np.exp(-naf.confidence_interval_)
+        self.confidence_interval_survival_function_ = self.confidence_interval_
+        self.confidence_interval_cumulative_density = 1 - self.confidence_interval_
 
         # estimation methods
         self._estimation_method = "survival_function_"

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -150,6 +150,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         cluster_col: Optional[str] = None,
         robust: bool = False,
         batch_mode: Optional[bool] = None,
+        timeline: Optional[Iterator] = None,
     ) -> "CoxPHFitter":
         """
         Fit the Cox proportional hazard model to a dataset.
@@ -269,6 +270,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
             cluster_col=cluster_col,
             robust=robust,
             batch_mode=batch_mode,
+            timeline=timeline,
         )
         return self
 
@@ -542,6 +544,7 @@ class SemiParametricPHFitter(ProportionalHazardMixin, SemiParametricRegressionFi
         cluster_col: Optional[str] = None,
         robust: bool = False,
         batch_mode: Optional[bool] = None,
+        timeline: Optional[Iterator] = None,
     ) -> "SemiParametricPHFitter":
         """
         Fit the Cox proportional hazard model to a dataset.
@@ -690,6 +693,7 @@ class SemiParametricPHFitter(ProportionalHazardMixin, SemiParametricRegressionFi
         self.params_ = pd.Series(params_, index=X.columns, name="coef")
         self.baseline_hazard_ = baseline_hazard_
         self.baseline_cumulative_hazard_ = baseline_cumulative_hazard_
+        self.timeline = utils.coalesce(timeline, self.baseline_cumulative_hazard_.index)
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -1685,6 +1689,8 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
 
         if times is not None:
             times = np.atleast_1d(times).astype(float)
+        else:
+            times = self.timeline
         if conditional_after is not None:
             conditional_after = utils._to_1d_array(conditional_after).reshape(n, 1)
 
@@ -1707,7 +1713,7 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
                     )
                 col = utils._get_index(stratified_X)
                 v = self.predict_partial_hazard(stratified_X)
-                times_ = utils.coalesce(times, self.baseline_cumulative_hazard_.index)
+                times_ = times
                 n_ = stratified_X.shape[0]
                 if conditional_after is not None:
                     conditional_after_ = stratified_X.pop("_conditional_after")[:, None]
@@ -1728,7 +1734,7 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
 
             v = self.predict_partial_hazard(X)
             col = utils._get_index(v)
-            times_ = utils.coalesce(times, self.baseline_cumulative_hazard_.index)
+            times_ = times
 
             if conditional_after is not None:
                 times_to_evaluate_at = np.tile(times_, (n, 1)) + conditional_after

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -2376,7 +2376,9 @@ class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, Pr
         """
         df = df.copy()
         df["_intercept"] = 1
-        return super(ParametricSplinePHFitter, self).predict_cumulative_hazard(df, times=None, conditional_after=None)
+        return super(ParametricSplinePHFitter, self).predict_cumulative_hazard(
+            df, times=times, conditional_after=conditional_after
+        )
 
     def predict_hazard(self, df, *, times=None):
         """

--- a/lifelines/fitters/spline_fitter.py
+++ b/lifelines/fitters/spline_fitter.py
@@ -18,7 +18,7 @@ class SplineFitter(KnownModelParametricUnivariateFitter, SplineFitterMixin):
     Parameters
     -----------
     knot_locations: list, np.array
-        The locations of the cubic breakpoints. Typically, the first knot is the minimum observed death, the last knot is the maximum observed death, and the knots in between
+        The locations of the cubic breakpoints. Must be length two or more. Typically, the first knot is the minimum observed death, the last knot is the maximum observed death, and the knots in between
         are the centiles of observed data (ex: if one additional knot, choose the 50th percentile, the median. If two additional knots, choose the 33rd and 66th percentiles).
 
     References
@@ -81,6 +81,7 @@ class SplineFitter(KnownModelParametricUnivariateFitter, SplineFitterMixin):
     def __init__(self, knot_locations: np.array, *args, **kwargs):
         self.knot_locations = knot_locations
         self.n_knots = len(self.knot_locations)
+        assert self.n_knots > 1, "knot_locations must have two or more elements."
         self._fitted_parameter_names = ["phi_%d_" % i for i in range(self.n_knots)]
         self._bounds = [(None, None)] * (self.n_knots)
         super(SplineFitter, self).__init__(*args, **kwargs)

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -2899,20 +2899,29 @@ class TestCoxPHFitter:
     def test_conditional_after_with_custom_times(self, rossi):
         cph_semi = CoxPHFitter(baseline_estimation_method="breslow").fit(rossi, "week", "arrest")
         cph_spline = CoxPHFitter(n_baseline_knots=2, baseline_estimation_method="spline").fit(rossi, "week", "arrest")
+        times = np.arange(5)
 
         # predict single
-        cph_semi.fit(rossi, "week", "arrest").predict_survival_function(rossi.iloc[0], times=np.arange(5), conditional_after=[10])
-        cph_spline.fit(rossi, "week", "arrest").predict_survival_function(
-            rossi.iloc[0], times=np.arange(5), conditional_after=[10]
+        result = cph_semi.fit(rossi, "week", "arrest").predict_survival_function(
+            rossi.iloc[0], times=times, conditional_after=[10]
         )
+        npt.assert_allclose(result.index.values, times)
+
+        result = cph_spline.fit(rossi, "week", "arrest").predict_survival_function(
+            rossi.iloc[0], times=times, conditional_after=[10]
+        )
+        npt.assert_allclose(result.index.values, times)
 
         # predict multiple
-        cph_semi.fit(rossi, "week", "arrest").predict_survival_function(
-            rossi.iloc[:10], times=np.arange(5), conditional_after=[10] * 10
+        result = cph_semi.fit(rossi, "week", "arrest").predict_survival_function(
+            rossi.iloc[:10], times=times, conditional_after=[10] * 10
         )
-        cph_spline.fit(rossi, "week", "arrest").predict_survival_function(
-            rossi.iloc[:10], times=np.arange(5), conditional_after=[10] * 10
+        npt.assert_allclose(result.index.values, times)
+
+        result = cph_spline.fit(rossi, "week", "arrest").predict_survival_function(
+            rossi.iloc[:10], times=times, conditional_after=[10] * 10
         )
+        npt.assert_allclose(result.index.values, times)
 
     def test_conditional_after_with_strata_in_prediction(self, rossi, cph):
         rossi.loc[rossi["week"] == 1, "week"] = 0

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1472,6 +1472,14 @@ class TestKaplanMeierFitter:
         npt.assert_allclose(kmf_interval.survival_function_.loc[6, "NPMLE_estimate_upper"], 0.375, rtol=1e-2)
         npt.assert_allclose(kmf_interval.survival_function_.loc[6, "NPMLE_estimate_lower"], 0.0, rtol=1e-2)
 
+    def test_really_late_entrance(self):
+        T = [1, 2, 3, 1, 2, 6]
+        entries = [0, 0, 0, 0, 0, 5]
+
+        kmf = KaplanMeierFitter()
+        kmf.fit(T, entry=entries)
+        assert np.all((kmf.survival_function_.diff().dropna() <= 0))
+
 
 class TestNelsonAalenFitter:
     def nelson_aalen(self, lifetimes, observed=None):
@@ -2778,6 +2786,18 @@ class TestCoxPHFitter:
     @pytest.fixture
     def cph_spline(self):
         return CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=1)
+
+    def test_timeline_argument_can_be_set(self, rossi, cph_spline, cph):
+        timeline = np.linspace(0, 100)
+        cph.fit(rossi, "week", "arrest", timeline=timeline)
+
+        cph_spline.fit(rossi, "week", "arrest", timeline=timeline)
+
+        npt.assert_allclose(cph_spline.timeline, timeline)
+        npt.assert_allclose(cph.timeline, timeline)
+
+        npt.assert_allclose(cph.predict_survival_function(rossi).index.values, timeline)
+        npt.assert_allclose(cph_spline.predict_survival_function(rossi).index.values, timeline)
 
     def test_penalizer_can_be_an_array(self, rossi):
 

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -17,6 +17,7 @@ from lifelines import (
     WeibullAFTFitter,
     ExponentialFitter,
     AalenJohansenFitter,
+    BreslowFlemingHarringtonFitter,
 )
 
 from lifelines.tests.test_estimation import known_parametric_univariate_fitters
@@ -326,6 +327,14 @@ class TestPlotting:
         naf.fit(data1)
         naf.plot_hazard(bandwidth=5.0, iloc=slice(0, 1700))
         self.plt.title("test_naf_plot_cumulative_hazard_bandwith_1")
+        self.plt.show(block=block)
+        return
+
+    def test_breslow_fleming_harrington_plotting(self, block):
+        T = 50 * np.random.exponential(1, size=(200, 1)) ** 2
+        bf = BreslowFlemingHarringtonFitter().fit(T)
+        bf.plot()
+        self.plt.title("test_breslow_fleming_harrington_plotting")
         self.plt.show(block=block)
         return
 

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.24.14"
+__version__ = "0.24.15"


### PR DESCRIPTION
#### 0.24.15

##### Bug fixes
- fixed an edge case in `KaplanMeierFitter` where a really late entry would occur after all other population had died.
- fixed `plot` in `BreslowFlemingtonHarrisFitter`
- fixed bug where using `conditional_after` and `times` in `CoxPHFitter("spline")` prediction methods would be ignored.

