### PR TITLE
V0.25.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
   matrix:
     - PANDAS_VERSION=0.23.4  && NUMPY_VERSION=1.19.0
     - PANDAS_VERSION=0.25.3  && NUMPY_VERSION=1.19.0
-    - NUMPY_VERSION=1.15.4   && PANDAS_VERSION=1.0.5
-    - NUMPY_VERSION=1.19.0   && PANDAS_VERSION=1.0.5
+    - NUMPY_VERSION=1.15.4   && PANDAS_VERSION=1.1.0
+    - NUMPY_VERSION=1.19.0   && PANDAS_VERSION=1.1.0
 before_install:
   - ls
   # - sudo apt-get update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+#### 0.25.1 - unreleased
+
+##### Bug fixes
+ - ok _actually_ ship the out-of-sample calibration code
+ - fix `labels=False` in `add_at_risk_counts`
+
+
 #### 0.25.0 - 2020-07-27
 
 ##### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ##### Bug fixes
  - ok _actually_ ship the out-of-sample calibration code
  - fix `labels=False` in `add_at_risk_counts`
+ - all for specific rows to be shown in `add_at_risk_counts`
+ - put `patsy` as a proper dependency.
 
 
 #### 0.25.0 - 2020-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-#### 0.25.1 - unreleased
+#### 0.25.1 - 2020-08-01
 
 ##### Bug fixes
  - ok _actually_ ship the out-of-sample calibration code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - fix `labels=False` in `add_at_risk_counts`
  - all for specific rows to be shown in `add_at_risk_counts`
  - put `patsy` as a proper dependency.
+ - suppress some Pandas 1.1 warnings.
 
 
 #### 0.25.0 - 2020-07-27

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 ---------
 
-0.25.1 - unreleased
+0.25.1 - 2020-08-01
 ^^^^^^^^^^^^^^^^^^^
 
 Bug fixes
@@ -11,6 +11,9 @@ Bug fixes
 -  fix ``labels=False`` in ``add_at_risk_counts``
 -  all for specific rows to be shown in ``add_at_risk_counts``
 -  put ``patsy`` as a proper dependency.
+-  suppress some Pandas 1.1 warnings.
+
+.. _section-1:
 
 0.25.0 - 2020-07-27
 ^^^^^^^^^^^^^^^^^^^
@@ -83,7 +86,7 @@ Bug fixes
 -  fixed NaN bug in ``survival_table_from_events`` with intervals when
    no events would occur in a interval.
 
-.. _section-1:
+.. _section-2:
 
 0.24.15 - 2020-07-09
 ^^^^^^^^^^^^^^^^^^^^
@@ -103,7 +106,7 @@ Bug fixes
 
 -  fixed ``utils.median_survival_time`` not accepting Pandas Series.
 
-.. _section-2:
+.. _section-3:
 
 0.24.15 - 2020-07-07
 ^^^^^^^^^^^^^^^^^^^^
@@ -119,7 +122,7 @@ Bug fixes
 -  fixed bug where using ``conditional_after`` and ``times`` in
    ``CoxPHFitter("spline")`` prediction methods would be ignored.
 
-.. _section-3:
+.. _section-4:
 
 0.24.14 - 2020-07-02
 ^^^^^^^^^^^^^^^^^^^^
@@ -136,7 +139,7 @@ Bug fixes
 -  fixed a bug where some columns would not be displayed in
    ``print_summary``
 
-.. _section-4:
+.. _section-5:
 
 0.24.13 - 2020-06-22
 ^^^^^^^^^^^^^^^^^^^^
@@ -151,7 +154,7 @@ Bug fixes
 -  fixed a bug where ``CoxPHFitter`` would fail with working with
    ``sklearn_adapter``
 
-.. _section-5:
+.. _section-6:
 
 0.24.12 - 2020-06-20
 ^^^^^^^^^^^^^^^^^^^^
@@ -163,7 +166,7 @@ New features
 
 -  improved convergence of ``GeneralizedGamma(Regression)Fitter``.
 
-.. _section-6:
+.. _section-7:
 
 0.24.11 - 2020-06-17
 ^^^^^^^^^^^^^^^^^^^^
@@ -191,7 +194,7 @@ API Changes
    penalized by ``penalizer`` - we now penalizing everything except
    intercept terms in linear relationships.
 
-.. _section-7:
+.. _section-8:
 
 0.24.10 - 2020-06-16
 ^^^^^^^^^^^^^^^^^^^^
@@ -221,7 +224,7 @@ Bug fixes
 -  fixed a bug in initialization of some interval-censoring models ->
    better convergence.
 
-.. _section-8:
+.. _section-9:
 
 0.24.9 - 2020-06-05
 ^^^^^^^^^^^^^^^^^^^
@@ -244,7 +247,7 @@ Bug fixes
 -  Cleared up some mislabeling in ``plot_loglogs``. Thanks @sean-reed!
 -  tuples are now able to be used as input in univariate models.
 
-.. _section-9:
+.. _section-10:
 
 0.24.8 - 2020-05-17
 ^^^^^^^^^^^^^^^^^^^
@@ -258,7 +261,7 @@ New features
    Not all edge cases are fully checked, and some features are missing.
    Try it under ``KaplanMeierFitter.fit_interval_censoring``
 
-.. _section-10:
+.. _section-11:
 
 0.24.7 - 2020-05-17
 ^^^^^^^^^^^^^^^^^^^
@@ -279,7 +282,7 @@ New features
 -  some convergence tweaks which should help recent performance
    regressions.
 
-.. _section-11:
+.. _section-12:
 
 0.24.6 - 2020-05-05
 ^^^^^^^^^^^^^^^^^^^
@@ -302,7 +305,7 @@ Bug fixes
 -  fixed bug where ``cdf_plot`` and ``qq_plot`` were not factoring in
    the weights correctly.
 
-.. _section-12:
+.. _section-13:
 
 0.24.5 - 2020-05-01
 ^^^^^^^^^^^^^^^^^^^
@@ -324,7 +327,7 @@ Bug fixes
 -  Improved ``at_risk_counts`` for subplots.
 -  More data validation checks for ``CoxTimeVaryingFitter``
 
-.. _section-13:
+.. _section-14:
 
 0.24.4 - 2020-04-13
 ^^^^^^^^^^^^^^^^^^^
@@ -338,7 +341,7 @@ Bug fixes
 -  setting a dataframe in ``ancillary_df`` works for interval censoring
 -  ``.score`` works for interval censored models
 
-.. _section-14:
+.. _section-15:
 
 0.24.3 - 2020-03-25
 ^^^^^^^^^^^^^^^^^^^
@@ -361,7 +364,7 @@ Bug fixes
 -  Fixed error in HTML printer that was hiding concordance index
    information.
 
-.. _section-15:
+.. _section-16:
 
 0.24.2 - 2020-03-15
 ^^^^^^^^^^^^^^^^^^^
@@ -378,7 +381,7 @@ Bug fixes
 -  Fixed a keyword bug in ``plot_covariate_groups`` for parametric
    models.
 
-.. _section-16:
+.. _section-17:
 
 0.24.1 - 2020-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -398,7 +401,7 @@ Bug fixes
 
 -  Fixed bug with plotting hazards in NelsonAalenFitter.
 
-.. _section-17:
+.. _section-18:
 
 0.24.0 - 2020-02-20
 ^^^^^^^^^^^^^^^^^^^
@@ -472,7 +475,7 @@ Bug fixes
 -  Cox models now incorporate any penalizers in their
    ``log_likelihood_``
 
-.. _section-18:
+.. _section-19:
 
 0.23.9 - 2020-01-28
 ^^^^^^^^^^^^^^^^^^^
@@ -488,7 +491,7 @@ Bug fixes
    of ``GeneralizedGammaRegressionFitter`` and any custom regression
    models should update their code as soon as possible.
 
-.. _section-19:
+.. _section-20:
 
 0.23.8 - 2020-01-21
 ^^^^^^^^^^^^^^^^^^^
@@ -504,14 +507,14 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-20:
+.. _section-21:
 
 0.23.7 - 2020-01-14
 ^^^^^^^^^^^^^^^^^^^
 
 Bug fixes for py3.5.
 
-.. _section-21:
+.. _section-22:
 
 0.23.6 - 2020-01-07
 ^^^^^^^^^^^^^^^^^^^
@@ -530,7 +533,7 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-22:
+.. _section-23:
 
 0.23.5 - 2020-01-05
 ^^^^^^^^^^^^^^^^^^^
@@ -554,14 +557,14 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-23:
+.. _section-24:
 
 0.23.4 - 2019-12-15
 ^^^^^^^^^^^^^^^^^^^
 
 -  Bug fix for PyPI
 
-.. _section-24:
+.. _section-25:
 
 0.23.3 - 2019-12-11
 ^^^^^^^^^^^^^^^^^^^
@@ -581,7 +584,7 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-25:
+.. _section-26:
 
 0.23.2 - 2019-12-07
 ^^^^^^^^^^^^^^^^^^^
@@ -607,7 +610,7 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-26:
+.. _section-27:
 
 0.23.1 - 2019-11-27
 ^^^^^^^^^^^^^^^^^^^
@@ -634,7 +637,7 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-27:
+.. _section-28:
 
 0.23.0 - 2019-11-17
 ^^^^^^^^^^^^^^^^^^^
@@ -670,7 +673,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-28:
+.. _section-29:
 
 0.22.10 - 2019-11-08
 ^^^^^^^^^^^^^^^^^^^^
@@ -688,7 +691,7 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-29:
+.. _section-30:
 
 0.22.9 - 2019-10-30
 ^^^^^^^^^^^^^^^^^^^
@@ -705,7 +708,7 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-30:
+.. _section-31:
 
 0.22.8 - 2019-10-06
 ^^^^^^^^^^^^^^^^^^^
@@ -727,7 +730,7 @@ Bug fixes
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-31:
+.. _section-32:
 
 0.22.7 - 2019-09-29
 ^^^^^^^^^^^^^^^^^^^
@@ -759,7 +762,7 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-32:
+.. _section-33:
 
 0.22.6 - 2019-09-25
 ^^^^^^^^^^^^^^^^^^^
@@ -787,7 +790,7 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-33:
+.. _section-34:
 
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
@@ -818,7 +821,7 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-34:
+.. _section-35:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
@@ -850,7 +853,7 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-35:
+.. _section-36:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
@@ -891,7 +894,7 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-36:
+.. _section-37:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
@@ -914,7 +917,7 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-37:
+.. _section-38:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
@@ -957,7 +960,7 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-38:
+.. _section-39:
 
 0.22.0 - 2019-07-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1005,7 +1008,7 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-39:
+.. _section-40:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1029,7 +1032,7 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-40:
+.. _section-41:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
@@ -1055,7 +1058,7 @@ Bug fixes
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-41:
+.. _section-42:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
@@ -1089,7 +1092,7 @@ API changes
 Bug fixes
 '''''''''
 
-.. _section-42:
+.. _section-43:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
@@ -1118,7 +1121,7 @@ Bug fixes
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-43:
+.. _section-44:
 
 0.21.0 - 2019-04-12
 ^^^^^^^^^^^^^^^^^^^
@@ -1158,7 +1161,7 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-44:
+.. _section-45:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
@@ -1189,7 +1192,7 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-45:
+.. _section-46:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
@@ -1222,7 +1225,7 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-46:
+.. _section-47:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1240,7 +1243,7 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-47:
+.. _section-48:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
@@ -1285,7 +1288,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-48:
+.. _section-49:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -1309,7 +1312,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-49:
+.. _section-50:
 
 0.20.0 - 2019-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1345,7 +1348,7 @@ Bug fixes
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-50:
+.. _section-51:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
@@ -1360,7 +1363,7 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-51:
+.. _section-52:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1372,7 +1375,7 @@ Bug fixes
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-52:
+.. _section-53:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1389,7 +1392,7 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-53:
+.. _section-54:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1412,7 +1415,7 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-54:
+.. _section-55:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
@@ -1434,7 +1437,7 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-55:
+.. _section-56:
 
 0.19.0 - 2019-02-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1495,7 +1498,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-56:
+.. _section-57:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -1505,7 +1508,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-57:
+.. _section-58:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1526,7 +1529,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-58:
+.. _section-59:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -1536,7 +1539,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-59:
+.. _section-60:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -1546,7 +1549,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-60:
+.. _section-61:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1562,7 +1565,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-61:
+.. _section-62:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1573,7 +1576,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-62:
+.. _section-63:
 
 0.18.0 - 2019-01-31
 ^^^^^^^^^^^^^^^^^^^
@@ -1610,7 +1613,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-63:
+.. _section-64:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1618,7 +1621,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-64:
+.. _section-65:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -1630,7 +1633,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-65:
+.. _section-66:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1638,7 +1641,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-66:
+.. _section-67:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -1649,7 +1652,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-67:
+.. _section-68:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1666,7 +1669,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-68:
+.. _section-69:
 
 0.17.0 - 2019-01-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1687,7 +1690,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-69:
+.. _section-70:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1695,7 +1698,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-70:
+.. _section-71:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1706,14 +1709,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-71:
+.. _section-72:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-72:
+.. _section-73:
 
 0.16.0 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1749,7 +1752,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-73:
+.. _section-74:
 
 0.15.4
 ^^^^^^
@@ -1757,14 +1760,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-74:
+.. _section-75:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-75:
+.. _section-76:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1775,7 +1778,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-76:
+.. _section-77:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1784,7 +1787,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-77:
+.. _section-78:
 
 0.15.0 - 2018-11-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1855,7 +1858,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-78:
+.. _section-79:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1863,7 +1866,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-79:
+.. _section-80:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1871,7 +1874,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-80:
+.. _section-81:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1888,7 +1891,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-81:
+.. _section-82:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1900,7 +1903,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-82:
+.. _section-83:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1908,7 +1911,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-83:
+.. _section-84:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1926,7 +1929,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-84:
+.. _section-85:
 
 0.14.0 - 2018-03-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1948,7 +1951,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-85:
+.. _section-86:
 
 0.13.0 - 2017-12-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1977,7 +1980,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-86:
+.. _section-87:
 
 0.12.0
 ^^^^^^
@@ -1994,7 +1997,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-87:
+.. _section-88:
 
 0.11.3
 ^^^^^^
@@ -2006,7 +2009,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-88:
+.. _section-89:
 
 0.11.2
 ^^^^^^
@@ -2014,14 +2017,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-89:
+.. _section-90:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-90:
+.. _section-91:
 
 0.11.0 - 2017-06-21
 ^^^^^^^^^^^^^^^^^^^
@@ -2035,14 +2038,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-91:
+.. _section-92:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-92:
+.. _section-93:
 
 0.10.0
 ^^^^^^
@@ -2057,7 +2060,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-93:
+.. _section-94:
 
 0.9.4
 ^^^^^
@@ -2080,7 +2083,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-94:
+.. _section-95:
 
 0.9.2
 ^^^^^
@@ -2089,7 +2092,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-95:
+.. _section-96:
 
 0.9.1
 ^^^^^
@@ -2097,7 +2100,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-96:
+.. _section-97:
 
 0.9.0
 ^^^^^
@@ -2113,7 +2116,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-97:
+.. _section-98:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -2130,7 +2133,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-98:
+.. _section-99:
 
 0.8.0
 ^^^^^
@@ -2149,7 +2152,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-99:
+.. _section-100:
 
 0.7.1
 ^^^^^
@@ -2168,7 +2171,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-100:
+.. _section-101:
 
 0.7.0 - 2015-03-01
 ^^^^^^^^^^^^^^^^^^
@@ -2187,7 +2190,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-101:
+.. _section-102:
 
 0.6.1
 ^^^^^
@@ -2199,7 +2202,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-102:
+.. _section-103:
 
 0.6.0 - 2015-02-04
 ^^^^^^^^^^^^^^^^^^
@@ -2222,7 +2225,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-103:
+.. _section-104:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -2243,7 +2246,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-104:
+.. _section-105:
 
 0.5.0 - 2014-12-07
 ^^^^^^^^^^^^^^^^^^
@@ -2256,7 +2259,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-105:
+.. _section-106:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -2268,7 +2271,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-106:
+.. _section-107:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -2289,7 +2292,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-107:
+.. _section-108:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -2309,7 +2312,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-108:
+.. _section-109:
 
 0.4.1.1
 ^^^^^^^
@@ -2322,7 +2325,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-109:
+.. _section-110:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -2341,7 +2344,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-110:
+.. _section-111:
 
 0.4.0 - 2014-06-08
 ^^^^^^^^^^^^^^^^^^

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.25.1 - unreleased
+^^^^^^^^^^^^^^^^^^^
+
+Bug fixes
+'''''''''
+
+-  ok *actually* ship the out-of-sample calibration code
+-  fix ``labels=False`` in ``add_at_risk_counts``
+-  all for specific rows to be shown in ``add_at_risk_counts``
+-  put ``patsy`` as a proper dependency.
+
 0.25.0 - 2020-07-27
 ^^^^^^^^^^^^^^^^^^^
 
@@ -56,6 +67,8 @@ API Changes
    `here <https://lifelines.readthedocs.io/en/latest/Survival%20Regression.html#plotting-the-effect-of-varying-a-covariate>`__.
 -  all exceptions and warnings have moved to ``lifelines.exceptions``
 
+.. _bug-fixes-1:
+
 Bug fixes
 '''''''''
 
@@ -83,7 +96,7 @@ New features
 -  improved algorithm choice for large DataFrames for Cox models. Should
    see a significant performance boost.
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -95,7 +108,7 @@ Bug fixes
 0.24.15 - 2020-07-07
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
@@ -111,7 +124,7 @@ Bug fixes
 0.24.14 - 2020-07-02
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -128,7 +141,7 @@ Bug fixes
 0.24.13 - 2020-06-22
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -200,7 +213,7 @@ API Changes
 -  Related to above: the fitted spline parameters are now available in
    the ``.summary`` and ``.print_summary`` methods.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
@@ -223,7 +236,7 @@ New features
    ``tarone-ware``, ``peto``, ``fleming-harrington``. Thanks @sean-reed
 -  new interval censored dataset: ``lifelines.datasets.load_mice``
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -281,7 +294,7 @@ New features
 -  New ``lifelines.plotting.plot_interval_censored_lifetimes`` for
    plotting interval censored data - thanks @sean-reed!
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
@@ -301,7 +314,7 @@ New features
 
 -  ``plot_lifetimes`` accepts pandas Series.
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
@@ -316,7 +329,7 @@ Bug fixes
 0.24.4 - 2020-04-13
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
@@ -340,7 +353,7 @@ New features
    the hazard ratio would be at previous times. This is useful because
    the final hazard ratio is some weighted average of these.
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
@@ -353,7 +366,7 @@ Bug fixes
 0.24.2 - 2020-03-15
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
@@ -378,7 +391,7 @@ New features
 -  Stability improvements for GeneralizedGammaRegressionFitter and
    CoxPHFitter with spline estimation.
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
@@ -446,7 +459,7 @@ API Changes
    to ``scoring_method``.
 -  removed ``_score_`` and ``path`` from Cox model.
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
@@ -464,7 +477,7 @@ Bug fixes
 0.23.9 - 2020-01-28
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 '''''''''
@@ -480,7 +493,7 @@ Bug fixes
 0.23.8 - 2020-01-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 '''''''''
@@ -531,7 +544,7 @@ New features
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 '''''''''
@@ -560,7 +573,7 @@ New features
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 '''''''''
@@ -585,7 +598,7 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 '''''''''
@@ -609,7 +622,7 @@ New features
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 '''''''''
@@ -635,7 +648,7 @@ New features
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
 '''''''''
@@ -665,7 +678,7 @@ API Changes
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
 '''''''''
@@ -680,7 +693,7 @@ Bug fixes
 0.22.9 - 2019-10-30
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
 '''''''''
@@ -707,7 +720,7 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
 '''''''''
@@ -727,7 +740,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
 '''''''''
@@ -758,7 +771,7 @@ New features
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
 '''''''''
@@ -788,7 +801,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
 '''''''''
@@ -829,7 +842,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
 '''''''''
@@ -866,7 +879,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug fixes
 '''''''''
@@ -890,7 +903,7 @@ New features
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-29:
+.. _bug-fixes-30:
 
 Bug fixes
 '''''''''
@@ -934,7 +947,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-30:
+.. _bug-fixes-31:
 
 Bug fixes
 '''''''''
@@ -983,7 +996,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-31:
+.. _bug-fixes-32:
 
 Bug fixes
 '''''''''
@@ -1006,7 +1019,7 @@ New features
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-32:
+.. _bug-fixes-33:
 
 Bug fixes
 '''''''''
@@ -1035,7 +1048,7 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-33:
+.. _bug-fixes-34:
 
 Bug fixes
 '''''''''
@@ -1071,7 +1084,7 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-34:
+.. _bug-fixes-35:
 
 Bug fixes
 '''''''''
@@ -1098,7 +1111,7 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-35:
+.. _bug-fixes-36:
 
 Bug fixes
 '''''''''
@@ -1135,7 +1148,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-36:
+.. _bug-fixes-37:
 
 Bug fixes
 '''''''''
@@ -1167,7 +1180,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-37:
+.. _bug-fixes-38:
 
 Bug fixes
 '''''''''
@@ -1200,7 +1213,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-38:
+.. _bug-fixes-39:
 
 Bug fixes
 '''''''''
@@ -1256,7 +1269,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-39:
+.. _bug-fixes-40:
 
 Bug fixes
 '''''''''
@@ -1325,7 +1338,7 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-40:
+.. _bug-fixes-41:
 
 Bug fixes
 '''''''''
@@ -1352,7 +1365,7 @@ New features
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-41:
+.. _bug-fixes-42:
 
 Bug fixes
 '''''''''
@@ -1389,7 +1402,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-42:
+.. _bug-fixes-43:
 
 Bug fixes
 '''''''''
@@ -1465,7 +1478,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-43:
+.. _bug-fixes-44:
 
 Bug Fixes
 '''''''''

--- a/docs/Examples.rst
+++ b/docs/Examples.rst
@@ -175,7 +175,7 @@ Restricted mean survival times (RMST)
     .. math::  \text{RMST}(t) = \int_0^t S(\tau) d\tau
 
 
-This is a good metric for comparing two survival curves, as their difference represents the area between the curves (see figure below). The upper limit is often finite because the tail of the estimated survival curve has high variance and can strongly influence the integral.
+This is a good metric for comparing two survival curves, as their difference represents the area between the curves (see figure below) which is a measure of "time lost". The upper limit of the integral above is often finite because the tail of the estimated survival curve has high variance and can strongly influence the integral.
 
 .. code-block:: python
 
@@ -1006,7 +1006,7 @@ The information provided by ``print_summary`` can be a lot, and even too much fo
 Fixing a ``FormulaSyntaxError``
 ##############################################
 
-As a of *lifelines* v0.25.0, formulas are used internally (even if not explicity used in the call to ``fit``). This may cause problems if your dataframe has column names with spaces, periods, or other characters. The cheapest way to fix this is to change your column names:
+As a of *lifelines* v0.25.0, formulas can be used to model your dataframe. This may cause problems if your dataframe has column names with spaces, periods, or other characters. The cheapest way to fix this is to change your column names:
 
 
 .. code-block:: python

--- a/docs/Survival Analysis intro.rst
+++ b/docs/Survival Analysis intro.rst
@@ -199,7 +199,15 @@ The integral has a more common name: the *cumulative hazard function*, denoted :
 .. math:: S(t) = \exp\left(-H(t) \right)
 
 
-What I love about the above equation is that it defines **all** survival
+With that, the two figures below represent the hazard and the cumulative hazard, respectively, of the survival function in the figure above.
+
+.. image:: images/intro_hazards.png
+    :width: 550px
+    :align: center
+
+
+
+What I like about the above relationships is that it defines **all** survival
 functions. Notice that we can now speak either about the
 survival function, :math:`S(t)`, the hazard, :math:`h(t)`, or the cumulative hazard function,
 :math:`H(t)`, and we can convert back and forth quite easily. Below is a graphic of all the relationships between the quantities.
@@ -211,20 +219,14 @@ survival function, :math:`S(t)`, the hazard, :math:`h(t)`, or the cumulative haz
     :align: center
     :figclass: align-center
 
-    Map of the mathematical entities used in the survival analysis and the transforms between them.
+    Map of the mathematical entities used in survival analysis and the transforms between them.
     Don't panic: *lifelines* does this all for you.
 
-
-The two figures below represent the hazard and the cumulative hazard of the survival function in the figure above.
-
-.. image:: images/intro_hazards.png
-    :width: 550px
-    :align: center
 
 
 
 Next steps
 -----------------
 
-Of course, we do not observe the true survival function of a population. We
+Of course, we do not observe the true survival function or hazard of a population. We
 must use the observed data to estimate it. There are many ways to estimate the survival function and the hazard functions, which brings us to :doc:`estimation using lifelines</Survival analysis with lifelines>`.

--- a/docs/Survival Analysis intro.rst
+++ b/docs/Survival Analysis intro.rst
@@ -28,7 +28,6 @@ service, and a death is when the user leaves the service.
 Censoring
 ----------
 
-
 At the time you want to make inferences about durations, it is possible that not all the death events have occurred yet. For example, a
 medical professional will not wait 50 years for each individual in the
 study to pass away before investigating -- he or she is interested in

--- a/docs/Survival analysis with lifelines.rst
+++ b/docs/Survival analysis with lifelines.rst
@@ -165,7 +165,6 @@ an ``axis`` object, that can be used for plotting further estimates:
     kmf.fit(T[~dem], event_observed=E[~dem], label="Non-democratic Regimes")
     kmf.plot(ax=ax)
 
-    plt.ylim(0, 1);
     plt.title("Lifespans of different global regimes");
 
 
@@ -191,7 +190,6 @@ probabilities of survival at those points:
     kmf.fit(T[~dem], event_observed=E[~dem], timeline=t, label="Non-democratic Regimes")
     ax = kmf.plot(ax=ax)
 
-    plt.ylim(0, 1)
     plt.title("Lifespans of different global regimes");
 
 .. image:: images/lifelines_intro_multi_kmf_fitter_2.png

--- a/lifelines/calibration.py
+++ b/lifelines/calibration.py
@@ -9,7 +9,7 @@ from lifelines.fitters import RegressionFitter
 from lifelines import CRCSplineFitter
 
 
-def survival_probability_calibration(model: RegressionFitter, training_df: pd.DataFrame, t0: float, ax=None):
+def survival_probability_calibration(model: RegressionFitter, df: pd.DataFrame, t0: float, ax=None):
     r"""
     Smoothed calibration curves for time-to-event models. This is analogous to
     calibration curves for classification models, extended to handle survival probabilities
@@ -22,8 +22,9 @@ def survival_probability_calibration(model: RegressionFitter, training_df: pd.Da
 
     model:
         a fitted lifelines regression model to be evaluated
-    training_df: DataFrame
-        the DataFrame used to train the model
+    df: DataFrame
+        a DataFrame - if equal to the training data, then this is an in-sample calibration. Could also be an out-of-sample
+        dataset.
     t0: float
         the time to evaluate the probability of event occurring prior at.
 
@@ -49,10 +50,10 @@ def survival_probability_calibration(model: RegressionFitter, training_df: pd.Da
     T = model.duration_col
     E = model.event_col
 
-    predictions_at_t0 = np.clip(1 - model.predict_survival_function(training_df, times=[t0]).T.squeeze(), 1e-10, 1 - 1e-10)
+    predictions_at_t0 = np.clip(1 - model.predict_survival_function(df, times=[t0]).T.squeeze(), 1e-10, 1 - 1e-10)
 
     # create new dataset with the predictions
-    prediction_df = pd.DataFrame({"ccl_at_%d" % t0: ccl(predictions_at_t0), T: model.durations, E: model.event_observed})
+    prediction_df = pd.DataFrame({"ccl_at_%d" % t0: ccl(predictions_at_t0), T: df[T], E: df[E]})
 
     # fit new dataset to flexible spline model
     # this new model connects prediction probabilities and actual survival. It should be very flexible, almost to the point of overfitting. It's goal is just to smooth out the data!

--- a/lifelines/calibration.py
+++ b/lifelines/calibration.py
@@ -73,7 +73,7 @@ def survival_probability_calibration(model: RegressionFitter, df: pd.DataFrame, 
 
     # predict new model at values 0 to 1, but remember to ccl it!
     x = np.linspace(np.clip(predictions_at_t0.min() - 0.01, 0, 1), np.clip(predictions_at_t0.max() + 0.01, 0, 1), 100)
-    y = 1 - crc.predict_survival_function(pd.DataFrame({"ccl_at_%d" % t0: ccl(x), "constant": 1}), times=[t0]).T.squeeze()
+    y = 1 - crc.predict_survival_function(pd.DataFrame({"ccl_at_%d" % t0: ccl(x)}), times=[t0]).T.squeeze()
 
     # plot our results
     ax.set_title("Smoothed calibration curve of \npredicted vs observed probabilities of t ≤ %d mortality" % t0)

--- a/lifelines/calibration.py
+++ b/lifelines/calibration.py
@@ -61,7 +61,7 @@ def survival_probability_calibration(model: RegressionFitter, df: pd.DataFrame, 
     regressors = {"beta_": ["ccl_at_%d" % t0], "gamma0_": "1", "gamma1_": "1", "gamma2_": "1"}
 
     # this model is from examples/royson_crowther_clements_splines.py
-    crc = CRCSplineFitter(knots, penalizer=0)
+    crc = CRCSplineFitter(knots, penalizer=0.000001)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
         if CensoringType.is_right_censoring(model):

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -80,7 +80,7 @@ class BaseFitter:
 
         See Also
         ---------
-        ``fit``
+        fit
         """
         return self.fit(*args, **kwargs)
 
@@ -612,7 +612,7 @@ class ParametricUnivariateFitter(UnivariateFitter):
 
         See Also
         --------
-        ``print_summary``
+        print_summary
         """
         with np.errstate(invalid="ignore", divide="ignore", over="ignore", under="ignore"):
             ci = (1 - self.alpha) * 100
@@ -638,7 +638,7 @@ class ParametricUnivariateFitter(UnivariateFitter):
         style: string
             {html, ascii, latex}
         columns:
-            only display a subset of `summary` columns. Default all.
+            only display a subset of ``summary`` columns. Default all.
         kwargs:
             print additional metadata in the output (useful to provide model names, dataset names, etc.) when comparing
             multiple outputs.
@@ -2086,7 +2086,7 @@ class ParametricRegressionFitter(RegressionFitter):
 
         See Also
         --------
-        ``print_summary``
+        print_summary
         """
 
         ci = (1 - self.alpha) * 100
@@ -2116,7 +2116,7 @@ class ParametricRegressionFitter(RegressionFitter):
         style: string
             {html, ascii, latex}
         columns:
-            only display a subset of `summary` columns. Default all.
+            only display a subset of ``summary`` columns. Default all.
         kwargs:
             print additional metadata in the output (useful to provide model names, dataset names, etc.) when comparing
             multiple outputs.
@@ -2459,7 +2459,7 @@ class ParametricRegressionFitter(RegressionFitter):
 
     def plot_covariate_groups(*args, **kwargs):
         """
-        Deprecated as of v0.25.0. Use plot_partial_effects_on_outcome instead.
+        Deprecated as of v0.25.0. Use ``plot_partial_effects_on_outcome`` instead.
         """
         warnings.warn("This method name is deprecated. Use `plot_partial_effects_on_outcome` instead.", DeprecationWarning)
         return plot_partial_effects_on_outcome(*args, **kwargs)
@@ -2624,12 +2624,15 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             since the fitter is iterative, show convergence
             diagnostics. Useful if convergence is failing.
 
-        ancillary: None, boolean, or DataFrame, optional (default=None)
+        formula: string
+            Use an R-style formula for modeling the dataset. See formula syntax: https://patsy.readthedocs.io/en/latest/quickstart.html
+
+        ancillary: None, boolean, str, or DataFrame, optional (default=None)
             Choose to model the ancillary parameters.
             If None or False, explicitly do not fit the ancillary parameters using any covariates.
-            If True, model the ancillary parameters with the same covariates/formula as ``df``.
+            If True, model the ancillary parameters with the same covariates as ``df``.
             If DataFrame, provide covariates to model the ancillary parameters. Must be the same row count as ``df``.
-            If string, must be a R-like formula.
+            If str, should be a formula
 
         fit_intercept: bool, optional
             If true, add a constant column to the regression. Overrides value set in class instantiation.
@@ -2650,9 +2653,6 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         entry_col: string
             specify a column in the DataFrame that denotes any late-entries (left truncation) that occurred. See
             the docs on `left truncation <https://lifelines.readthedocs.io/en/latest/Survival%20analysis%20with%20lifelines.html#left-truncated-late-entry-data>`__
-
-        formula: string
-            Use an R-style formula for modeling the dataset. See formula syntax: https://patsy.readthedocs.io/en/latest/quickstart.html
 
         Returns
         -------
@@ -2779,11 +2779,15 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             the  name of the column in DataFrame that contains the subjects' death
             observation. If left as None, will be inferred from the start and stop columns (lower_bound==upper_bound means uncensored)
 
-        ancillary: None, boolean, or DataFrame, optional (default=None)
+        formula: string
+            Use an R-style formula for modeling the dataset. See formula syntax: https://patsy.readthedocs.io/en/latest/quickstart.html
+
+        ancillary: None, boolean, str, or DataFrame, optional (default=None)
             Choose to model the ancillary parameters.
             If None or False, explicitly do not fit the ancillary parameters using any covariates.
             If True, model the ancillary parameters with the same covariates as ``df``.
             If DataFrame, provide covariates to model the ancillary parameters. Must be the same row count as ``df``.
+            If str, should be a formula
 
         fit_intercept: bool, optional
             If true, add a constant column to the regression. Overrides value set in class instantiation.
@@ -2809,8 +2813,6 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             specify a column in the DataFrame that denotes any late-entries (left truncation) that occurred. See
             the docs on `left truncation <https://lifelines.readthedocs.io/en/latest/Survival%20analysis%20with%20lifelines.html#left-truncated-late-entry-data>`__
 
-        formula: string
-            Use an R-style formula for modeling the dataset. See formula syntax: https://patsy.readthedocs.io/en/latest/quickstart.html
 
         Returns
         -------
@@ -2954,12 +2956,15 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             the  name of the column in DataFrame that contains the subjects' death
             observation. If left as None, assume all individuals are uncensored.
 
+        formula: string
+            Use an R-style formula for modeling the dataset. See formula syntax: https://patsy.readthedocs.io/en/latest/quickstart.html
+
         ancillary: None, boolean, str, or DataFrame, optional (default=None)
             Choose to model the ancillary parameters.
             If None or False, explicitly do not fit the ancillary parameters using any covariates.
             If True, model the ancillary parameters with the same covariates as ``df``.
             If DataFrame, provide covariates to model the ancillary parameters. Must be the same row count as ``df``.
-            If str, must be a valid formula
+            If str, should be a formula
 
         fit_intercept: bool, optional
             If true, add a constant column to the regression. Overrides value set in class instantiation.
@@ -2984,9 +2989,6 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         entry_col: str
             specify a column in the DataFrame that denotes any late-entries (left truncation) that occurred. See
             the docs on `left truncation <https://lifelines.readthedocs.io/en/latest/Survival%20analysis%20with%20lifelines.html#left-truncated-late-entry-data>`__
-
-        formula: string
-            Use an R-style formula for modeling the dataset. See formula syntax: https://patsy.readthedocs.io/en/latest/quickstart.html
 
 
         Returns
@@ -3193,12 +3195,14 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
 
     def plot_covariate_groups(*args, **kwargs):
         """
-        Deprecated as of v0.25.0. Use plot_partial_effects_on_outcome instead.
+        Deprecated as of v0.25.0. Use ``plot_partial_effects_on_outcome`` instead.
         """
         warnings.warn("This method name is deprecated. Use `plot_partial_effects_on_outcome` instead.", DeprecationWarning)
         return plot_partial_effects_on_outcome(*args, **kwargs)
 
-    def plot_partial_effects_on_outcome(self, covariates, values, plot_baseline=True, ax=None, times=None, **kwargs):
+    def plot_partial_effects_on_outcome(
+        self, covariates, values, plot_baseline=True, times=None, y="survival", ax=None, **kwargs
+    ):
         """
         Produces a visual representation comparing the baseline survival curve of the model versus
         what happens when a covariate(s) is varied over values in a group. This is useful to compare
@@ -3271,9 +3275,9 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         for covariate, value in zip(covariates, values.T):
             ancillary_X[covariate] = value
 
-        self.predict_survival_function(X, ancillary=ancillary_X, times=times).plot(ax=ax, **kwargs)
+        getattr(self, "predict_%s" % y)(X, ancillary=ancillary_X, times=times).plot(ax=ax, **kwargs)
         if plot_baseline:
-            self.predict_survival_function(x_bar, ancillary=x_bar_anc, times=times).rename(columns={0: "baseline survival"}).plot(
+            getattr(self, "predict_%s" % y)(x_bar, ancillary=x_bar_anc, times=times).rename(columns={0: "baseline %s" % y}).plot(
                 ax=ax, ls=":", color="k"
             )
         return ax
@@ -3310,10 +3314,8 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             a (n,d) covariate numpy array or DataFrame. If a DataFrame, columns
             can be in any order. If a numpy array, columns must be in the
             same order as the training data.
-        ancillary_X: numpy array or DataFrame, optional
-            a (n,d) covariate numpy array or DataFrame. If a DataFrame, columns
-            can be in any order. If a numpy array, columns must be in the
-            same order as the training data.
+        ancillary:
+            supply an dataframe to regress ancillary parameters against, if necessary.
         times: iterable, optional
             an iterable of increasing times to predict the survival function at. Default
             is the set of all durations (observed and unobserved).
@@ -3339,6 +3341,8 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             a (n,d) covariate numpy array or DataFrame. If a DataFrame, columns
             can be in any order. If a numpy array, columns must be in the
             same order as the training data.
+        ancillary:
+            supply an dataframe to regress ancillary parameters against, if necessary.
         conditional_after: iterable, optional
             Must be equal is size to df.shape[0] (denoted `n` above).  An iterable (array, list, series) of possibly non-zero values that represent how long the
             subject has already lived for. Ex: if :math:`T` is the unknown event time, then this represents
@@ -3374,6 +3378,8 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             a (n,d) covariate numpy array, Series, or DataFrame. If a DataFrame, columns
             can be in any order. If a numpy array, columns must be in the
             same order as the training data.
+        ancillary:
+            supply an dataframe to regress ancillary parameters against, if necessary.
         times: iterable, optional
             an iterable of increasing times to predict the cumulative hazard at. Default
             is the set of all durations (observed and unobserved).
@@ -3423,6 +3429,8 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             a (n,d) covariate numpy array or DataFrame. If a DataFrame, columns
             can be in any order. If a numpy array, columns must be in the
             same order as the training data.
+        ancillary:
+            supply an dataframe to regress ancillary parameters against, if necessary.
         times: iterable, optional
             an iterable of increasing times to predict the cumulative hazard at. Default
             is the set of all durations (observed and unobserved).

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -3201,7 +3201,7 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         return plot_partial_effects_on_outcome(*args, **kwargs)
 
     def plot_partial_effects_on_outcome(
-        self, covariates, values, plot_baseline=True, times=None, y="survival", ax=None, **kwargs
+        self, covariates, values, plot_baseline=True, times=None, y="survival_function", ax=None, **kwargs
     ):
         """
         Produces a visual representation comparing the baseline survival curve of the model versus

--- a/lifelines/fitters/aalen_additive_fitter.py
+++ b/lifelines/fitters/aalen_additive_fitter.py
@@ -536,7 +536,7 @@ It's important to know that the naive variance estimates of the coefficients are
         style: string
             {html, ascii, latex}
         columns:
-            only display a subset of `summary` columns. Default all.
+            only display a subset of ``summary`` columns. Default all.
         kwargs:
             print additional meta data in the output (useful to provide model names, dataset names, etc.) when comparing
             multiple outputs.

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -74,7 +74,7 @@ class CoxTimeVaryingFitter(SemiParametricRegressionFittter, ProportionalHazardMi
         The event_observed variable provided
     weights: Series
         The event_observed variable provided
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     strata: list
         the strata provided

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -649,7 +649,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         style: string
             {html, ascii, latex}
         columns:
-            only display a subset of `summary` columns. Default all.
+            only display a subset of ``summary`` columns. Default all.
         kwargs:
             print additional meta data in the output (useful to provide model names, dataset names, etc.) when comparing
             multiple outputs.

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -99,7 +99,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         The event_observed variable provided
     weights: Series
         The event_observed variable provided
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     strata: list
         the strata provided
@@ -209,7 +209,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
             "The Robust Inference for the Cox Proportional Hazards Model", Journal of the American Statistical Association, Vol. 84, No. 408 (Dec., 1989), pp. 1074- 1078
 
         formula: str, optional
-            an Wilkinson formula, like in R and statsmodels, for the RHS. If left as None, all columns not assigned as durations, weights, etc. are used.
+            an Wilkinson formula, like in R and statsmodels, for the right-hand-side. If left as None, all columns not assigned as durations, weights, etc. are used.
 
         batch_mode: bool, optional
             enabling batch_mode can be faster for datasets with a large number of ties. If left as None, lifelines will choose the best option.
@@ -265,7 +265,6 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
             cph = CoxPHFitter()
             cph.fit(df, 'T', 'E', strata=['month', 'age'], robust=True, weights_col='weights')
             cph.print_summary()
-            cph.predict_median(df)
 
         """
         self.strata = utils.coalesce(strata, self.strata)
@@ -530,7 +529,7 @@ class SemiParametricPHFitter(ProportionalHazardMixin, SemiParametricRegressionFi
         The event_observed variable provided
     weights: Series
         The event_observed variable provided
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     strata: list
         the strata provided

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -358,7 +358,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         style: string
             {html, ascii, latex}
         columns:
-            only display a subset of `summary` columns. Default all.
+            only display a subset of ``summary`` columns. Default all.
         kwargs:
             print additional metadata in the output (useful to provide model names, dataset names, etc.) when comparing
             multiple outputs.
@@ -2115,7 +2115,7 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
 
     def plot_covariate_groups(*args, **kwargs):
         """
-        Deprecated as of v0.25.0. Use plot_partial_effects_on_outcome instead.
+        Deprecated as of v0.25.0. Use ``plot_partial_effects_on_outcome`` instead.
         """
         warnings.warn("This method name is deprecated. Use `plot_partial_effects_on_outcome` instead.", DeprecationWarning)
         return plot_partial_effects_on_outcome(*args, **kwargs)

--- a/lifelines/fitters/exponential_fitter.py
+++ b/lifelines/fitters/exponential_fitter.py
@@ -27,11 +27,6 @@ class ExponentialFitter(KnownModelParametricUnivariateFitter):
     alpha: float, optional (default=0.05)
         the level in the confidence intervals.
 
-    Important
-    ----------
-    The parameterization of this model changed in lifelines 0.19.0. Previously, the cumulative hazard looked like
-    :math:`\lambda t`. The parameterization is now the reciprocal of :math:`\lambda`.
-
     Attributes
     ----------
     cumulative_hazard_ : DataFrame
@@ -46,7 +41,7 @@ class ExponentialFitter(KnownModelParametricUnivariateFitter):
         The estimated survival function (with custom timeline if provided)
     confidence_interval_survival_function_ : DataFrame
         The lower and upper confidence intervals for the survival function
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     median_survival_time_: float
         The median time to event
@@ -62,7 +57,7 @@ class ExponentialFitter(KnownModelParametricUnivariateFitter):
         The entry array provided, or None
     cumulative_density_ : DataFrame
         The estimated cumulative density function (with custom timeline if provided)
-    density: DataFrame
+    density_: DataFrame
         The estimated density function (PDF) (with custom timeline if provided)
 
     confidence_interval_cumulative_density_ : DataFrame

--- a/lifelines/fitters/generalized_gamma_fitter.py
+++ b/lifelines/fitters/generalized_gamma_fitter.py
@@ -81,10 +81,10 @@ class GeneralizedGammaFitter(KnownModelParametricUnivariateFitter):
         The estimated survival function (with custom timeline if provided)
     cumulative_density_ : DataFrame
         The estimated cumulative density function (with custom timeline if provided)
-    density: DataFrame
+    density_: DataFrame
         The estimated density function (PDF) (with custom timeline if provided)
 
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     median_survival_time_: float
         The median time to event

--- a/lifelines/fitters/generalized_gamma_regression_fitter.py
+++ b/lifelines/fitters/generalized_gamma_regression_fitter.py
@@ -86,10 +86,10 @@ class GeneralizedGammaRegressionFitter(ParametricRegressionFitter):
         The estimated survival function (with custom timeline if provided)
     cumulative_density_ : DataFrame
         The estimated cumulative density function (with custom timeline if provided)
-    density: DataFrame
+    density_: DataFrame
         The estimated density function (PDF) (with custom timeline if provided)
 
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     median_: float
         The median time to event

--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -347,7 +347,7 @@ class KaplanMeierFitter(NonParametricUnivariateFitter):
         setattr(self, secondary_estimate_name, pd.DataFrame(1 - np.exp(log_estimate), columns=[self._label]))
 
         self.__estimate = getattr(self, primary_estimate_name)
-        self.confidence_interval_ = self._bounds(cumulative_sq_[:, None], alpha, ci_labels)
+        self.confidence_interval_ = self._bounds(cumulative_sq_.values[:, None], alpha, ci_labels)
         self._median = median_survival_times(self.survival_function_)
         self._cumulative_sq_ = cumulative_sq_
 

--- a/lifelines/fitters/log_logistic_aft_fitter.py
+++ b/lifelines/fitters/log_logistic_aft_fitter.py
@@ -61,7 +61,7 @@ class LogLogisticAFTFitter(ParametericAFTRegressionFitter):
         The event_observed variable provided
     weights: Series
         The event_observed variable provided
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     standard_errors_: Series
         the standard errors of the estimates

--- a/lifelines/fitters/log_logistic_fitter.py
+++ b/lifelines/fitters/log_logistic_fitter.py
@@ -57,9 +57,9 @@ class LogLogisticFitter(KnownModelParametricUnivariateFitter):
         The estimated survival function (with custom timeline if provided)
     cumulative_density_ : DataFrame
         The estimated cumulative density function (with custom timeline if provided)
-    density: DataFrame
+    density_: DataFrame
         The estimated density function (PDF) (with custom timeline if provided)
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     median_survival_time_: float
         The median time to event

--- a/lifelines/fitters/log_normal_aft_fitter.py
+++ b/lifelines/fitters/log_normal_aft_fitter.py
@@ -62,7 +62,7 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
         The event_observed variable provided
     weights: Series
         The event_observed variable provided
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     standard_errors_: Series
         the standard errors of the estimates

--- a/lifelines/fitters/log_normal_fitter.py
+++ b/lifelines/fitters/log_normal_fitter.py
@@ -38,10 +38,10 @@ class LogNormalFitter(KnownModelParametricUnivariateFitter):
         The estimated survival function (with custom timeline if provided)
     cumulative_density_ : DataFrame
         The estimated cumulative density function (with custom timeline if provided)
-    density: DataFrame
+    density_: DataFrame
         The estimated density function (PDF) (with custom timeline if provided)
 
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     median_survival_time_: float
         The median time to event

--- a/lifelines/fitters/mixture_cure_fitter.py
+++ b/lifelines/fitters/mixture_cure_fitter.py
@@ -57,7 +57,7 @@ class MixtureCureFitter(ParametricUnivariateFitter):
         The estimated survival function (with custom timeline if provided)
     cumulative_density_ : DataFrame
         The estimated cumulative density function (with custom timeline if provided)
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     median_survival_time_: float
         The median time to event

--- a/lifelines/fitters/nelson_aalen_fitter.py
+++ b/lifelines/fitters/nelson_aalen_fitter.py
@@ -133,7 +133,7 @@ class NelsonAalenFitter(UnivariateFitter):
         # estimates
         self._label = coalesce(label, self._label, "NA_estimate")
         self.cumulative_hazard_ = pd.DataFrame(cumulative_hazard_, columns=[self._label])
-        self.confidence_interval_ = self._bounds(cumulative_sq_[:, None], alpha if alpha else self.alpha, ci_labels)
+        self.confidence_interval_ = self._bounds(cumulative_sq_.values[:, None], alpha if alpha else self.alpha, ci_labels)
         self.confidence_interval_cumulative_hazard_ = self.confidence_interval_
         self._cumulative_sq = cumulative_sq_
 

--- a/lifelines/fitters/piecewise_exponential_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_fitter.py
@@ -44,10 +44,10 @@ class PiecewiseExponentialFitter(KnownModelParametricUnivariateFitter):
         The estimated survival function (with custom timeline if provided)
     cumulative_density_ : DataFrame
         The estimated cumulative density function (with custom timeline if provided)
-    density: DataFrame
+    density_: DataFrame
         The estimated density function (PDF) (with custom timeline if provided)
 
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     median_survival_time_: float
         The median time to event

--- a/lifelines/fitters/spline_fitter.py
+++ b/lifelines/fitters/spline_fitter.py
@@ -52,10 +52,9 @@ class SplineFitter(KnownModelParametricUnivariateFitter, SplineFitterMixin):
         The estimated survival function (with custom timeline if provided)
     cumulative_density_ : DataFrame
         The estimated cumulative density function (with custom timeline if provided)
-    density: DataFrame
+    density_: DataFrame
         The estimated density function (PDF) (with custom timeline if provided)
-
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     median_survival_time_: float
         The median time to event
@@ -71,8 +70,10 @@ class SplineFitter(KnownModelParametricUnivariateFitter, SplineFitterMixin):
         The time line to use for plotting and indexing
     entry: array or None
         The entry array provided, or None
-    knot_locations:
-        The locations of the cubic breakpoints.
+    knot_locations: array
+        The locations of the breakpoints.
+    n_knots: int
+        Count of breakpoints
 
     """
     _scipy_fit_method = "SLSQP"

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -68,7 +68,7 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter, ProportionalHazardMixin):
         The event_observed variable provided
     weights: Series
         The event_observed variable provided
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     standard_errors_: Series
         the standard errors of the estimates

--- a/lifelines/fitters/weibull_fitter.py
+++ b/lifelines/fitters/weibull_fitter.py
@@ -37,11 +37,6 @@ class WeibullFitter(KnownModelParametricUnivariateFitter):
     alpha: float, optional (default=0.05)
         the level in the confidence intervals.
 
-    Important
-    ----------
-    The parameterization of this model changed in lifelines 0.19.0. Previously, the cumulative hazard looked like
-    :math:`(\lambda t)^\rho`. The parameterization is now the reciprocal of :math:`\lambda`.
-
     Examples
     --------
     .. code:: python
@@ -64,10 +59,9 @@ class WeibullFitter(KnownModelParametricUnivariateFitter):
         The estimated survival function (with custom timeline if provided)
     cumulative_density_ : DataFrame
         The estimated cumulative density function (with custom timeline if provided)
-    density: DataFrame
+    density_: DataFrame
         The estimated density function (PDF) (with custom timeline if provided)
-
-    variance_matrix_ : numpy array
+    variance_matrix_ : DataFrame
         The variance matrix of the coefficients
     median_survival_time_: float
         The median time to event

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -357,7 +357,7 @@ def remove_ticks(ax, x=False, y=False):
     return ax
 
 
-def add_at_risk_counts(*fitters, ax=None, labels: Optional[Union[Iterable, bool]] = None, **kwargs):
+def add_at_risk_counts(*fitters, ax=None, labels: Optional[Union[Iterable, bool]] = None, hide_censoring_row=False, **kwargs):
     """
     Add counts showing how many individuals were at risk at each time point in
     survival/hazard plots.
@@ -419,13 +419,10 @@ def add_at_risk_counts(*fitters, ax=None, labels: Optional[Union[Iterable, bool]
 
     if labels is None:
         labels = [f._label for f in fitters]
+        labels = [l.replace("_", r"\_") for l in labels]
     elif labels is False:
         labels = [None] * len(fitters)
 
-    labels = [l.replace("_", r"\_") for l in labels]
-
-    # remove xlabel
-    ax.set_xlabel("")
     # Create another axes where we can put size ticks
     ax2 = plt.twiny(ax=ax)
     # Move the ticks below existing axes
@@ -554,8 +551,8 @@ def plot_interval_censored_lifetimes(
     label_plot_bars = type(lower_bound) is pd.Series and type(lower_bound.index) is not pd.RangeIndex
 
     N = lower_bound.shape[0]
-    if N > 80:
-        warnings.warn("For less visual clutter, you may want to subsample to less than 80 individuals.")
+    if N > 25:
+        warnings.warn("For less visual clutter, you may want to subsample to less than 25 individuals.")
 
     assert upper_bound.shape[0] == N
 
@@ -649,8 +646,8 @@ def plot_lifetimes(
     label_plot_bars = type(durations) is pd.Series and type(durations.index) is not pd.RangeIndex
 
     N = durations.shape[0]
-    if N > 80:
-        warnings.warn("For less visual clutter, you may want to subsample to less than 80 individuals.")
+    if N > 25:
+        warnings.warn("For less visual clutter, you may want to subsample to less than 25 individuals.")
 
     if event_observed is None:
         event_observed = np.ones(N, dtype=bool)

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -431,7 +431,7 @@ def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None,
         labels = [None] * len(fitters)
 
     if rows_to_show is None:
-        rows_to_show = ["At Risk", "Censored", "Events"]
+        rows_to_show = ["At risk", "Censored", "Events"]
     n_rows = len(rows_to_show)
 
     # Create another axes where we can put size ticks

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -74,7 +74,13 @@ def create_scipy_stats_model_from_lifelines_model(model):
 
 def cdf_plot(model, timeline=None, ax=None, **plot_kwargs):
     """
+    This plot compares the empirical CDF (derived by KaplanMeier) vs the model CDF.
 
+    Parameters
+    ------------
+    model: lifelines univariate model
+    timeline: iterable
+    ax: matplotlib axis
 
     """
     from lifelines import KaplanMeierFitter
@@ -357,9 +363,9 @@ def remove_ticks(ax, x=False, y=False):
     return ax
 
 
-def add_at_risk_counts(*fitters, ax=None, labels: Optional[Union[Iterable, bool]] = None, hide_censoring_row=False, **kwargs):
+def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None, rows_to_show=None, ax=None, **kwargs):
     """
-    Add counts showing how many individuals were at risk at each time point in
+    Add counts showing how many individuals were at risk, censored, and observed, at each time point in
     survival/hazard plots.
 
     Parameters
@@ -372,6 +378,8 @@ def add_at_risk_counts(*fitters, ax=None, labels: Optional[Union[Iterable, bool]
     labels:
         provide labels for the fitters, default is to use the provided fitter label. Set to
         False for no labels.
+    rows_to_show: list
+        list of a subset of {'At risk', 'Censored', 'Events'}. Default shows all columns.
 
     Returns
     --------
@@ -419,9 +427,12 @@ def add_at_risk_counts(*fitters, ax=None, labels: Optional[Union[Iterable, bool]
 
     if labels is None:
         labels = [f._label for f in fitters]
-        labels = [l.replace("_", r"\_") for l in labels]
     elif labels is False:
         labels = [None] * len(fitters)
+
+    if rows_to_show is None:
+        rows_to_show = ["At Risk", "Censored", "Events"]
+    n_rows = len(rows_to_show)
 
     # Create another axes where we can put size ticks
     ax2 = plt.twiny(ax=ax)
@@ -462,27 +473,29 @@ def add_at_risk_counts(*fitters, ax=None, labels: Optional[Union[Iterable, bool]
                 f.event_table.assign(at_risk=lambda x: x.at_risk - x.removed)
                 .loc[:tick, ["at_risk", "censored", "observed"]]
                 .agg({"at_risk": "min", "censored": "sum", "observed": "sum"})
+                .rename({"at_risk": "At risk", "censored": "Censored", "observed": "Events"})
             )
-            counts.extend([int(c) for c in event_table_slice.loc[["at_risk", "censored", "observed"]]])
+            counts.extend([int(c) for c in event_table_slice.loc[rows_to_show]])
 
         if tick == ax2.get_xticks()[0]:
             max_length = len(str(max(counts)))
             for i, c in enumerate(counts):
-                if i % 3 == 0:
+                if i % n_rows == 0:
                     if is_latex_enabled():
-                        lbl += ("\n" if i > 0 else "") + r"\textbf{%s}" % labels[int(i / 3)] + "\n"
+                        lbl += ("\n" if i > 0 else "") + r"\textbf{%s}" % labels[int(i / n_rows)] + "\n"
                     else:
-                        lbl += ("\n" if i > 0 else "") + r"$\mathit{%s}$" % labels[int(i / 3)] + "\n"
+                        lbl += ("\n" if i > 0 else "") + r"%s" % labels[int(i / n_rows)] + "\n"
 
-                l = ["  At risk", "Censored  ", " Events  "][i % 3]
-                s = "{}   ".format(l) + "{{:>{}d}}\n".format(max_length)
+                l = rows_to_show[i % n_rows]
+                l = {"At risk": "  At risk", "Censored": "Censored  ", "Events": " Events  "}.get(l)
+                s = "{}   ".format(l.rjust(10, " ")) + "{{:>{}d}}\n".format(max_length)
                 lbl += s.format(c)
 
         else:
             # Create tick label
             lbl += ""
             for i, c in enumerate(counts):
-                if i % 3 == 0 and i > 0:
+                if i % n_rows == 0 and i > 0:
                     lbl += "\n\n"
                 s = "\n{}"
                 lbl += s.format(c)

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -127,6 +127,19 @@ class TestPlotting:
         self.plt.title("test_kmf_add_at_risk_counts_with_subplot")
         self.plt.show(block=block)
 
+    def test_kmf_add_at_risk_counts_with_specific_rows(self, block, kmf):
+        T = np.random.exponential(10, size=(100))
+        E = np.random.binomial(1, 0.8, size=(100))
+        kmf.fit(T, E)
+
+        fig = self.plt.figure()
+        ax = fig.subplots(1, 1)
+        kmf.plot(ax=ax)
+        add_at_risk_counts(kmf, ax=ax, rows_to_show=["Censored", "At risk"])
+
+        self.plt.title("test_kmf_add_at_risk_counts_with_specific_rows")
+        self.plt.show(block=block)
+
     def test_kmf_add_at_risk_counts_with_custom_subplot(self, block, kmf):
         # https://github.com/CamDavidsonPilon/lifelines/issues/991#issuecomment-614427882
         import lifelines

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -773,4 +773,13 @@ class TestPlotting:
         rossi = load_rossi()
         cph = CoxPHFitter().fit(rossi, "week", "arrest")
         survival_probability_calibration(cph, rossi, 25)
+        self.plt.title("test_survival_probability_calibration")
+        self.plt.show(block=block)
+
+    def test_survival_probability_calibration_on_out_of_sample_data(self, block):
+        rossi = load_rossi()
+        rossi = rossi.sample(frac=1.0)
+        cph = CoxPHFitter().fit(rossi.loc[:300], "week", "arrest")
+        survival_probability_calibration(cph.loc[300:], rossi, 25)
+        self.plt.title("test_survival_probability_calibration_on_out_of_sample_data")
         self.plt.show(block=block)

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -793,6 +793,6 @@ class TestPlotting:
         rossi = load_rossi()
         rossi = rossi.sample(frac=1.0)
         cph = CoxPHFitter().fit(rossi.loc[:300], "week", "arrest")
-        survival_probability_calibration(cph.loc[300:], rossi, 25)
+        survival_probability_calibration(cph, rossi.loc[300:], 25)
         self.plt.title("test_survival_probability_calibration_on_out_of_sample_data")
         self.plt.show(block=block)

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1851,7 +1851,7 @@ class CovariateParameterMappings:
             else:
                 raise ValueError("Unexpected transform.")
 
-    def transform_df(self, df):
+    def transform_df(self, df: pd.DataFrame):
 
         import patsy
 
@@ -1876,26 +1876,26 @@ class CovariateParameterMappings:
 
         # in pandas 0.23.4, the Xs as a dict is sorted differently from the Xs as a DataFrame's columns
         # hence we need to reorder, see https://github.com/CamDavidsonPilon/lifelines/issues/931
-        Xs = pd.concat(Xs, axis=1, names=("param", "covariate")).astype(float)
-        Xs = Xs[list(self.mappings.keys())]
+        Xs_df = pd.concat(Xs, axis=1, names=("param", "covariate")).astype(float)
+        Xs_df = Xs_df[list(self.mappings.keys())]
 
         # we can't concat empty dataframes and return a column MultiIndex,
         # so we create a "fake" dataframe (acts like a dataframe) to return.
-        if Xs.size == 0:
+        if Xs_df.size == 0:
             return {p: pd.DataFrame(index=df.index) for p in self.mappings.keys()}
         else:
-            return Xs
+            return Xs_df
 
     def keys(self):
         yield from self.mappings.keys()
 
-    def _list_seed_transform(self, list_):
+    def _list_seed_transform(self, list_: List):
         list_ = list_.copy()
         if self.force_intercept:
             list_.append(self.INTERCEPT_COL)
         return list_
 
-    def _string_seed_transform(self, formula, df):
+    def _string_seed_transform(self, formula: str, df: pd.DataFrame):
         # user input a formula, hopefully
         import patsy
 
@@ -1909,7 +1909,7 @@ class CovariateParameterMappings:
             import traceback
 
             column_error = "\n".join(traceback.format_exc().split("\n")[-4:])
-            raise utils.FormulaSyntaxError(
+            raise exceptions.FormulaSyntaxError(
                 (
                     """
 It looks like the DataFrame has non-standard column names. See below for which column:

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.25.0"
+__version__ = "0.25.1"

--- a/reqs/base-requirements.txt
+++ b/reqs/base-requirements.txt
@@ -4,3 +4,4 @@ pandas>=0.23.0
 matplotlib>=3.0
 autograd>=1.3
 autograd-gamma>=0.3
+patsy>=0.5.0


### PR DESCRIPTION
#### 0.25.1 - 2020-08-01

##### Bug fixes
 - ok _actually_ ship the out-of-sample calibration code
 - fix `labels=False` in `add_at_risk_counts`
 - all for specific rows to be shown in `add_at_risk_counts`
 - put `patsy` as a proper dependency.
 - suppress some Pandas 1.1 warnings.
