### PR TITLE
V0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+#### 0.25.2 - unreleased
+
+##### Bug fixes
+ - fix CoxPHFitter with splines when predict_hazard was called.
+ -
+
+
 #### 0.25.1 - 2020-08-01
 
 ##### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@
 ##### New features
  - Spline `CoxPHFitter` can now use `strata`.
 
+##### API Changes
+ - a small parameterization change of the spline `CoxPHFitter`. The linear term in the spline part was moved to a new `Intercept` term in the `beta_`.
+ - `n_baseline_knots` in the spline `CoxPHFitter` now refers to _all_ knots, and not just interior knots (this was confusing to me, the author.). So add 2 to `n_baseline_knots` to recover the identical model as previously.
+
 ##### Bug fixes
  - fix splines `CoxPHFitter` with  when `predict_hazard` was called.
+ - fix some exception imports I missed.
+ - fix log-likelihood p-value in splines `CoxPHFitter`
 
 
 #### 0.25.1 - 2020-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-#### 0.25.2 - unreleased
+#### 0.25.2 - 2020-08-08
 
 ##### New features
  - Spline `CoxPHFitter` can now use `strata`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 #### 0.25.2 - unreleased
 
+##### New features
+ - Spline `CoxPHFitter` can now use `strata`.
+
 ##### Bug fixes
- - fix CoxPHFitter with splines when predict_hazard was called.
- -
+ - fix splines `CoxPHFitter` with  when `predict_hazard` was called.
 
 
 #### 0.25.1 - 2020-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ##### Bug fixes
  - ok _actually_ ship the out-of-sample calibration code
  - fix `labels=False` in `add_at_risk_counts`
- - all for specific rows to be shown in `add_at_risk_counts`
+ - allow for specific rows to be shown in `add_at_risk_counts`
  - put `patsy` as a proper dependency.
  - suppress some Pandas 1.1 warnings.
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,28 +1,61 @@
 Changelog
 ---------
 
+0.25.2 - 2020-08-08
+^^^^^^^^^^^^^^^^^^^
+
+New features
+''''''''''''
+
+-  Spline ``CoxPHFitter`` can now use ``strata``.
+
+API Changes
+'''''''''''
+
+-  a small parameterization change of the spline ``CoxPHFitter``. The
+   linear term in the spline part was moved to a new ``Intercept`` term
+   in the ``beta_``.
+-  ``n_baseline_knots`` in the spline ``CoxPHFitter`` now refers to
+   *all* knots, and not just interior knots (this was confusing to me,
+   the author.). So add 2 to ``n_baseline_knots`` to recover the
+   identical model as previously.
+
+Bug fixes
+'''''''''
+
+-  fix splines ``CoxPHFitter`` with when ``predict_hazard`` was called.
+-  fix some exception imports I missed.
+-  fix log-likelihood p-value in splines ``CoxPHFitter``
+
+.. _section-1:
+
 0.25.1 - 2020-08-01
 ^^^^^^^^^^^^^^^^^^^
+
+.. _bug-fixes-1:
 
 Bug fixes
 '''''''''
 
 -  ok *actually* ship the out-of-sample calibration code
 -  fix ``labels=False`` in ``add_at_risk_counts``
--  all for specific rows to be shown in ``add_at_risk_counts``
+-  allow for specific rows to be shown in ``add_at_risk_counts``
 -  put ``patsy`` as a proper dependency.
 -  suppress some Pandas 1.1 warnings.
 
-.. _section-1:
+.. _section-2:
 
 0.25.0 - 2020-07-27
 ^^^^^^^^^^^^^^^^^^^
+
+.. _new-features-1:
 
 New features
 ''''''''''''
 
 -  Formulas! *lifelines* now supports R-like formulas in regression
-   models. See docs `here <>`__.
+   models. See docs
+   `here <https://lifelines.readthedocs.io/en/latest/Survival%20Regression.html#fitting-the-regression>`__.
 -  ``plot_covariate_group`` now can plot other y-values like hazards and
    cumulative hazards (default: survival function).
 -  ``CoxPHFitter`` now accepts late entries via ``entry_col``.
@@ -32,6 +65,8 @@ New features
    the displayed values. This helps with clutter in notebooks, latex, or
    on the terminal.
 -  ``add_at_risk_counts`` now follows the cool new KMunicate suggestions
+
+.. _api-changes-1:
 
 API Changes
 '''''''''''
@@ -70,7 +105,7 @@ API Changes
    `here <https://lifelines.readthedocs.io/en/latest/Survival%20Regression.html#plotting-the-effect-of-varying-a-covariate>`__.
 -  all exceptions and warnings have moved to ``lifelines.exceptions``
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 '''''''''
@@ -86,12 +121,12 @@ Bug fixes
 -  fixed NaN bug in ``survival_table_from_events`` with intervals when
    no events would occur in a interval.
 
-.. _section-2:
+.. _section-3:
 
-0.24.15 - 2020-07-09
+0.24.16 - 2020-07-09
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ''''''''''''
@@ -99,19 +134,19 @@ New features
 -  improved algorithm choice for large DataFrames for Cox models. Should
    see a significant performance boost.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 '''''''''
 
 -  fixed ``utils.median_survival_time`` not accepting Pandas Series.
 
-.. _section-3:
+.. _section-4:
 
 0.24.15 - 2020-07-07
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 '''''''''
@@ -122,12 +157,12 @@ Bug fixes
 -  fixed bug where using ``conditional_after`` and ``times`` in
    ``CoxPHFitter("spline")`` prediction methods would be ignored.
 
-.. _section-4:
+.. _section-5:
 
 0.24.14 - 2020-07-02
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 '''''''''
@@ -139,12 +174,12 @@ Bug fixes
 -  fixed a bug where some columns would not be displayed in
    ``print_summary``
 
-.. _section-5:
+.. _section-6:
 
 0.24.13 - 2020-06-22
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 '''''''''
@@ -154,24 +189,24 @@ Bug fixes
 -  fixed a bug where ``CoxPHFitter`` would fail with working with
    ``sklearn_adapter``
 
-.. _section-6:
+.. _section-7:
 
 0.24.12 - 2020-06-20
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ''''''''''''
 
 -  improved convergence of ``GeneralizedGamma(Regression)Fitter``.
 
-.. _section-7:
+.. _section-8:
 
 0.24.11 - 2020-06-17
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ''''''''''''
@@ -185,7 +220,7 @@ New features
    and the integrated calibration index (ICI) for survival models” by P.
    Austin, F. Harrell, and D. van Klaveren.
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API Changes
 '''''''''''
@@ -194,12 +229,12 @@ API Changes
    penalized by ``penalizer`` - we now penalizing everything except
    intercept terms in linear relationships.
 
-.. _section-8:
+.. _section-9:
 
 0.24.10 - 2020-06-16
 ^^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ''''''''''''
@@ -208,7 +243,7 @@ New features
    offer much better prediction and baseline-hazard estimation,
    including extrapolation and interpolation.
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API Changes
 '''''''''''
@@ -216,7 +251,7 @@ API Changes
 -  Related to above: the fitted spline parameters are now available in
    the ``.summary`` and ``.print_summary`` methods.
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 '''''''''
@@ -224,12 +259,12 @@ Bug fixes
 -  fixed a bug in initialization of some interval-censoring models ->
    better convergence.
 
-.. _section-9:
+.. _section-10:
 
 0.24.9 - 2020-06-05
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ''''''''''''
@@ -239,7 +274,7 @@ New features
    ``tarone-ware``, ``peto``, ``fleming-harrington``. Thanks @sean-reed
 -  new interval censored dataset: ``lifelines.datasets.load_mice``
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 '''''''''
@@ -247,12 +282,12 @@ Bug fixes
 -  Cleared up some mislabeling in ``plot_loglogs``. Thanks @sean-reed!
 -  tuples are now able to be used as input in univariate models.
 
-.. _section-10:
+.. _section-11:
 
 0.24.8 - 2020-05-17
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ''''''''''''
@@ -261,12 +296,12 @@ New features
    Not all edge cases are fully checked, and some features are missing.
    Try it under ``KaplanMeierFitter.fit_interval_censoring``
 
-.. _section-11:
+.. _section-12:
 
 0.24.7 - 2020-05-17
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ''''''''''''
@@ -282,12 +317,12 @@ New features
 -  some convergence tweaks which should help recent performance
    regressions.
 
-.. _section-12:
+.. _section-13:
 
 0.24.6 - 2020-05-05
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-8:
+.. _new-features-9:
 
 New features
 ''''''''''''
@@ -297,7 +332,7 @@ New features
 -  New ``lifelines.plotting.plot_interval_censored_lifetimes`` for
    plotting interval censored data - thanks @sean-reed!
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 '''''''''
@@ -305,19 +340,19 @@ Bug fixes
 -  fixed bug where ``cdf_plot`` and ``qq_plot`` were not factoring in
    the weights correctly.
 
-.. _section-13:
+.. _section-14:
 
 0.24.5 - 2020-05-01
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-9:
+.. _new-features-10:
 
 New features
 ''''''''''''
 
 -  ``plot_lifetimes`` accepts pandas Series.
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 '''''''''
@@ -327,12 +362,12 @@ Bug fixes
 -  Improved ``at_risk_counts`` for subplots.
 -  More data validation checks for ``CoxTimeVaryingFitter``
 
-.. _section-14:
+.. _section-15:
 
 0.24.4 - 2020-04-13
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 '''''''''
@@ -341,12 +376,12 @@ Bug fixes
 -  setting a dataframe in ``ancillary_df`` works for interval censoring
 -  ``.score`` works for interval censored models
 
-.. _section-15:
+.. _section-16:
 
 0.24.3 - 2020-03-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-10:
+.. _new-features-11:
 
 New features
 ''''''''''''
@@ -356,7 +391,7 @@ New features
    the hazard ratio would be at previous times. This is useful because
    the final hazard ratio is some weighted average of these.
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 '''''''''
@@ -364,12 +399,12 @@ Bug fixes
 -  Fixed error in HTML printer that was hiding concordance index
    information.
 
-.. _section-16:
+.. _section-17:
 
 0.24.2 - 2020-03-15
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 '''''''''
@@ -381,12 +416,12 @@ Bug fixes
 -  Fixed a keyword bug in ``plot_covariate_groups`` for parametric
    models.
 
-.. _section-17:
+.. _section-18:
 
 0.24.1 - 2020-03-05
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-11:
+.. _new-features-12:
 
 New features
 ''''''''''''
@@ -394,14 +429,14 @@ New features
 -  Stability improvements for GeneralizedGammaRegressionFitter and
    CoxPHFitter with spline estimation.
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 '''''''''
 
 -  Fixed bug with plotting hazards in NelsonAalenFitter.
 
-.. _section-18:
+.. _section-19:
 
 0.24.0 - 2020-02-20
 ^^^^^^^^^^^^^^^^^^^
@@ -410,7 +445,7 @@ This version and future versions of lifelines no longer support py35.
 Pandas 1.0 is fully supported, along with previous versions. Minimum
 Scipy has been bumped to 1.2.0.
 
-.. _new-features-12:
+.. _new-features-13:
 
 New features
 ''''''''''''
@@ -434,7 +469,7 @@ New features
 -  new ``lifelines.fitters.mixins.ProportionalHazardMixin`` that
    implements proportional hazard checks.
 
-.. _api-changes-3:
+.. _api-changes-4:
 
 API Changes
 '''''''''''
@@ -462,7 +497,7 @@ API Changes
    to ``scoring_method``.
 -  removed ``_score_`` and ``path`` from Cox model.
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 '''''''''
@@ -475,12 +510,12 @@ Bug fixes
 -  Cox models now incorporate any penalizers in their
    ``log_likelihood_``
 
-.. _section-19:
+.. _section-20:
 
 0.23.9 - 2020-01-28
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 '''''''''
@@ -491,12 +526,12 @@ Bug fixes
    of ``GeneralizedGammaRegressionFitter`` and any custom regression
    models should update their code as soon as possible.
 
-.. _section-20:
+.. _section-21:
 
 0.23.8 - 2020-01-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 '''''''''
@@ -507,19 +542,19 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-21:
+.. _section-22:
 
 0.23.7 - 2020-01-14
 ^^^^^^^^^^^^^^^^^^^
 
 Bug fixes for py3.5.
 
-.. _section-22:
+.. _section-23:
 
 0.23.6 - 2020-01-07
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-13:
+.. _new-features-14:
 
 New features
 ''''''''''''
@@ -533,12 +568,12 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-23:
+.. _section-24:
 
 0.23.5 - 2020-01-05
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-14:
+.. _new-features-15:
 
 New features
 ''''''''''''
@@ -547,7 +582,7 @@ New features
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 '''''''''
@@ -557,26 +592,26 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-24:
+.. _section-25:
 
 0.23.4 - 2019-12-15
 ^^^^^^^^^^^^^^^^^^^
 
 -  Bug fix for PyPI
 
-.. _section-25:
+.. _section-26:
 
 0.23.3 - 2019-12-11
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-15:
+.. _new-features-16:
 
 New features
 ''''''''''''
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 '''''''''
@@ -584,12 +619,12 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-26:
+.. _section-27:
 
 0.23.2 - 2019-12-07
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-16:
+.. _new-features-17:
 
 New features
 ''''''''''''
@@ -601,7 +636,7 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 '''''''''
@@ -610,12 +645,12 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-27:
+.. _section-28:
 
 0.23.1 - 2019-11-27
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-17:
+.. _new-features-18:
 
 New features
 ''''''''''''
@@ -625,7 +660,7 @@ New features
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
 '''''''''
@@ -637,12 +672,12 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-28:
+.. _section-29:
 
 0.23.0 - 2019-11-17
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-18:
+.. _new-features-19:
 
 New features
 ''''''''''''
@@ -651,7 +686,7 @@ New features
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
 '''''''''
@@ -661,7 +696,7 @@ Bug fixes
    now fixed.
 -  fixed a NaN error in confidence intervals for KaplanMeierFitter
 
-.. _api-changes-4:
+.. _api-changes-5:
 
 API Changes
 '''''''''''
@@ -673,7 +708,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-29:
+.. _section-30:
 
 0.22.10 - 2019-11-08
 ^^^^^^^^^^^^^^^^^^^^
@@ -681,7 +716,7 @@ API Changes
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
 '''''''''
@@ -691,12 +726,12 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-30:
+.. _section-31:
 
 0.22.9 - 2019-10-30
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
 '''''''''
@@ -708,12 +743,12 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-31:
+.. _section-32:
 
 0.22.8 - 2019-10-06
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-19:
+.. _new-features-20:
 
 New features
 ''''''''''''
@@ -723,19 +758,19 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
 '''''''''
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-32:
+.. _section-33:
 
 0.22.7 - 2019-09-29
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-20:
+.. _new-features-21:
 
 New features
 ''''''''''''
@@ -743,7 +778,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
 '''''''''
@@ -752,7 +787,7 @@ Bug fixes
 -  realigned values in ``print_summary``.
 -  fixed bug in ``survival_difference_at_fixed_point_in_time_test``
 
-.. _api-changes-5:
+.. _api-changes-6:
 
 API Changes
 '''''''''''
@@ -762,24 +797,24 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-33:
+.. _section-34:
 
 0.22.6 - 2019-09-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-21:
+.. _new-features-22:
 
 New features
 ''''''''''''
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
 '''''''''
 
-.. _api-changes-6:
+.. _api-changes-7:
 
 API Changes
 '''''''''''
@@ -790,12 +825,12 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-34:
+.. _section-35:
 
 0.22.5 - 2019-09-20
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-22:
+.. _new-features-23:
 
 New features
 ''''''''''''
@@ -804,7 +839,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
 '''''''''
@@ -813,7 +848,7 @@ Bug fixes
 -  Fixed an issue with ``AalenJohansenFitter`` failing to plot
    confidence intervals.
 
-.. _api-changes-7:
+.. _api-changes-8:
 
 API Changes
 '''''''''''
@@ -821,12 +856,12 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-35:
+.. _section-36:
 
 0.22.4 - 2019-09-04
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-23:
+.. _new-features-24:
 
 New features
 ''''''''''''
@@ -837,7 +872,7 @@ New features
 -  new ``utils.restricted_mean_survival_time`` that approximates the
    RMST using numerical integration against survival functions.
 
-.. _api-changes-8:
+.. _api-changes-9:
 
 API changes
 '''''''''''
@@ -845,7 +880,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug fixes
 '''''''''
@@ -853,12 +888,12 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-36:
+.. _section-37:
 
 0.22.3 - 2019-08-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-24:
+.. _new-features-25:
 
 New features
 ''''''''''''
@@ -871,7 +906,7 @@ New features
 -  smarter initial conditions for parametric regression models.
 -  New regression model: ``GeneralizedGammaRegressionFitter``
 
-.. _api-changes-9:
+.. _api-changes-10:
 
 API changes
 '''''''''''
@@ -882,7 +917,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-29:
+.. _bug-fixes-30:
 
 Bug fixes
 '''''''''
@@ -894,19 +929,19 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-37:
+.. _section-38:
 
 0.22.2 - 2019-07-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-25:
+.. _new-features-26:
 
 New features
 ''''''''''''
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-30:
+.. _bug-fixes-31:
 
 Bug fixes
 '''''''''
@@ -917,12 +952,12 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-38:
+.. _section-39:
 
 0.22.1 - 2019-07-14
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-26:
+.. _new-features-27:
 
 New features
 ''''''''''''
@@ -937,7 +972,7 @@ New features
    right censoring)
 -  improvements to ``lifelines.utils.gamma``
 
-.. _api-changes-10:
+.. _api-changes-11:
 
 API changes
 '''''''''''
@@ -950,7 +985,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-31:
+.. _bug-fixes-32:
 
 Bug fixes
 '''''''''
@@ -960,12 +995,12 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-39:
+.. _section-40:
 
 0.22.0 - 2019-07-03
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-27:
+.. _new-features-28:
 
 New features
 ''''''''''''
@@ -977,7 +1012,7 @@ New features
 -  for parametric univariate models, the ``conditional_time_to_event_``
    is now exact instead of an approximation.
 
-.. _api-changes-11:
+.. _api-changes-12:
 
 API changes
 '''''''''''
@@ -999,7 +1034,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-32:
+.. _bug-fixes-33:
 
 Bug fixes
 '''''''''
@@ -1008,21 +1043,21 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-40:
+.. _section-41:
 
 0.21.5 - 2019-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 I’m skipping 0.21.4 version because of deployment issues.
 
-.. _new-features-28:
+.. _new-features-29:
 
 New features
 ''''''''''''
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-33:
+.. _bug-fixes-34:
 
 Bug fixes
 '''''''''
@@ -1032,12 +1067,12 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-41:
+.. _section-42:
 
 0.21.3 - 2019-06-04
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-29:
+.. _new-features-30:
 
 New features
 ''''''''''''
@@ -1051,19 +1086,19 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-34:
+.. _bug-fixes-35:
 
 Bug fixes
 '''''''''
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-42:
+.. _section-43:
 
 0.21.2 - 2019-05-16
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-30:
+.. _new-features-31:
 
 New features
 ''''''''''''
@@ -1075,7 +1110,7 @@ New features
    that computes, you guessed it, the log-likelihood ratio test.
    Previously this was an internal API that is being exposed.
 
-.. _api-changes-12:
+.. _api-changes-13:
 
 API changes
 '''''''''''
@@ -1087,17 +1122,17 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-35:
+.. _bug-fixes-36:
 
 Bug fixes
 '''''''''
 
-.. _section-43:
+.. _section-44:
 
 0.21.1 - 2019-04-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-31:
+.. _new-features-32:
 
 New features
 ''''''''''''
@@ -1106,7 +1141,7 @@ New features
    ``add_covariate_to_timeline``
 -  PiecewiseExponentialFitter now allows numpy arrays as breakpoints
 
-.. _api-changes-13:
+.. _api-changes-14:
 
 API changes
 '''''''''''
@@ -1114,19 +1149,19 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-36:
+.. _bug-fixes-37:
 
 Bug fixes
 '''''''''
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-44:
+.. _section-45:
 
 0.21.0 - 2019-04-12
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-32:
+.. _new-features-33:
 
 New features
 ''''''''''''
@@ -1140,7 +1175,7 @@ New features
 -  a new interval censored dataset is available under
    ``lifelines.datasets.load_diabetes``
 
-.. _api-changes-14:
+.. _api-changes-15:
 
 API changes
 '''''''''''
@@ -1151,7 +1186,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-37:
+.. _bug-fixes-38:
 
 Bug fixes
 '''''''''
@@ -1161,19 +1196,19 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-45:
+.. _section-46:
 
 0.20.5 - 2019-04-08
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-33:
+.. _new-features-34:
 
 New features
 ''''''''''''
 
 -  performance improvements for ``print_summary``.
 
-.. _api-changes-15:
+.. _api-changes-16:
 
 API changes
 '''''''''''
@@ -1183,7 +1218,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-38:
+.. _bug-fixes-39:
 
 Bug fixes
 '''''''''
@@ -1192,12 +1227,12 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-46:
+.. _section-47:
 
 0.20.4 - 2019-03-27
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-34:
+.. _new-features-35:
 
 New features
 ''''''''''''
@@ -1208,7 +1243,7 @@ New features
    generating piecewise exp. data
 -  Faster ``print_summary`` for AFT models.
 
-.. _api-changes-16:
+.. _api-changes-17:
 
 API changes
 '''''''''''
@@ -1216,7 +1251,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-39:
+.. _bug-fixes-40:
 
 Bug fixes
 '''''''''
@@ -1225,12 +1260,12 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-47:
+.. _section-48:
 
 0.20.3 - 2019-03-23
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-35:
+.. _new-features-36:
 
 New features
 ''''''''''''
@@ -1243,12 +1278,12 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-48:
+.. _section-49:
 
 0.20.2 - 2019-03-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-36:
+.. _new-features-37:
 
 New features
 ''''''''''''
@@ -1263,7 +1298,7 @@ New features
 -  add a ``lifelines.plotting.qq_plot`` for univariate parametric models
    that handles censored data.
 
-.. _api-changes-17:
+.. _api-changes-18:
 
 API changes
 '''''''''''
@@ -1272,7 +1307,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-40:
+.. _bug-fixes-41:
 
 Bug fixes
 '''''''''
@@ -1288,7 +1323,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-49:
+.. _section-50:
 
 0.20.1 - 2019-03-16
 ^^^^^^^^^^^^^^^^^^^
@@ -1302,7 +1337,7 @@ Bug fixes
    decades of development.
 -  suppressed unimportant warnings
 
-.. _api-changes-18:
+.. _api-changes-19:
 
 API changes
 '''''''''''
@@ -1312,7 +1347,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-50:
+.. _section-51:
 
 0.20.0 - 2019-03-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1321,7 +1356,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-37:
+.. _new-features-38:
 
 New features
 ''''''''''''
@@ -1329,7 +1364,7 @@ New features
 -  smarter initialization for AFT models which should improve
    convergence.
 
-.. _api-changes-19:
+.. _api-changes-20:
 
 API changes
 '''''''''''
@@ -1341,19 +1376,19 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-41:
+.. _bug-fixes-42:
 
 Bug fixes
 '''''''''
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-51:
+.. _section-52:
 
 0.19.5 - 2019-02-26
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-38:
+.. _new-features-39:
 
 New features
 ''''''''''''
@@ -1363,24 +1398,24 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-52:
+.. _section-53:
 
 0.19.4 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _bug-fixes-42:
+.. _bug-fixes-43:
 
 Bug fixes
 '''''''''
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-53:
+.. _section-54:
 
 0.19.3 - 2019-02-25
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-39:
+.. _new-features-40:
 
 New features
 ''''''''''''
@@ -1392,12 +1427,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-54:
+.. _section-55:
 
 0.19.2 - 2019-02-22
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-40:
+.. _new-features-41:
 
 New features
 ''''''''''''
@@ -1405,7 +1440,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-43:
+.. _bug-fixes-44:
 
 Bug fixes
 '''''''''
@@ -1415,12 +1450,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-55:
+.. _section-56:
 
 0.19.1 - 2019-02-21
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-41:
+.. _new-features-42:
 
 New features
 ''''''''''''
@@ -1428,7 +1463,7 @@ New features
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-20:
+.. _api-changes-21:
 
 API changes
 '''''''''''
@@ -1437,12 +1472,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-56:
+.. _section-57:
 
 0.19.0 - 2019-02-20
 ^^^^^^^^^^^^^^^^^^^
 
-.. _new-features-42:
+.. _new-features-43:
 
 New features
 ''''''''''''
@@ -1455,7 +1490,7 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-21:
+.. _api-changes-22:
 
 API changes
 '''''''''''
@@ -1481,7 +1516,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-44:
+.. _bug-fixes-45:
 
 Bug Fixes
 '''''''''
@@ -1498,7 +1533,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-57:
+.. _section-58:
 
 0.18.6 - 2019-02-13
 ^^^^^^^^^^^^^^^^^^^
@@ -1508,7 +1543,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-58:
+.. _section-59:
 
 0.18.5 - 2019-02-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1529,7 +1564,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-59:
+.. _section-60:
 
 0.18.4 - 2019-02-10
 ^^^^^^^^^^^^^^^^^^^
@@ -1539,7 +1574,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-60:
+.. _section-61:
 
 0.18.3 - 2019-02-07
 ^^^^^^^^^^^^^^^^^^^
@@ -1549,7 +1584,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-61:
+.. _section-62:
 
 0.18.2 - 2019-02-05
 ^^^^^^^^^^^^^^^^^^^
@@ -1565,7 +1600,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-62:
+.. _section-63:
 
 0.18.1 - 2019-02-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1576,7 +1611,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-63:
+.. _section-64:
 
 0.18.0 - 2019-01-31
 ^^^^^^^^^^^^^^^^^^^
@@ -1613,7 +1648,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-64:
+.. _section-65:
 
 0.17.5 - 2019-01-25
 ^^^^^^^^^^^^^^^^^^^
@@ -1621,7 +1656,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-65:
+.. _section-66:
 
 0.17.4 -2019-01-25
 ^^^^^^^^^^^^^^^^^^
@@ -1633,7 +1668,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-66:
+.. _section-67:
 
 0.17.3 - 2019-01-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1641,7 +1676,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-67:
+.. _section-68:
 
 0.17.2 2019-01-22
 ^^^^^^^^^^^^^^^^^
@@ -1652,7 +1687,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-68:
+.. _section-69:
 
 0.17.1 - 2019-01-20
 ^^^^^^^^^^^^^^^^^^^
@@ -1669,7 +1704,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-69:
+.. _section-70:
 
 0.17.0 - 2019-01-11
 ^^^^^^^^^^^^^^^^^^^
@@ -1690,7 +1725,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-70:
+.. _section-71:
 
 0.16.3 - 2019-01-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1698,7 +1733,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-71:
+.. _section-72:
 
 0.16.2 - 2019-01-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1709,14 +1744,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-72:
+.. _section-73:
 
 0.16.1 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-73:
+.. _section-74:
 
 0.16.0 - 2019-01-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1752,7 +1787,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-74:
+.. _section-75:
 
 0.15.4
 ^^^^^^
@@ -1760,14 +1795,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-75:
+.. _section-76:
 
 0.15.3 - 2018-12-18
 ^^^^^^^^^^^^^^^^^^^
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-76:
+.. _section-77:
 
 0.15.2 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1778,7 +1813,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-77:
+.. _section-78:
 
 0.15.1 - 2018-11-23
 ^^^^^^^^^^^^^^^^^^^
@@ -1787,7 +1822,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-78:
+.. _section-79:
 
 0.15.0 - 2018-11-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1858,7 +1893,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-79:
+.. _section-80:
 
 0.14.6 - 2018-07-02
 ^^^^^^^^^^^^^^^^^^^
@@ -1866,7 +1901,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-80:
+.. _section-81:
 
 0.14.5 - 2018-06-29
 ^^^^^^^^^^^^^^^^^^^
@@ -1874,7 +1909,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-81:
+.. _section-82:
 
 0.14.4 - 2018-06-14
 ^^^^^^^^^^^^^^^^^^^
@@ -1891,7 +1926,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-82:
+.. _section-83:
 
 0.14.3 - 2018-05-24
 ^^^^^^^^^^^^^^^^^^^
@@ -1903,7 +1938,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-83:
+.. _section-84:
 
 0.14.2 - 2018-05-18
 ^^^^^^^^^^^^^^^^^^^
@@ -1911,7 +1946,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-84:
+.. _section-85:
 
 0.14.1 - 2018-04-01
 ^^^^^^^^^^^^^^^^^^^
@@ -1929,7 +1964,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-85:
+.. _section-86:
 
 0.14.0 - 2018-03-03
 ^^^^^^^^^^^^^^^^^^^
@@ -1951,7 +1986,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-86:
+.. _section-87:
 
 0.13.0 - 2017-12-22
 ^^^^^^^^^^^^^^^^^^^
@@ -1980,7 +2015,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-87:
+.. _section-88:
 
 0.12.0
 ^^^^^^
@@ -1997,7 +2032,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-88:
+.. _section-89:
 
 0.11.3
 ^^^^^^
@@ -2009,7 +2044,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-89:
+.. _section-90:
 
 0.11.2
 ^^^^^^
@@ -2017,14 +2052,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-90:
+.. _section-91:
 
 0.11.1 - 2017-06-22
 ^^^^^^^^^^^^^^^^^^^
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-91:
+.. _section-92:
 
 0.11.0 - 2017-06-21
 ^^^^^^^^^^^^^^^^^^^
@@ -2038,14 +2073,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-92:
+.. _section-93:
 
 0.10.1 - 2017-06-05
 ^^^^^^^^^^^^^^^^^^^
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-93:
+.. _section-94:
 
 0.10.0
 ^^^^^^
@@ -2060,7 +2095,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-94:
+.. _section-95:
 
 0.9.4
 ^^^^^
@@ -2083,7 +2118,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-95:
+.. _section-96:
 
 0.9.2
 ^^^^^
@@ -2092,7 +2127,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-96:
+.. _section-97:
 
 0.9.1
 ^^^^^
@@ -2100,7 +2135,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-97:
+.. _section-98:
 
 0.9.0
 ^^^^^
@@ -2116,7 +2151,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-98:
+.. _section-99:
 
 0.8.1 - 2015-08-01
 ^^^^^^^^^^^^^^^^^^
@@ -2133,7 +2168,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-99:
+.. _section-100:
 
 0.8.0
 ^^^^^
@@ -2152,7 +2187,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-100:
+.. _section-101:
 
 0.7.1
 ^^^^^
@@ -2171,7 +2206,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-101:
+.. _section-102:
 
 0.7.0 - 2015-03-01
 ^^^^^^^^^^^^^^^^^^
@@ -2190,7 +2225,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-102:
+.. _section-103:
 
 0.6.1
 ^^^^^
@@ -2202,7 +2237,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-103:
+.. _section-104:
 
 0.6.0 - 2015-02-04
 ^^^^^^^^^^^^^^^^^^
@@ -2225,7 +2260,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-104:
+.. _section-105:
 
 0.5.1 - 2014-12-24
 ^^^^^^^^^^^^^^^^^^
@@ -2246,7 +2281,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-105:
+.. _section-106:
 
 0.5.0 - 2014-12-07
 ^^^^^^^^^^^^^^^^^^
@@ -2259,7 +2294,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-106:
+.. _section-107:
 
 0.4.4 - 2014-11-27
 ^^^^^^^^^^^^^^^^^^
@@ -2271,7 +2306,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-107:
+.. _section-108:
 
 0.4.3 - 2014-07-23
 ^^^^^^^^^^^^^^^^^^
@@ -2292,7 +2327,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-108:
+.. _section-109:
 
 0.4.2 - 2014-06-19
 ^^^^^^^^^^^^^^^^^^
@@ -2312,7 +2347,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-109:
+.. _section-110:
 
 0.4.1.1
 ^^^^^^^
@@ -2325,7 +2360,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-110:
+.. _section-111:
 
 0.4.1 - 2014-06-11
 ^^^^^^^^^^^^^^^^^^
@@ -2344,7 +2379,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-111:
+.. _section-112:
 
 0.4.0 - 2014-06-08
 ^^^^^^^^^^^^^^^^^^

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -477,7 +477,7 @@ After fitting a Cox model, we can look back and compute important model residual
 Modeling baseline hazard and survival with splines
 -----------------------------------------------------
 
-Normally, the Cox model is *semi-parametric*, which means that its baseline hazard, :math:`h_0(t)`, has no parametric form. This is the default for *lifelines*. However, it is sometimes valuable to produce a parametric baseline instead. A parametric baseline makes survival predictions more robust, allows for better understanding of baseline behaviour.
+Normally, the Cox model is *semi-parametric*, which means that its baseline hazard, :math:`h_0(t)`, has no parametric form. This is the default for *lifelines*. However, it is sometimes valuable to produce a parametric baseline instead. A parametric baseline makes survival predictions more efficient, allows for better understanding of baseline behaviour, and allows interpolation/extrapolation.
 
 In *lifelines*, there is an option to fit to a parametric baseline with cubic splines:
 
@@ -510,15 +510,17 @@ Below we compare the non-parametric and the fully parametric baseline survivals:
 
     Modeling the baseline survival with splines vs non-parametric.
 
+Spline models can also handle almost all the non-parametric options, including: `strata`, `penalizer`, `timeline`, `formula`, etc.
+
 
 
 Parametric survival models
 ==================================
 
+We ended the previous section discussing a *fully*-parametric Cox model, but there are many many more parametric models to consider. Below we go over these, starting with the most common: AFT models.
 
 Accelerated failure time models
 -----------------------------------------------
-
 
 Suppose we have two populations, A and B, with different survival functions, :math:`S_A(t)` and :math:`S_B(t)`, and they are related by some *accelerated failure rate*, :math:`\lambda`:
 

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -489,7 +489,7 @@ In *lifelines*, there is an option to fit to a parametric baseline with cubic sp
 
     rossi = load_rossi()
 
-    cph_spline = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=3)
+    cph_spline = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=5)
     cph_spline.fit(rossi, 'week', event_col='arrest')
 
 To access the baseline hazard and baseline survival, one can use :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter.baseline_hazard_` and :attr:`~lifelines.fitters.coxph_fitter.CoxPHFitter.baseline_survival_` respectively. One nice thing about parametric models is we can interpolate baseline survival / hazards  too, see :meth:`~lifelines.fitters.coxph_fitter.CoxPHFitter.baseline_hazard_at_times` and :meth:`~lifelines.fitters.coxph_fitter.CoxPHFitter.baseline_survival_at_times`.

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -3128,7 +3128,6 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
 
         # we may use this later in print_summary
         self._ll_null_ = uni_model.log_likelihood_
-        self._ll_null_dof = len(uni_model._fitted_parameter_names)
 
         initial_point = {}
         cols = Xs.columns

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1950,6 +1950,9 @@ class ParametricRegressionFitter(RegressionFitter):
             else:
                 entries = np.zeros_like(E, dtype=float)
 
+            if self.strata:
+                df = df.set_index(self.strata)
+
             Xs = self.regressors.transform_df(df)
 
             return -self._neg_likelihood(self.params_.values, Ts, E, W, entries, utils.DataframeSlicer(Xs))
@@ -2043,6 +2046,10 @@ class ParametricRegressionFitter(RegressionFitter):
         )
 
     @property
+    def _ll_null_dof(self):
+        return len(self._fitted_parameter_names)
+
+    @property
     def _ll_null(self):
         if hasattr(self, "_ll_null_"):
             return self._ll_null_
@@ -2067,9 +2074,7 @@ class ParametricRegressionFitter(RegressionFitter):
             if utils.CensoringType.is_left_censoring(self):
                 df["T"], df["E"] = self.durations, self.event_observed
                 model.fit_left_censoring(df, "T", "E", entry_col="entry", weights_col="w", regressors=regressors)
-
         self._ll_null_ = model.log_likelihood_
-        self._ll_null_dof = model.params_.shape[0]
         return self._ll_null_
 
     def log_likelihood_ratio_test(self):
@@ -2082,7 +2087,6 @@ class ParametricRegressionFitter(RegressionFitter):
 
         ll_null = self._ll_null
         ll_alt = self.log_likelihood_
-
         test_stat = 2 * ll_alt - 2 * ll_null
         degrees_freedom = self.params_.shape[0] - self._ll_null_dof  # delta in number of parameters between models
         p_value = _chisq_test_p_value(test_stat, degrees_freedom=degrees_freedom)

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -645,7 +645,7 @@ class ParametricUnivariateFitter(UnivariateFitter):
 
         """
 
-        justify = utils.string_justify(25)
+        justify = utils.string_rjustify(25)
 
         p = Printer(
             self,
@@ -2122,7 +2122,7 @@ class ParametricRegressionFitter(RegressionFitter):
             multiple outputs.
 
         """
-        justify = utils.string_justify(25)
+        justify = utils.string_rjustify(25)
         headers = []
 
         if utils.CensoringType.is_interval_censoring(self):

--- a/lifelines/fitters/aalen_additive_fitter.py
+++ b/lifelines/fitters/aalen_additive_fitter.py
@@ -22,7 +22,7 @@ from lifelines.utils import (
     concordance_index,
     check_nans_or_infs,
     normalize,
-    string_justify,
+    string_rjustify,
     _to_list,
     format_floats,
     format_p_value,
@@ -542,7 +542,7 @@ It's important to know that the naive variance estimates of the coefficients are
             multiple outputs.
 
         """
-        justify = string_justify(25)
+        justify = string_rjustify(25)
 
         headers = []
         headers.append(("duration col", "'%s'" % self.duration_col))

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -39,7 +39,7 @@ from lifelines.utils import (
     normalize,
     StepSizer,
     check_nans_or_infs,
-    string_justify,
+    string_rjustify,
     coalesce,
 )
 from lifelines import utils
@@ -655,7 +655,7 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             multiple outputs.
 
         """
-        justify = string_justify(18)
+        justify = string_rjustify(18)
 
         headers = []
 

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -18,7 +18,7 @@ from autograd import elementwise_grad
 from autograd import numpy as anp
 
 
-from lifelines.fitters import SemiParametricRegressionFittter
+from lifelines.fitters import SemiParametricRegressionFitter
 from lifelines.fitters.mixins import ProportionalHazardMixin
 from lifelines.utils.printer import Printer
 from lifelines.statistics import _chisq_test_p_value, StatisticalResult
@@ -49,7 +49,7 @@ __all__ = ["CoxTimeVaryingFitter"]
 matrix_axis_0_sum_to_1d_array = lambda m: np.sum(m, 0)
 
 
-class CoxTimeVaryingFitter(SemiParametricRegressionFittter, ProportionalHazardMixin):
+class CoxTimeVaryingFitter(SemiParametricRegressionFitter, ProportionalHazardMixin):
     r"""
     This class implements fitting Cox's time-varying proportional hazard model:
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -16,7 +16,7 @@ from autograd import elementwise_grad
 from autograd import numpy as anp
 
 from lifelines.utils.concordance import _concordance_summary_statistics, _concordance_ratio, concordance_index
-from lifelines.fitters import RegressionFitter, SemiParametricRegressionFittter, ParametricRegressionFitter
+from lifelines.fitters import RegressionFitter, SemiParametricRegressionFitter, ParametricRegressionFitter
 from lifelines.fitters.mixins import SplineFitterMixin, ProportionalHazardMixin
 from lifelines.statistics import _chisq_test_p_value, StatisticalResult
 from lifelines.plotting import set_kwargs_drawstyle
@@ -315,28 +315,45 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         return model
 
     def _fit_model_spline(self, *args, **kwargs):
-        # handle strata and cluster_col
-        if kwargs["strata"] is not None:
-            raise ValueError("strata is not available for this baseline estimation method")
-        if kwargs["cluster_col"] is not None:
-            raise ValueError("cluster_col is not available for this baseline estimation method")
-        assert self.n_baseline_knots is not None, "n_baseline_knots must be set in initialization."
-
-        # these are not needed
-        kwargs.pop("strata")
-        kwargs.pop("cluster_col")
-        kwargs.pop("step_size")
-        kwargs.pop("batch_mode")
 
         df = args[0].copy()
 
+        # handle if they provided a formla
         formula = kwargs.pop("formula")
         if type(formula) == str:
             formula += "-1"
 
-        regressors = {**{"beta_": formula}, **{"phi%d_" % i: "1" for i in range(0, self.n_baseline_knots + 2)}}
+        # handle cluster_col
+        if kwargs["cluster_col"] is not None:
+            raise ValueError("cluster_col is not available for this baseline estimation method")
+        assert self.n_baseline_knots is not None, "n_baseline_knots must be set in initialization."
+
+        # these are not needed, should be popped off.
+        kwargs.pop("cluster_col")
+        kwargs.pop("step_size")
+        kwargs.pop("batch_mode")
+
+        # handle strata
+        strata = kwargs.pop("strata")
+
+        if strata is None:
+            regressors = {**{"beta_": formula}, **{"phi%d_" % i: "1" for i in range(0, self.n_baseline_knots + 2)}}
+            strata_values = None
+        elif type(strata) in [str, list]:  # gross
+            spline_namer = ParametricSplinePHFitter._strata_spline_labeler
+            strata = utils._to_list(strata)
+            # how many unique strata are there?
+            df = df.set_index(strata).sort_index()
+            strata_values = df.groupby(strata).size().index.tolist()
+            regressors = {"beta_": formula}
+            for stratum in strata_values:
+                regressors.update({spline_namer(stratum, i): "1" for i in range(0, self.n_baseline_knots + 2)})
+        else:
+            raise ValueError("Wrong type for strata. String or list of strings")
 
         model = ParametricSplinePHFitter(
+            strata=strata,
+            strata_values=strata_values,
             penalizer=self.penalizer,
             l1_ratio=self.l1_ratio,
             n_baseline_knots=self.n_baseline_knots,
@@ -467,8 +484,133 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
             results[t] = model.hazard_ratios_
         return DataFrame(results).T
 
+    def plot_partial_effects_on_outcome(self, covariates, values, plot_baseline=True, y="survival_function", **kwargs):
+        """
+        Produces a plot comparing the baseline curve of the model versus
+        what happens when a covariate(s) is varied over values in a group. This is useful to compare
+        subjects' survival as we vary covariate(s), all else being held equal.
 
-class SemiParametricPHFitter(ProportionalHazardMixin, SemiParametricRegressionFittter):
+        The baseline curve is equal to the predicted curve at all average values (median for ordinal, and mode for categorical)
+        in the original dataset. This same logic is applied to the stratified datasets if ``strata`` was used in fitting.
+
+        Parameters
+        ----------
+        covariates: string or list
+            a string (or list of strings) of the covariate(s) in the original dataset that we wish to vary.
+        values: 1d or 2d iterable
+            an iterable of the specific values we wish the covariate(s) to take on.
+        plot_baseline: bool
+            also display the baseline survival, defined as the survival at the mean of the original dataset.
+        y: str
+            one of "survival_function", or "cumulative_hazard"
+        kwargs:
+            pass in additional plotting commands.
+
+        Returns
+        -------
+        ax: matplotlib axis, or list of axis'
+            the matplotlib axis that be edited.
+
+
+        Examples
+        ---------
+        .. code:: python
+
+            from lifelines import datasets, CoxPHFitter
+            rossi = datasets.load_rossi()
+
+            cph = CoxPHFitter().fit(rossi, 'week', 'arrest')
+            cph.plot_partial_effects_on_outcome('prio', values=arange(0, 15, 3), cmap='coolwarm')
+
+        .. image:: /images/plot_covariate_example1.png
+
+        .. code:: python
+
+            # multiple variables at once
+            cph.plot_partial_effects_on_outcome(['prio', 'paro'], values=[
+             [0,  0],
+             [5,  0],
+             [10, 0],
+             [0,  1],
+             [5,  1],
+             [10, 1]
+            ], cmap='coolwarm')
+
+        .. image:: /images/plot_covariate_example2.png
+
+        .. code:: python
+
+            # if you have categorical variables, you can do the following to see the
+            # effect of all the categories on one plot.
+            cph.plot_partial_effects_on_outcome('categorical_var', values=["A", "B", "C"])
+
+
+        """
+        from matplotlib import pyplot as plt
+
+        covariates = utils._to_list(covariates)
+        n_covariates = len(covariates)
+        values = np.asarray(values)
+        if len(values.shape) == 1:
+            values = values[None, :].T
+
+        if n_covariates != values.shape[1]:
+            raise ValueError("The number of covariates must equal to second dimension of the values array.")
+
+        for covariate in covariates:
+            if covariate not in self._central_values.columns:
+                raise KeyError("covariate `%s` is not present in the original dataset" % covariate)
+
+        drawstyle = "steps-post" if isinstance(self._model, SemiParametricRegressionFitter) else None
+        set_kwargs_drawstyle(kwargs, drawstyle)
+
+        if self.strata is None:
+            axes = kwargs.pop("ax", None) or plt.figure().add_subplot(111)
+            x_bar = self._central_values
+            X = pd.concat([x_bar] * values.shape[0])
+
+            if np.array_equal(np.eye(n_covariates), values) or np.array_equal(
+                np.append(np.eye(n_covariates), np.zeros((n_covariates, 1)), axis=1), values
+            ):
+                X.index = ["%s=1" % c for c in covariates]
+            else:
+                X.index = [", ".join("%s=%s" % (c, v) for (c, v) in zip(covariates, row)) for row in values]
+            for covariate, value in zip(covariates, values.T):
+                X[covariate] = value
+            getattr(self, "predict_%s" % y)(X).plot(ax=axes, **kwargs)
+            if plot_baseline:
+                getattr(self, "predict_%s" % y)(x_bar).plot(ax=axes, ls=":", color="k", drawstyle=drawstyle)
+
+        else:
+            axes = []
+            for stratum in self.baseline_survival_.columns:
+                ax = plt.figure().add_subplot(1, 1, 1)
+
+                # we turn this into a DF so stratum values that are ints are not converted to floats, etc.
+                x_bar = self._central_values.loc[stratum].rename("stratum %s baseline %s" % (str(stratum), y)).to_frame().T
+
+                for name, value in zip(utils._to_list(self.strata), utils._to_tuple(stratum)):
+                    x_bar[name] = value
+
+                X = pd.concat([x_bar] * values.shape[0])
+
+                if np.array_equal(np.eye(len(covariates)), values):
+                    X.index = ["%s=1" % c for c in covariates]
+                else:
+                    X.index = [", ".join("%s=%s" % (c, v) for (c, v) in zip(covariates, row)) for row in values]
+
+                for covariate, value in zip(covariates, values.T):
+                    X[covariate] = value
+
+                getattr(self, "predict_%s" % y)(X).plot(ax=ax, **kwargs)
+                if plot_baseline:
+                    getattr(self, "predict_%s" % y)(x_bar).plot(ax=ax, ls=":", drawstyle=drawstyle)
+                plt.legend()
+                axes.append(ax)
+        return axes
+
+
+class SemiParametricPHFitter(ProportionalHazardMixin, SemiParametricRegressionFitter):
     r"""
     This class implements fitting Cox's proportional hazard model using Efron's method for ties.
 
@@ -2112,137 +2254,6 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
 
         return ax
 
-    def plot_covariate_groups(*args, **kwargs):
-        """
-        Deprecated as of v0.25.0. Use ``plot_partial_effects_on_outcome`` instead.
-        """
-        warnings.warn("This method name is deprecated. Use `plot_partial_effects_on_outcome` instead.", DeprecationWarning)
-        return plot_partial_effects_on_outcome(*args, **kwargs)
-
-    def plot_partial_effects_on_outcome(self, covariates, values, plot_baseline=True, y="survival_function", **kwargs):
-        """
-        Produces a plot comparing the baseline curve of the model versus
-        what happens when a covariate(s) is varied over values in a group. This is useful to compare
-        subjects' survival as we vary covariate(s), all else being held equal.
-
-        The baseline curve is equal to the predicted curve at all average values (median for ordinal, and mode for categorical)
-        in the original dataset. This same logic is applied to the stratified datasets if ``strata`` was used in fitting.
-
-        Parameters
-        ----------
-        covariates: string or list
-            a string (or list of strings) of the covariate(s) in the original dataset that we wish to vary.
-        values: 1d or 2d iterable
-            an iterable of the specific values we wish the covariate(s) to take on.
-        plot_baseline: bool
-            also display the baseline survival, defined as the survival at the mean of the original dataset.
-        y: str
-            one of "survival_function", or "cumulative_hazard"
-        kwargs:
-            pass in additional plotting commands.
-
-        Returns
-        -------
-        ax: matplotlib axis, or list of axis'
-            the matplotlib axis that be edited.
-
-
-        Examples
-        ---------
-        .. code:: python
-
-            from lifelines import datasets, CoxPHFitter
-            rossi = datasets.load_rossi()
-
-            cph = CoxPHFitter().fit(rossi, 'week', 'arrest')
-            cph.plot_partial_effects_on_outcome('prio', values=arange(0, 15, 3), cmap='coolwarm')
-
-        .. image:: /images/plot_covariate_example1.png
-
-        .. code:: python
-
-            # multiple variables at once
-            cph.plot_partial_effects_on_outcome(['prio', 'paro'], values=[
-             [0,  0],
-             [5,  0],
-             [10, 0],
-             [0,  1],
-             [5,  1],
-             [10, 1]
-            ], cmap='coolwarm')
-
-        .. image:: /images/plot_covariate_example2.png
-
-        .. code:: python
-
-            # if you have categorical variables, you can do the following to see the
-            # effect of all the categories on one plot.
-            cph.plot_partial_effects_on_outcome('categorical_var', values=["A", "B", "C"])
-
-
-        """
-        from matplotlib import pyplot as plt
-
-        covariates = utils._to_list(covariates)
-        n_covariates = len(covariates)
-        values = np.asarray(values)
-        if len(values.shape) == 1:
-            values = values[None, :].T
-
-        if n_covariates != values.shape[1]:
-            raise ValueError("The number of covariates must equal to second dimension of the values array.")
-
-        for covariate in covariates:
-            if covariate not in self._central_values.columns:
-                raise KeyError("covariate `%s` is not present in the original dataset" % covariate)
-
-        drawstyle = "steps-post"
-        set_kwargs_drawstyle(kwargs, drawstyle)
-
-        if self.strata is None:
-            axes = kwargs.pop("ax", None) or plt.figure().add_subplot(111)
-            x_bar = self._central_values
-            X = pd.concat([x_bar] * values.shape[0])
-
-            if np.array_equal(np.eye(n_covariates), values) or np.array_equal(
-                np.append(np.eye(n_covariates), np.zeros((n_covariates, 1)), axis=1), values
-            ):
-                X.index = ["%s=1" % c for c in covariates]
-            else:
-                X.index = [", ".join("%s=%s" % (c, v) for (c, v) in zip(covariates, row)) for row in values]
-            for covariate, value in zip(covariates, values.T):
-                X[covariate] = value
-            getattr(self, "predict_%s" % y)(X).plot(ax=axes, **kwargs)
-            if plot_baseline:
-                getattr(self, "predict_%s" % y)(x_bar).plot(ax=axes, ls=":", color="k", drawstyle=drawstyle)
-
-        else:
-            axes = []
-            for stratum in self.baseline_survival_.columns:
-                ax = plt.figure().add_subplot(1, 1, 1)
-
-                x_bar = self._central_values.loc[stratum].rename("stratum %s baseline %s" % (str(stratum), y))
-
-                for name, value in zip(utils._to_list(self.strata), utils._to_tuple(stratum)):
-                    x_bar[name] = value
-
-                X = pd.concat([x_bar.to_frame().T] * values.shape[0])
-
-                if np.array_equal(np.eye(len(covariates)), values):
-                    X.index = ["%s=1" % c for c in covariates]
-                else:
-                    X.index = [", ".join("%s=%s" % (c, v) for (c, v) in zip(covariates, row)) for row in values]
-
-                for covariate, value in zip(covariates, values.T):
-                    X[covariate] = value
-
-                getattr(self, "predict_%s" % y)(X).plot(ax=ax, **kwargs)
-                if plot_baseline:
-                    getattr(self, "predict_%s" % y)(x_bar).plot(ax=ax, ls=":", drawstyle=drawstyle)
-                plt.legend()
-                axes.append(ax)
-        return axes
-
     def score(self, df: pd.DataFrame, scoring_method: str = "log_likelihood") -> float:
         """
         Score the data in df on the fitted model. With default scoring method, returns
@@ -2379,15 +2390,31 @@ class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, Pr
     _FAST_MEDIAN_PREDICT = False
 
     cluster_col = None
-    strata = None
 
-    def __init__(self, n_baseline_knots=1, *args, **kwargs):
+    def __init__(self, strata, strata_values, n_baseline_knots=1, *args, **kwargs):
+        self.strata = strata
+        self.strata_values = strata_values
+
         assert (
             n_baseline_knots is not None and n_baseline_knots > 0
         ), "n_baseline_knots must be a positive integer. Set in class instantiation"
+
         self.n_baseline_knots = n_baseline_knots
-        self._fitted_parameter_names = ["beta_"] + ["phi%d_" % i for i in range(0, self.n_baseline_knots + 2)]
         super(ParametricSplinePHFitter, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    def _strata_spline_labeler(stratum, i):
+        return "s%s_phi%d_" % (stratum, i)
+
+    @property
+    def _fitted_parameter_names(self):
+        if self.strata is not None:
+            names = ["beta_"]
+            for stratum in self.strata_values:
+                names += [self._strata_spline_labeler(stratum, i) for i in range(0, self.n_baseline_knots + 2)]
+            return names
+        else:
+            return ["beta_"] + ["phi%d_" % i for i in range(0, self.n_baseline_knots + 2)]
 
     def _set_knots(self, T, E):
         self.knots = np.percentile(T[E.astype(bool).values], np.linspace(5, 95, self.n_baseline_knots + 2))
@@ -2398,8 +2425,24 @@ class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, Pr
 
     def _create_initial_point(self, Ts, E, entries, weights, Xs):
         #  Some non-zero initial points. This is important as it nudges the model slightly away from the degenerate all-zeros model. Try setting it to 0, and watch the model fail to converge.
-        v = [
-            {
+        if self.strata is not None:
+            params = {"beta_": np.zeros(len(Xs["beta_"].columns))}
+            for stratum in self.strata_values:
+                params.update(
+                    {
+                        self._strata_spline_labeler(stratum, 0): np.array([0.0]),
+                        self._strata_spline_labeler(stratum, 1): np.array([0.05]),
+                        self._strata_spline_labeler(stratum, 2): np.array([-0.05]),
+                    }
+                )
+                params.update(
+                    {self._strata_spline_labeler(stratum, i): np.array([0.0]) for i in range(3, self.n_baseline_knots + 2)}
+                )
+
+            return params
+
+        else:
+            return {
                 **{
                     "beta_": np.zeros(len(Xs["beta_"].columns)),
                     "phi0_": np.array([0.0]),
@@ -2408,38 +2451,80 @@ class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, Pr
                 },
                 **{"phi%d_" % i: np.array([0.0]) for i in range(3, self.n_baseline_knots + 2)},
             }
-        ]
-        return v
 
-    def _cumulative_hazard(self, params, T, Xs):
+    def _cumulative_hazard_with_strata(self, params, T, Xs):
         lT = anp.log(T)
+        output = []
+
+        # hack for iterating over stratified T
+        start, stop = 0, 0
+
+        # I can assume Xs is sorted by strata values
+        for stratum, Xs_ in Xs.groupby(self.strata):
+            stop = stop + Xs_.size
+
+            if T.ndim > 1:
+                lT_ = lT[:, start:stop]
+            else:
+                lT_ = lT[start:stop]
+
+            H_ = safe_exp(
+                anp.dot(Xs_["beta_"], params["beta_"])
+                + params[self._strata_spline_labeler(stratum, 0)]
+                + params[self._strata_spline_labeler(stratum, 1)] * lT_
+            )
+
+            for i in range(2, self.n_baseline_knots + 2):
+                H_ = H_ * safe_exp(
+                    params[self._strata_spline_labeler(stratum, i)]
+                    * self.basis(lT_, anp.log(self.knots[i - 1]), anp.log(self.knots[0]), anp.log(self.knots[-1]))
+                )
+
+            output.append(H_)
+            start = stop
+
+        return anp.hstack(output) if output else anp.array([])
+
+    def _cumulative_hazard_sans_strata(self, params, T, Xs):
+        lT = anp.log(T)
+
         H = safe_exp(anp.dot(Xs["beta_"], params["beta_"]) + params["phi0_"] + params["phi1_"] * lT)
 
         for i in range(2, self.n_baseline_knots + 2):
-            H *= safe_exp(
+            H = H * safe_exp(
                 params["phi%d_" % i] * self.basis(lT, anp.log(self.knots[i - 1]), anp.log(self.knots[0]), anp.log(self.knots[-1]))
             )
         return H
 
+    def _cumulative_hazard(self, params, T, Xs):
+        if self.strata is not None:
+            return self._cumulative_hazard_with_strata(params, T, Xs)
+        else:
+            return self._cumulative_hazard_sans_strata(params, T, Xs)
+
     @property
     def baseline_hazard_(self):
-        return self.baseline_hazard_at_times()
+        return self.baseline_hazard_at_times(self.timeline)
 
     @property
     def baseline_survival_(self):
-        return self.baseline_survival_at_times()
+        return self.baseline_survival_at_times(self.timeline)
 
     @property
     def baseline_cumulative_hazard_(self):
-        return self.baseline_cumulative_hazard_at_times()
+        return self.baseline_cumulative_hazard_at_times(self.timeline)
 
     def baseline_hazard_at_times(self, times=None):
         """
         Predict the baseline hazard at times (Defaults to observed durations)
         """
         times = utils.coalesce(times, self.timeline)
-        v = self.predict_hazard(self._central_values, times=times)
-        v.columns = ["baseline hazard"]
+        if self.strata is not None:
+            v = self.predict_hazard(self._central_values.reset_index(), times=times)
+            v.columns = self._central_values.index.values
+        else:
+            v = self.predict_hazard(self._central_values, times=times)
+            v.columns = ["baseline hazard"]
         return v
 
     def baseline_survival_at_times(self, times=None):
@@ -2447,8 +2532,12 @@ class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, Pr
         Predict the baseline survival at times (Defaults to observed durations)
         """
         times = utils.coalesce(times, self.timeline)
-        v = self.predict_survival_function(self._central_values, times=times)
-        v.columns = ["baseline survival"]
+        if self.strata is not None:
+            v = self.predict_survival_function(self._central_values.reset_index(), times=times)
+            v.columns = self._central_values.index.values
+        else:
+            v = self.predict_survival_function(self._central_values, times=times)
+            v.columns = ["baseline survival"]
         return v
 
     def baseline_cumulative_hazard_at_times(self, times=None):
@@ -2456,8 +2545,12 @@ class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, Pr
         Predict the baseline cumulative hazard at times (Defaults to observed durations)
         """
         times = utils.coalesce(times, self.timeline)
-        v = self.predict_cumulative_hazard(self._central_values, times=times)
-        v.columns = ["baseline cumulative hazard"]
+        if self.strata is not None:
+            v = self.predict_cumulative_hazard(self._central_values.reset_index(), times=times)
+            v.columns = self._central_values.index.values
+        else:
+            v = self.predict_cumulative_hazard(self._central_values, times=times)
+            v.columns = ["baseline cumulative hazard"]
         return v
 
     def predict_cumulative_hazard(self, df, *, times=None, conditional_after=None):
@@ -2485,13 +2578,43 @@ class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, Pr
             the cumulative hazards of individuals over the timeline
 
         """
+        if isinstance(df, pd.Series):
+            df = df.to_frame().T.infer_objects()
+
         df = df.copy()
         df["Intercept"] = 1
-        return super(ParametricSplinePHFitter, self).predict_cumulative_hazard(
-            df, times=times, conditional_after=conditional_after
-        )
 
-    def predict_hazard(self, df, *, times=None):
+        if self.strata is not None:
+            df = df.reset_index().set_index(self.strata)
+
+            cumulative_hazard = pd.DataFrame()
+            if conditional_after is not None:
+                # need to pass this into the groupby
+                df["conditional_after_"] = conditional_after
+
+            for stratum, stratified_X in df.groupby(self.strata):
+
+                if conditional_after is not None:
+                    conditional_after_ = stratified_X.pop("conditional_after_")
+                else:
+                    conditional_after_ = None
+
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", category=UserWarning)
+                    cumulative_hazard_ = super(ParametricSplinePHFitter, self).predict_cumulative_hazard(
+                        stratified_X, times=times, conditional_after=conditional_after_
+                    )
+                cumulative_hazard_.columns = stratified_X["index"]
+                cumulative_hazard = cumulative_hazard.merge(cumulative_hazard_, how="outer", right_index=True, left_index=True)
+
+            return cumulative_hazard
+
+        else:
+            return super(ParametricSplinePHFitter, self).predict_cumulative_hazard(
+                df, times=times, conditional_after=conditional_after
+            )
+
+    def predict_hazard(self, df, *, conditional_after=None, times=None):
         """
         Predict the hazard for individuals, given their covariates.
 
@@ -2518,15 +2641,32 @@ class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, Pr
 
         df = df.copy()
         df["Intercept"] = 1
-        times = utils.coalesce(times, self.timeline)
-        times = np.atleast_1d(times).astype(float)
 
-        n = df.shape[0]
-        Xs = self.regressors.transform_df(df)
+        if self.strata is not None:
+            df = df.reset_index().set_index(self.strata)
 
-        params_dict = {parameter_name: self.params_.loc[parameter_name].values for parameter_name in self._fitted_parameter_names}
+            cumulative_hazard = pd.DataFrame()
+            if conditional_after is not None:
+                # need to pass this into the groupby
+                df["conditional_after_"] = conditional_after
 
-        return pd.DataFrame(self._hazard(params_dict, np.tile(times, (n, 1)).T, Xs), index=times, columns=df.index)
+            for stratum, stratified_X in df.groupby(self.strata):
+
+                if conditional_after is not None:
+                    conditional_after_ = stratified_X.pop("conditional_after_")
+                else:
+                    conditional_after_ = None
+
+                cumulative_hazard_ = super(ParametricSplinePHFitter, self).predict_hazard(
+                    stratified_X, times=times, conditional_after=conditional_after_
+                )
+                cumulative_hazard_.columns = stratified_X["index"]
+                cumulative_hazard = cumulative_hazard.merge(cumulative_hazard_, how="outer", right_index=True, left_index=True)
+
+            return cumulative_hazard
+
+        else:
+            return super(ParametricSplinePHFitter, self).predict_hazard(df, times=times, conditional_after=conditional_after)
 
     def score(self, df: pd.DataFrame, scoring_method: str = "log_likelihood") -> float:
         df = df.copy()

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -2546,20 +2546,20 @@ class _BatchVsSingle:
     SINGLE = "single"
 
     def decide(self, batch_mode: Optional[bool], n_unique: int, n_total: int, n_vars: int) -> str:
-        frac_dups = n_unique / n_total
+        log_frac_dups = np.log(n_unique / n_total)
         if batch_mode or (
             # https://github.com/CamDavidsonPilon/lifelines/issues/591 for original issue.
             # new values from from perf/batch_vs_single script.
             (batch_mode is None)
             and (
-                2.909_374e-01
-                + n_total * -8.411_575e-07
-                + frac_dups * 5.084_471e00
-                + n_total * frac_dups * 2.110_770e-08
-                + frac_dups ** 2 * -3.578_701e00
-                + n_total ** 2 * 6.094_380e-13
-                + n_vars * -1.428_580e-03
-                + n_vars * n_total * 1.612_768e-09
+                1.537_271e00
+                + n_total * 4.771_387e-06
+                + log_frac_dups * 2.610_877e-01
+                + n_total * log_frac_dups * -3.830_987e-11
+                + log_frac_dups ** 2 * 1.389_890e-02
+                + n_total ** 2 * 3.129_870e-14
+                + n_vars * 3.196_517e-03
+                + n_vars * n_total * -7.356_722e-07
             )
             < 1
         ):

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -365,7 +365,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         """
 
         # Print information about data first
-        justify = utils.string_justify(25)
+        justify = utils.string_rjustify(25)
 
         headers = []
         headers.append(("duration col", "'%s'" % self.duration_col))
@@ -2522,7 +2522,7 @@ class ParametricSplinePHFitter(ParametricRegressionFitter, SplineFitterMixin, Pr
         times = np.atleast_1d(times).astype(float)
 
         n = df.shape[0]
-        Xs = self._create_Xs_dict(df)
+        Xs = self.regressors.transform_df(df)
 
         params_dict = {parameter_name: self.params_.loc[parameter_name].values for parameter_name in self._fitted_parameter_names}
 

--- a/lifelines/fitters/generalized_gamma_regression_fitter.py
+++ b/lifelines/fitters/generalized_gamma_regression_fitter.py
@@ -128,7 +128,6 @@ class GeneralizedGammaRegressionFitter(ParametricRegressionFitter):
 
             # we may use these later in log_likelihood_test()
             self._ll_null_ = uni_model.log_likelihood_
-            self._ll_null_dof = len(uni_model._fitted_parameter_names)
             assert self._ll_null_dof == 3
 
             default_point = super(GeneralizedGammaRegressionFitter, self)._create_initial_point(Ts, E, entries, weights, Xs)

--- a/lifelines/fitters/piecewise_exponential_regression_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_regression_fitter.py
@@ -41,6 +41,7 @@ class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
     # about 50% faster than BFGS
     _scipy_fit_method = "SLSQP"
     _scipy_fit_options = {"ftol": 1e-6, "maxiter": 200}
+    fit_intercept = True
 
     def __init__(self, breakpoints, alpha=0.05, penalizer=0.0):
         super(PiecewiseExponentialRegressionFitter, self).__init__(alpha=alpha)

--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -10,7 +10,7 @@ import pandas as pd
 from lifelines import utils
 from lifelines.utils import (
     group_survival_table_from_events,
-    string_justify,
+    string_rjustify,
     format_p_value,
     format_floats,
     interpolate_at_times_and_return_pandas,
@@ -192,7 +192,7 @@ class StatisticalResult:
 
     def _stringify_meta_data(self, dictionary):
         longest_key = max([len(k) for k in dictionary])
-        justify = string_justify(longest_key)
+        justify = string_rjustify(longest_key)
         s = ""
         for k, v in dictionary.items():
             s += "{} = {}\n".format(justify(k), v)

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -2995,6 +2995,10 @@ class TestCoxPHFitter:
         assert list(cph_spline.baseline_survival_.columns) == ["baseline survival"]
         assert list(cph_spline.baseline_cumulative_hazard_.columns) == ["baseline cumulative hazard"]
 
+        assert cph_spline.baseline_survival_at_times([1, 2, 3]).shape[0] == 3
+        assert cph_spline.baseline_cumulative_hazard_at_times([1, 2, 3]).shape[0] == 3
+        assert cph_spline.baseline_hazard_at_times([1, 2, 3]).shape[0] == 3
+
     def test_conditional_after_in_prediction(self, rossi, cph):
         rossi.loc[rossi["week"] == 1, "week"] = 0
         cph.fit(rossi, "week", "arrest")

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -4716,6 +4716,8 @@ class TestAalenAdditiveFitter:
         aaf.fit(data_pred1, duration_col="t", event_col="E")
         x = data_pred1.iloc[:5].drop(["t", "E"], axis=1)
         y_df = aaf.predict_cumulative_hazard(x)
+        # need to provide a intercept col
+        x["int"] = 1.0
         y_np = aaf.predict_cumulative_hazard(x.values)
         assert_frame_equal(y_df, y_np)
 

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1783,8 +1783,8 @@ class TestRegressionFitters:
     def regression_models_sans_strata_model(self):
         return [
             CoxPHFitter(penalizer=1e-6, baseline_estimation_method="breslow"),
-            CoxPHFitter(penalizer=1e-6, baseline_estimation_method="spline", n_baseline_knots=1),
             CoxPHFitter(penalizer=1e-6, baseline_estimation_method="spline", n_baseline_knots=2),
+            CoxPHFitter(penalizer=1e-6, baseline_estimation_method="spline", n_baseline_knots=3),
             AalenAdditiveFitter(coef_penalizer=1.0, smoothing_penalizer=1.0),
             WeibullAFTFitter(fit_intercept=True),
             LogNormalAFTFitter(fit_intercept=True),
@@ -1976,7 +1976,7 @@ class TestRegressionFitters:
         normalized_rossi = rossi.copy()
         normalized_rossi["week"] = (normalized_rossi["week"]) / t.std()
 
-        for fitter in [CoxPHFitter(penalizer=1e-6, baseline_estimation_method="spline", n_baseline_knots=1)]:
+        for fitter in [CoxPHFitter(penalizer=1e-6, baseline_estimation_method="spline", n_baseline_knots=3)]:
             if (
                 isinstance(fitter, PiecewiseExponentialRegressionFitter)
                 or isinstance(fitter, CustomRegressionModelTesting)
@@ -2833,7 +2833,15 @@ class TestCoxPHFitter:
 
     @pytest.fixture
     def cph_spline(self):
-        return CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=1)
+        return CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2)
+
+    def test_spline_strata_null_dof(self, cph_spline, rossi):
+        cph_spline.fit(rossi, "week", "arrest", strata="paro", formula="age")
+        assert cph_spline._ll_null_dof < cph_spline.params_.shape[0]
+
+    def test_spline_strata_score(self, cph_spline, rossi):
+        cph_spline.fit(rossi, "week", "arrest", strata="paro", formula="age")
+        cph_spline.score(rossi)
 
     def test_categorical_variables_are_still_encoded_correctly(self, cph):
         """
@@ -2890,10 +2898,10 @@ class TestCoxPHFitter:
         assert cph.summary.index.tolist() == ["age", "race", "age:race"]
 
         cph_spline.fit(rossi, "week", "arrest", formula="age + race")
-        assert cph_spline.summary.loc["beta_"].index.tolist() == ["age", "race"]
+        assert cph_spline.summary.loc["beta_"].index.tolist() == ["Intercept", "age", "race"]
 
         cph_spline.fit(rossi, "week", "arrest", formula="age * race")
-        assert cph_spline.summary.loc["beta_"].index.tolist() == ["age", "race", "age:race"]
+        assert cph_spline.summary.loc["beta_"].index.tolist() == ["Intercept", "age", "race", "age:race"]
 
     def test_formulas_can_be_used_with_prediction(self, rossi, cph, cph_spline):
         cph.fit(rossi, "week", "arrest", formula="age * race")
@@ -2958,7 +2966,7 @@ class TestCoxPHFitter:
         test_data = pd.DataFrame({"Days": days, "Cov1": cov1, "Cov2": cov2})
         test_data = test_data[test_data["Days"] > 0]
 
-        cph_sp = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=1)
+        cph_sp = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=3)
         cph_sp.fit(test_data, duration_col="Days")
 
         # check survival is always decreasing
@@ -2980,13 +2988,13 @@ class TestCoxPHFitter:
             < CoxPHFitter(penalizer=0).fit(rossi, "week", "arrest").log_likelihood_
         )
         assert (
-            CoxPHFitter(penalizer=1e-6, baseline_estimation_method="spline", n_baseline_knots=1)
+            CoxPHFitter(penalizer=1e-6, baseline_estimation_method="spline", n_baseline_knots=3)
             .fit(rossi, "week", "arrest")
             .log_likelihood_
-            < CoxPHFitter(penalizer=1e-8, baseline_estimation_method="spline", n_baseline_knots=1)
+            < CoxPHFitter(penalizer=1e-8, baseline_estimation_method="spline", n_baseline_knots=3)
             .fit(rossi, "week", "arrest")
             .log_likelihood_
-            < CoxPHFitter(penalizer=0, baseline_estimation_method="spline", n_baseline_knots=1)
+            < CoxPHFitter(penalizer=0, baseline_estimation_method="spline", n_baseline_knots=3)
             .fit(rossi, "week", "arrest")
             .log_likelihood_
         )
@@ -3006,10 +3014,10 @@ class TestCoxPHFitter:
 
     def test_strata_estimation_is_same_if_using_trivial_strata(self, rossi, cph_spline):
         rossi["strata"] = "a"
-        trivial_strata_cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=1)
+        trivial_strata_cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=3)
         trivial_strata_cph.fit(rossi, "week", "arrest", strata="strata")
 
-        cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=1)
+        cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=3)
         cph.fit(rossi.drop("strata", axis=1), "week", "arrest")
 
         assert_frame_equal(
@@ -3018,8 +3026,8 @@ class TestCoxPHFitter:
         )
 
         assert_frame_equal(
-            cph.summary.loc[[("phi0_", "Intercept"), ("phi1_", "Intercept")]].reset_index(drop=True),
-            trivial_strata_cph.summary.loc[[("sa_phi0_", "Intercept"), ("sa_phi1_", "Intercept")]].reset_index(drop=True),
+            cph.summary.loc[[("beta_", "Intercept"), ("phi1_", "Intercept")]].reset_index(drop=True),
+            trivial_strata_cph.summary.loc[[("beta_", "Intercept"), ("sa_phi1_", "Intercept")]].reset_index(drop=True),
         )
 
     def test_baseline_estimation_for_spline(self, rossi, cph_spline):

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -498,9 +498,17 @@ class TestPlotting:
     def test_coxph_plot_partial_effects_on_outcome_with_strata(self, block):
         df = load_rossi()
         cp = CoxPHFitter()
-        cp.fit(df, "week", "arrest", strata=["paro", "fin"])
+        cp.fit(df, "week", "arrest", strata=["wexp"])
         cp.plot_partial_effects_on_outcome("age", [10, 50, 80])
         self.plt.title("test_coxph_plot_partial_effects_on_outcome_with_strata")
+        self.plt.show(block=block)
+
+    def test_spline_coxph_plot_partial_effects_on_outcome_with_strata(self, block):
+        df = load_rossi()
+        cp = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=1)
+        cp.fit(df, "week", "arrest", strata=["wexp"])
+        cp.plot_partial_effects_on_outcome("age", [10, 50, 80])
+        self.plt.title("test_spline_coxph_plot_partial_effects_on_outcome_with_strata")
         self.plt.show(block=block)
 
     def test_coxph_plot_partial_effects_on_outcome_with_single_strata(self, block):

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1658,6 +1658,22 @@ class DataframeSlicer:
         ix = _to_1d_array(ix)
         return DataframeSlicer(self.df[ix])
 
+    def groupby(self, *args, **kwargs):
+        yield from ((name, DataframeSlicer(df_)) for (name, df_) in self.df.groupby(*args, **kwargs))
+
+    @property
+    def size(self):
+        return self.df.shape[0]
+
+
+def make_simpliest_hashable(ele):
+    if type(ele) == list:
+        if len(ele) == 1:
+            return str(ele[0])
+        else:
+            return tuple(ele)
+    return ele
+
 
 def find_best_parametric_model(
     event_times,

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1627,7 +1627,8 @@ def interpolate_at_times_and_return_pandas(df_or_series, new_times) -> Union[pd.
     return pd.DataFrame(interpolate_at_times(df_or_series, new_times), index=new_times, columns=cols).squeeze()
 
 
-string_justify = lambda width: lambda s: s.rjust(width, " ")
+string_rjustify = lambda width: lambda s: s.rjust(width, " ")
+string_ljustify = lambda width: lambda s: s.ljust(width, " ")
 
 
 def safe_zip(first, second):

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1870,6 +1870,7 @@ class CovariateParameterMappings:
 
     @classmethod
     def add_intercept_col(cls, df):
+        df = df.copy()
         df[cls.INTERCEPT_COL] = 1
         return df
 

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1868,6 +1868,11 @@ class CovariateParameterMappings:
             else:
                 raise ValueError("Unexpected transform.")
 
+    @classmethod
+    def add_intercept_col(cls, df):
+        df[cls.INTERCEPT_COL] = 1
+        return df
+
     def transform_df(self, df: pd.DataFrame):
 
         import patsy
@@ -1878,7 +1883,7 @@ class CovariateParameterMappings:
                 (X,) = patsy.build_design_matrices([transform], df, return_type="dataframe")
             elif isinstance(transform, list):
                 if self.force_intercept:
-                    df[self.INTERCEPT_COL] = 1.0
+                    df = self.add_intercept_col(df)
                 X = df[transform]
             else:
                 raise ValueError("Unexpected transform.")

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -18,7 +18,7 @@ from scipy import stats
 import pandas as pd
 
 from lifelines.utils.concordance import concordance_index
-from lifelines.exceptions import ConvergenceWarning, ApproximationWarning, ConvergenceError
+from lifelines.exceptions import ConvergenceWarning, ApproximationWarning, ConvergenceError, FormulaSyntaxError
 
 
 __all__ = [
@@ -1926,7 +1926,7 @@ class CovariateParameterMappings:
             import traceback
 
             column_error = "\n".join(traceback.format_exc().split("\n")[-4:])
-            raise exceptions.FormulaSyntaxError(
+            raise FormulaSyntaxError(
                 (
                     """
 It looks like the DataFrame has non-standard column names. See below for which column:

--- a/lifelines/utils/printer.py
+++ b/lifelines/utils/printer.py
@@ -66,6 +66,7 @@ class Printer:
 
     def to_html(self):
         summary_df = self.model.summary
+
         decimals = self.decimals
         if self.columns is None:
             columns = summary_df.columns
@@ -76,9 +77,12 @@ class Printer:
         headers.insert(0, ("model", "lifelines." + self.model._class_name))
 
         header_df = pd.DataFrame.from_records(headers).set_index(0)
+
         header_html = header_df.to_html(header=False, notebook=True, index_names=False)
 
         summary_html = summary_df[columns].to_html(
+            col_space=12,
+            index_names=False,
             float_format=utils.format_floats(decimals),
             formatters={
                 **{c: utils.format_exp_floats(decimals) for c in columns if "exp(" in c},
@@ -88,7 +92,7 @@ class Printer:
 
         if self.footers:
             footer_df = pd.DataFrame.from_records(self.footers).set_index(0)
-            footer_html = footer_df.to_html(header=False, notebook=True, index_names=False)
+            footer_html = "<br>" + footer_df.to_html(header=False, notebook=True, index_names=False)
         else:
             footer_html = ""
         return header_html + summary_html + footer_html

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.25.1"
+__version__ = "0.25.2"

--- a/perf_tests/cp_perf_test.py
+++ b/perf_tests/cp_perf_test.py
@@ -16,8 +16,8 @@ if __name__ == "__main__":
     df = pd.concat([df] * reps)
     print(df.shape)
 
-    cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2, strata=["wexp"])
+    cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=3, strata=["wexp"])
     start_time = time.time()
     cph.fit(df, duration_col="week", event_col="arrest", show_progress=True, timeline=np.linspace(1, 60, 100))
-    print(cph.baseline_hazard_)
+    print(cph.score(df))
     print("--- %s seconds ---" % (time.time() - start_time))

--- a/perf_tests/cp_perf_test.py
+++ b/perf_tests/cp_perf_test.py
@@ -10,21 +10,14 @@ if __name__ == "__main__":
     from lifelines import CoxPHFitter
     from lifelines.datasets import load_rossi, load_regression_dataset
 
-    reps = 22222
+    reps = 1
     df = load_rossi()
+    # df['s'] = "a"
     df = pd.concat([df] * reps)
     print(df.shape)
 
-    cph = CoxPHFitter()
+    cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2, strata=["wexp", "mar"])
     start_time = time.time()
-    cph.fit(df, duration_col="week", event_col="arrest", show_progress=True)
-    # cph.print_summary()
+    cph.fit(df, duration_col="week", event_col="arrest", show_progress=True, timeline=np.linspace(1, 60, 100))
+    print(cph.baseline_hazard_)
     print("--- %s seconds ---" % (time.time() - start_time))
-
-    """
-    cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2)
-    start_time = time.time()
-    cph.fit(df, duration_col="week", event_col="arrest", show_progress=True)
-    cph.print_summary()
-    print("--- %s seconds ---" % (time.time() - start_time))
-    """

--- a/perf_tests/cp_perf_test.py
+++ b/perf_tests/cp_perf_test.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     df = pd.concat([df] * reps)
     print(df.shape)
 
-    cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2, strata=["wexp", "mar"])
+    cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2, strata=["wexp"])
     start_time = time.time()
     cph.fit(df, duration_col="week", event_col="arrest", show_progress=True, timeline=np.linspace(1, 60, 100))
     print(cph.baseline_hazard_)

--- a/perf_tests/cp_perf_test.py
+++ b/perf_tests/cp_perf_test.py
@@ -10,18 +10,21 @@ if __name__ == "__main__":
     from lifelines import CoxPHFitter
     from lifelines.datasets import load_rossi, load_regression_dataset
 
-    reps = 2
+    reps = 22222
     df = load_rossi()
     df = pd.concat([df] * reps)
     print(df.shape)
 
     cph = CoxPHFitter()
     start_time = time.time()
-    cph.fit(df, duration_col="week", event_col="arrest", show_progress=False)
-    cph.print_summary()
-
-    df["entry"] = 0
-    cph.fit(df, duration_col="week", event_col="arrest", entry_col="entry", show_progress=False)
-    cph.print_summary()
-
+    cph.fit(df, duration_col="week", event_col="arrest", show_progress=True)
+    # cph.print_summary()
     print("--- %s seconds ---" % (time.time() - start_time))
+
+    """
+    cph = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2)
+    start_time = time.time()
+    cph.fit(df, duration_col="week", event_col="arrest", show_progress=True)
+    cph.print_summary()
+    print("--- %s seconds ---" % (time.time() - start_time))
+    """


### PR DESCRIPTION
#### 0.25.2 - 2020-08-08

##### New features
 - Spline `CoxPHFitter` can now use `strata`.

##### API Changes
 - a small parameterization change of the spline `CoxPHFitter`. The linear term in the spline part was moved to a new `Intercept` term in the `beta_`.
 - `n_baseline_knots` in the spline `CoxPHFitter` now refers to _all_ knots, and not just interior knots (this was confusing to me, the author.). So add 2 to `n_baseline_knots` to recover the identical model as previously.

##### Bug fixes
 - fix splines `CoxPHFitter` with  when `predict_hazard` was called.
 - fix some exception imports I missed.
 - fix log-likelihood p-value in splines `CoxPHFitter`
