### PR TITLE
V0.25.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Changelog
 
+#### 0.25.5 - unreleased
+
+##### New features
+
+##### API Changes
+ - `check_assumptions` now returns a list of list of axes that can be manipulated
+
+
+
 #### 0.25.4 - 2020-08-26
 
 ##### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - fixed error when using `plot_partial_effects` with categorical data in AFT models
  - improved warning when Hessian matrix contains NaNs.
  - fixed performance regression in interval censoring fitting in parametric models
+ - `weights` wasn't being applied properly in NPMLE
 
 #### 0.25.4 - 2020-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ##### Bug fixes
  - fixed error when using `plot_partial_effects` with categorical data in AFT models
  - improved warning when Hessian matrix contains NaNs.
+ - fixed performance regression in interval censoring fitting in parametric models
 
 #### 0.25.4 - 2020-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 ##### API Changes
  - `check_assumptions` now returns a list of list of axes that can be manipulated
 
-
+##### Bug fixes
+ - fixed error when using `plot_partial_effects` with categorical data in AFT models
+ - improved warning when Hessian matrix contains NaNs.
 
 #### 0.25.4 - 2020-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## Changelog
 
-#### 0.25.5 - unreleased
-
-##### New features
+#### 0.25.5 - 2020-09-23
 
 ##### API Changes
  - `check_assumptions` now returns a list of list of axes that can be manipulated

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -16,6 +16,9 @@ Bug fixes
 -  fixed error when using ``plot_partial_effects`` with categorical data
    in AFT models
 -  improved warning when Hessian matrix contains NaNs.
+-  fixed performance regression in interval censoring fitting in
+   parametric models
+-  ``weights`` wasn’t being applied properly in NPMLE
 
 .. _section-1:
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,67 +1,89 @@
 Changelog
----------
+=========
+
+0.25.5 - 2020-09-23
+-------------------
+
+API Changes
+~~~~~~~~~~~
+
+-  ``check_assumptions`` now returns a list of list of axes that can be
+   manipulated
+
+Bug fixes
+~~~~~~~~~
+
+-  fixed error when using ``plot_partial_effects`` with categorical data
+   in AFT models
+-  improved warning when Hessian matrix contains NaNs.
+
+.. _section-1:
 
 0.25.4 - 2020-08-26
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  New baseline estimator for Cox models: ``piecewise``
 -  Performance improvements for parametric models
    ``log_likelihood_ratio_test()`` and ``print_summary()``
 -  Better step-size defaults for Cox model -> more robust convergence.
 
+.. _bug-fixes-1:
+
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fix ``check_assumptions`` when using formulas.
 
-.. _section-1:
+.. _section-2:
 
 0.25.3 - 2020-08-24
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-1:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``survival_difference_at_fixed_point_in_time_test`` now accepts
    fitters instead of raw data, meaning that you can use this function
    on left, right or interval censored data.
 
+.. _api-changes-1:
+
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  See note on ``survival_difference_at_fixed_point_in_time_test``
    above.
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fix ``StatisticalResult`` printing in notebooks
 -  fix Python error when calling ``plot_covariate_groups``
 -  fix dtype mismatches in ``plot_partial_effects_on_outcome``.
 
-.. _section-2:
+.. _section-3:
 
 0.25.2 - 2020-08-08
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-2:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Spline ``CoxPHFitter`` can now use ``strata``.
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  a small parameterization change of the spline ``CoxPHFitter``. The
    linear term in the spline part was moved to a new ``Intercept`` term
@@ -71,24 +93,24 @@ API Changes
    the author.). So add 2 to ``n_baseline_knots`` to recover the
    identical model as previously.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fix splines ``CoxPHFitter`` with when ``predict_hazard`` was called.
 -  fix some exception imports I missed.
 -  fix log-likelihood p-value in splines ``CoxPHFitter``
 
-.. _section-3:
+.. _section-4:
 
 0.25.1 - 2020-08-01
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  ok *actually* ship the out-of-sample calibration code
 -  fix ``labels=False`` in ``add_at_risk_counts``
@@ -96,15 +118,15 @@ Bug fixes
 -  put ``patsy`` as a proper dependency.
 -  suppress some Pandas 1.1 warnings.
 
-.. _section-4:
+.. _section-5:
 
 0.25.0 - 2020-07-27
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-3:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Formulas! *lifelines* now supports R-like formulas in regression
    models. See docs
@@ -119,10 +141,10 @@ New features
    on the terminal.
 -  ``add_at_risk_counts`` now follows the cool new KMunicate suggestions
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  With the introduction of formulas, all models can be using formulas
    under the hood.
@@ -158,10 +180,10 @@ API Changes
    `here <https://lifelines.readthedocs.io/en/latest/Survival%20Regression.html#plotting-the-effect-of-varying-a-covariate>`__.
 -  all exceptions and warnings have moved to ``lifelines.exceptions``
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  The p-value of the log-likelihood ratio test for the CoxPHFitter with
    splines was returning the wrong result because the degrees of freedom
@@ -174,35 +196,35 @@ Bug fixes
 -  fixed NaN bug in ``survival_table_from_events`` with intervals when
    no events would occur in a interval.
 
-.. _section-5:
+.. _section-6:
 
 0.24.16 - 2020-07-09
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 .. _new-features-4:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  improved algorithm choice for large DataFrames for Cox models. Should
    see a significant performance boost.
 
-.. _bug-fixes-5:
-
-Bug fixes
-'''''''''
-
--  fixed ``utils.median_survival_time`` not accepting Pandas Series.
-
-.. _section-6:
-
-0.24.15 - 2020-07-07
-^^^^^^^^^^^^^^^^^^^^
-
 .. _bug-fixes-6:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
+
+-  fixed ``utils.median_survival_time`` not accepting Pandas Series.
+
+.. _section-7:
+
+0.24.15 - 2020-07-07
+--------------------
+
+.. _bug-fixes-7:
+
+Bug fixes
+~~~~~~~~~
 
 -  fixed an edge case in ``KaplanMeierFitter`` where a really late entry
    would occur after all other population had died.
@@ -210,15 +232,15 @@ Bug fixes
 -  fixed bug where using ``conditional_after`` and ``times`` in
    ``CoxPHFitter("spline")`` prediction methods would be ignored.
 
-.. _section-7:
+.. _section-8:
 
 0.24.14 - 2020-07-02
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed a bug where using ``conditional_after`` and ``times`` in
    prediction methods would result in a shape error
@@ -227,42 +249,42 @@ Bug fixes
 -  fixed a bug where some columns would not be displayed in
    ``print_summary``
 
-.. _section-8:
+.. _section-9:
 
 0.24.13 - 2020-06-22
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed a bug where ``CoxPHFitter`` would ignore inputed ``alpha``
    levels for confidence intervals
 -  fixed a bug where ``CoxPHFitter`` would fail with working with
    ``sklearn_adapter``
 
-.. _section-9:
+.. _section-10:
 
 0.24.12 - 2020-06-20
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 .. _new-features-5:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  improved convergence of ``GeneralizedGamma(Regression)Fitter``.
 
-.. _section-10:
+.. _section-11:
 
 0.24.11 - 2020-06-17
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 .. _new-features-6:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  new spline regression model ``CRCSplineFitter`` based on the paper “A
    flexible parametric accelerated failure time model” by Michael J.
@@ -273,91 +295,91 @@ New features
    and the integrated calibration index (ICI) for survival models” by P.
    Austin, F. Harrell, and D. van Klaveren.
 
-.. _api-changes-3:
+.. _api-changes-4:
 
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  (and bug fix) scalar parameters in regression models were not being
    penalized by ``penalizer`` - we now penalizing everything except
    intercept terms in linear relationships.
 
-.. _section-11:
+.. _section-12:
 
 0.24.10 - 2020-06-16
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 .. _new-features-7:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  New improvements when using splines model in CoxPHFitter - it should
    offer much better prediction and baseline-hazard estimation,
    including extrapolation and interpolation.
 
-.. _api-changes-4:
+.. _api-changes-5:
 
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  Related to above: the fitted spline parameters are now available in
    the ``.summary`` and ``.print_summary`` methods.
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed a bug in initialization of some interval-censoring models ->
    better convergence.
 
-.. _section-12:
+.. _section-13:
 
 0.24.9 - 2020-06-05
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-8:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Faster NPMLE for interval censored data
 -  New weightings available in the ``logrank_test``: ``wilcoxon``,
    ``tarone-ware``, ``peto``, ``fleming-harrington``. Thanks @sean-reed
 -  new interval censored dataset: ``lifelines.datasets.load_mice``
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Cleared up some mislabeling in ``plot_loglogs``. Thanks @sean-reed!
 -  tuples are now able to be used as input in univariate models.
 
-.. _section-13:
+.. _section-14:
 
 0.24.8 - 2020-05-17
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-9:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Non parametric interval censoring is now available, *experimentally*.
    Not all edge cases are fully checked, and some features are missing.
    Try it under ``KaplanMeierFitter.fit_interval_censoring``
 
-.. _section-14:
+.. _section-15:
 
 0.24.7 - 2020-05-17
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-10:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``find_best_parametric_model`` can handle left and interval
    censoring. Also allows for more fitting options.
@@ -370,97 +392,97 @@ New features
 -  some convergence tweaks which should help recent performance
    regressions.
 
-.. _section-15:
+.. _section-16:
 
 0.24.6 - 2020-05-05
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-11:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  At the cost of some performance, convergence is improved in many
    models.
 -  New ``lifelines.plotting.plot_interval_censored_lifetimes`` for
    plotting interval censored data - thanks @sean-reed!
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed bug where ``cdf_plot`` and ``qq_plot`` were not factoring in
    the weights correctly.
 
-.. _section-16:
+.. _section-17:
 
 0.24.5 - 2020-05-01
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-12:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``plot_lifetimes`` accepts pandas Series.
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed important bug in interval censoring models. Users using
    interval censoring are strongly advised to upgrade.
 -  Improved ``at_risk_counts`` for subplots.
 -  More data validation checks for ``CoxTimeVaryingFitter``
 
-.. _section-17:
+.. _section-18:
 
 0.24.4 - 2020-04-13
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Improved stability of interval censoring in parametric models.
 -  setting a dataframe in ``ancillary_df`` works for interval censoring
 -  ``.score`` works for interval censored models
 
-.. _section-18:
+.. _section-19:
 
 0.24.3 - 2020-03-25
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-13:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  new ``logx`` kwarg in plotting curves
 -  PH models have ``compute_followup_hazard_ratios`` for simulating what
    the hazard ratio would be at previous times. This is useful because
    the final hazard ratio is some weighted average of these.
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed error in HTML printer that was hiding concordance index
    information.
 
-.. _section-19:
+.. _section-20:
 
 0.24.2 - 2020-03-15
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed bug when no covariates were passed into ``CoxPHFitter``. See
    #975
@@ -469,30 +491,30 @@ Bug fixes
 -  Fixed a keyword bug in ``plot_covariate_groups`` for parametric
    models.
 
-.. _section-20:
+.. _section-21:
 
 0.24.1 - 2020-03-05
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-14:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Stability improvements for GeneralizedGammaRegressionFitter and
    CoxPHFitter with spline estimation.
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed bug with plotting hazards in NelsonAalenFitter.
 
-.. _section-21:
+.. _section-22:
 
 0.24.0 - 2020-02-20
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 This version and future versions of lifelines no longer support py35.
 Pandas 1.0 is fully supported, along with previous versions. Minimum
@@ -501,7 +523,7 @@ Scipy has been bumped to 1.2.0.
 .. _new-features-15:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``CoxPHFitter`` and ``CoxTimeVaryingFitter`` has support for an
    elastic net penalty, which includes L1 and L2 regression.
@@ -522,10 +544,10 @@ New features
 -  new ``lifelines.fitters.mixins.ProportionalHazardMixin`` that
    implements proportional hazard checks.
 
-.. _api-changes-5:
+.. _api-changes-6:
 
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  Models’ prediction method that return a single array now return a
    Series (use to return a DataFrame). This includes ``predict_median``,
@@ -550,10 +572,10 @@ API Changes
    to ``scoring_method``.
 -  removed ``_score_`` and ``path`` from Cox model.
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed ``show_censors`` with
    ``KaplanMeierFitter.plot_cumulative_density`` see issue #940.
@@ -563,15 +585,15 @@ Bug fixes
 -  Cox models now incorporate any penalizers in their
    ``log_likelihood_``
 
-.. _section-22:
+.. _section-23:
 
 0.23.9 - 2020-01-28
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed important error when a parametric regression model would not
    assign the correct labels to fitted parameters’ variances. See more
@@ -579,15 +601,15 @@ Bug fixes
    of ``GeneralizedGammaRegressionFitter`` and any custom regression
    models should update their code as soon as possible.
 
-.. _section-23:
+.. _section-24:
 
 0.23.8 - 2020-01-21
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed important error when a parametric regression model would not
    assign the correct labels to fitted parameters. See more here:
@@ -595,22 +617,22 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-24:
+.. _section-25:
 
 0.23.7 - 2020-01-14
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 Bug fixes for py3.5.
 
-.. _section-25:
+.. _section-26:
 
 0.23.6 - 2020-01-07
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-16:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  New univariate model, ``SplineFitter``, that uses cubic splines to
    model the cumulative hazard.
@@ -621,66 +643,66 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-26:
+.. _section-27:
 
 0.23.5 - 2020-01-05
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-17:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  New ``predict_hazard`` for parametric regression models.
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixes error thrown when converge of regression models fails.
 -  ``kwargs`` is now used in ``plot_covariate_groups``
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-27:
+.. _section-28:
 
 0.23.4 - 2019-12-15
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Bug fix for PyPI
 
-.. _section-28:
+.. _section-29:
 
 0.23.3 - 2019-12-11
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-18:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-29:
+.. _section-30:
 
 0.23.2 - 2019-12-07
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-19:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  new ``lifelines.plotting.rmst_plot`` for pretty figures of survival
    curves and RMSTs.
@@ -689,34 +711,34 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed ``print_summary`` for AAF class.
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-30:
+.. _section-31:
 
 0.23.1 - 2019-11-27
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-20:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  new ``print_summary`` option ``style`` to print HTML, LaTeX or ASCII
    output
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed bug where computed statistics were not being shown in
    ``print_summary`` for HTML output.
@@ -725,34 +747,34 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-31:
+.. _section-32:
 
 0.23.0 - 2019-11-17
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-21:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  new ``print_summary`` abstraction that allows HTML printing in
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  The “comparison” value of some parametric univariate models wasn’t
    standard, so the null hypothesis p-value may have been wrong. This is
    now fixed.
 -  fixed a NaN error in confidence intervals for KaplanMeierFitter
 
-.. _api-changes-6:
+.. _api-changes-7:
 
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  To align values across models, the column names for the confidence
    intervals in parametric univariate models ``summary`` have changed.
@@ -761,33 +783,33 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-32:
+.. _section-33:
 
 0.22.10 - 2019-11-08
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed error in plotting models with “lower” or “upper” was in the
    label name.
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-33:
+.. _section-34:
 
 0.22.9 - 2019-10-30
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed ``predict_`` methods in AFT models when ``timeline`` was not
    specified.
@@ -796,81 +818,81 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-34:
+.. _section-35:
 
 0.22.8 - 2019-10-06
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-22:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Serializing lifelines is better supported. Packages like joblib and
    pickle are now supported. Thanks @AbdealiJK!
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-35:
+.. _section-36:
 
 0.22.7 - 2019-09-29
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-23:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed a bug in parametric prediction for interval censored data.
 -  realigned values in ``print_summary``.
 -  fixed bug in ``survival_difference_at_fixed_point_in_time_test``
 
-.. _api-changes-7:
+.. _api-changes-8:
 
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  ``utils.qth_survival_time`` no longer takes a ``cdf`` argument -
    users should take the compliment (1-cdf).
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-36:
+.. _section-37:
 
 0.22.6 - 2019-09-25
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-24:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-29:
+.. _bug-fixes-30:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
-.. _api-changes-8:
+.. _api-changes-9:
 
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  ``CoxPHFitter.baseline_cumulative_hazard_``\ ’s column is renamed
    ``"baseline cumulative hazard"`` - previously it was
@@ -878,46 +900,46 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-37:
+.. _section-38:
 
 0.22.5 - 2019-09-20
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-25:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Improvements to the **repr** of models that takes into accounts
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-30:
+.. _bug-fixes-31:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed issue where ``fit_interval_censoring`` wouldn’t accept lists.
 -  Fixed an issue with ``AalenJohansenFitter`` failing to plot
    confidence intervals.
 
-.. _api-changes-9:
+.. _api-changes-10:
 
 API Changes
-'''''''''''
+~~~~~~~~~~~
 
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-38:
+.. _section-39:
 
 0.22.4 - 2019-09-04
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-26:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Some performance improvements to regression models.
 -  lifelines will avoid penalizing the intercept (aka bias) variables in
@@ -925,31 +947,31 @@ New features
 -  new ``utils.restricted_mean_survival_time`` that approximates the
    RMST using numerical integration against survival functions.
 
-.. _api-changes-10:
+.. _api-changes-11:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-31:
+.. _bug-fixes-32:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-39:
+.. _section-40:
 
 0.22.3 - 2019-08-08
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-27:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  model’s now expose a ``log_likelihood_`` property.
 -  new ``conditional_after`` argument on ``predict_*`` methods that make
@@ -959,10 +981,10 @@ New features
 -  smarter initial conditions for parametric regression models.
 -  New regression model: ``GeneralizedGammaRegressionFitter``
 
-.. _api-changes-11:
+.. _api-changes-12:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  removed ``lifelines.utils.gamma`` - use ``autograd_gamma`` library
    instead.
@@ -970,10 +992,10 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-32:
+.. _bug-fixes-33:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  AFT log-likelihood ratio test was not using weights correctly.
 -  corrected (by bumping) scipy and autograd dependencies
@@ -982,22 +1004,22 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-40:
+.. _section-41:
 
 0.22.2 - 2019-07-25
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-28:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-33:
+.. _bug-fixes-34:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed printing error when using robust=True in regression models
 -  ``GeneralizedGammaFitter`` is more stable, maybe.
@@ -1005,15 +1027,15 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-41:
+.. _section-42:
 
 0.22.1 - 2019-07-14
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-29:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  New univariate model, ``GeneralizedGammaFitter``. This model contains
    many sub-models, so it is a good model to check fits.
@@ -1025,10 +1047,10 @@ New features
    right censoring)
 -  improvements to ``lifelines.utils.gamma``
 
-.. _api-changes-12:
+.. _api-changes-13:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  In AFT models, the column names in ``confidence_intervals_`` has
    changed to include the alpha value.
@@ -1038,25 +1060,25 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-34:
+.. _bug-fixes-35:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  when using ``censors_show`` in plotting functions, the censor ticks
    are now reactive to the estimate being shown.
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-42:
+.. _section-43:
 
 0.22.0 - 2019-07-03
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-30:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Ability to create custom parametric regression models by specifying
    the cumulative hazard. This enables new and extensions of AFT models.
@@ -1065,10 +1087,10 @@ New features
 -  for parametric univariate models, the ``conditional_time_to_event_``
    is now exact instead of an approximation.
 
-.. _api-changes-13:
+.. _api-changes-14:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  In Cox models, the attribute ``hazards_`` has been renamed to
    ``params_``. This aligns better with the other regression models, and
@@ -1087,48 +1109,48 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-35:
+.. _bug-fixes-36:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  for parametric univariate models, the ``conditional_time_to_event_``
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-43:
+.. _section-44:
 
 0.21.5 - 2019-06-22
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 I’m skipping 0.21.4 version because of deployment issues.
 
 .. _new-features-31:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-36:
+.. _bug-fixes-37:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed an implicit import of scikit-learn. scikit-learn is an optional
    package.
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-44:
+.. _section-45:
 
 0.21.3 - 2019-06-04
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-32:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  include in lifelines is a scikit-learn adapter so lifeline’s models
    can be used with scikit-learn’s API. See `documentation
@@ -1139,22 +1161,22 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-37:
+.. _bug-fixes-38:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-45:
+.. _section-46:
 
 0.21.2 - 2019-05-16
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-33:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  New regression model: ``PiecewiseExponentialRegressionFitter`` is
    available. See blog post here:
@@ -1163,10 +1185,10 @@ New features
    that computes, you guessed it, the log-likelihood ratio test.
    Previously this was an internal API that is being exposed.
 
-.. _api-changes-14:
+.. _api-changes-15:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  The default behavior of the ``predict`` method on non-parametric
    estimators (``KaplanMeierFitter``, etc.) has changed from (previous)
@@ -1175,49 +1197,49 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-38:
+.. _bug-fixes-39:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
-.. _section-46:
+.. _section-47:
 
 0.21.1 - 2019-04-26
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-34:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  users can provided their own start and stop column names in
    ``add_covariate_to_timeline``
 -  PiecewiseExponentialFitter now allows numpy arrays as breakpoints
 
-.. _api-changes-15:
+.. _api-changes-16:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-39:
+.. _bug-fixes-40:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-47:
+.. _section-48:
 
 0.21.0 - 2019-04-12
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-35:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``weights`` is now a optional kwarg for parametric univariate models.
 -  all univariate and multivariate parametric models now have ability to
@@ -1228,10 +1250,10 @@ New features
 -  a new interval censored dataset is available under
    ``lifelines.datasets.load_diabetes``
 
-.. _api-changes-16:
+.. _api-changes-17:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  ``left_censorship`` on all univariate fitters has been deprecated.
    Please use the new api ``model.fit_left_censoring(...)``.
@@ -1239,56 +1261,56 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-40:
+.. _bug-fixes-41:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  lifelines was silently converting any NaNs in the event vector to
    True. An error is now thrown instead.
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-48:
+.. _section-49:
 
 0.20.5 - 2019-04-08
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-36:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  performance improvements for ``print_summary``.
 
-.. _api-changes-17:
+.. _api-changes-18:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  ``utils.survival_events_from_table`` returns an integer weight vector
    as well as durations and censoring vector.
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-41:
+.. _bug-fixes-42:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed an error in the ``CoxTimeVaryingFitter``\ ’s likelihood ratio
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-49:
+.. _section-50:
 
 0.20.4 - 2019-03-27
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-37:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  left-truncation support in AFT models, using the ``entry_col`` kwarg
    in ``fit()``
@@ -1296,32 +1318,32 @@ New features
    generating piecewise exp. data
 -  Faster ``print_summary`` for AFT models.
 
-.. _api-changes-18:
+.. _api-changes-19:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-42:
+.. _bug-fixes-43:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Better handling for extremely large numbers in ``print_summary``
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-50:
+.. _section-51:
 
 0.20.3 - 2019-03-23
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-38:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Now ``cumulative_density_`` & ``survival_function_`` are *always*
    present on a fitted ``KaplanMeierFitter``.
@@ -1331,15 +1353,15 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-51:
+.. _section-52:
 
 0.20.2 - 2019-03-21
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-39:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  Left censoring is now supported in univariate parametric models:
    ``.fit(..., left_censorship=True)``. Examples are in the docs.
@@ -1351,19 +1373,19 @@ New features
 -  add a ``lifelines.plotting.qq_plot`` for univariate parametric models
    that handles censored data.
 
-.. _api-changes-19:
+.. _api-changes-20:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  ``plot_lifetimes`` no longer reverses the order when plotting. Thanks
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-43:
+.. _bug-fixes-44:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  fixed a naming error in ``KaplanMeierFitter`` when
    ``left_censorship`` was set to True, ``plot_cumulative_density_()``
@@ -1376,10 +1398,10 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-52:
+.. _section-53:
 
 0.20.1 - 2019-03-16
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Some performance improvements to ``CoxPHFitter`` (about 30%). I know
    it may seem silly, but we are now about the same or slighty faster
@@ -1390,20 +1412,20 @@ Bug fixes
    decades of development.
 -  suppressed unimportant warnings
 
-.. _api-changes-20:
+.. _api-changes-21:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  Previously, lifelines *always* added a 0 row to
    ``cph.baseline_hazard_``, even if there were no event at this time.
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-53:
+.. _section-54:
 
 0.20.0 - 2019-03-05
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Starting with 0.20.0, only Python3 will be supported. Over 75% of
    recent installs where Py3.
@@ -1412,15 +1434,15 @@ API changes
 .. _new-features-40:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  smarter initialization for AFT models which should improve
    convergence.
 
-.. _api-changes-21:
+.. _api-changes-22:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  ``inital_beta`` in Cox model’s ``.fit`` is now ``initial_point``.
 -  ``initial_point`` is now available in AFT models and
@@ -1429,49 +1451,49 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-44:
+.. _bug-fixes-45:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-54:
+.. _section-55:
 
 0.19.5 - 2019-02-26
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-41:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``plot_covariate_group`` can accept multiple covariates to plot. This
    is useful for columns that have implicit correlation like polynomial
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-55:
+.. _section-56:
 
 0.19.4 - 2019-02-25
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
-.. _bug-fixes-45:
+.. _bug-fixes-46:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-56:
+.. _section-57:
 
 0.19.3 - 2019-02-25
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-42:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  new AFT models: ``LogNormalAFTFitter`` and ``LogLogisticAFTFitter``.
 -  AFT models now accept a ``weights_col`` argument to ``fit``.
@@ -1480,60 +1502,60 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-57:
+.. _section-58:
 
 0.19.2 - 2019-02-22
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-43:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-46:
+.. _bug-fixes-47:
 
 Bug fixes
-'''''''''
+~~~~~~~~~
 
 -  The ``ExponentialFitter`` log likelihood *value* was incorrect -
    inference was correct however.
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-58:
+.. _section-59:
 
 0.19.1 - 2019-02-21
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-44:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-22:
+.. _api-changes-23:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  **Important**: we changed the parameterization of the
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-59:
+.. _section-60:
 
 0.19.0 - 2019-02-20
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. _new-features-45:
 
 New features
-''''''''''''
+~~~~~~~~~~~~
 
 -  New regression model ``WeibullAFTFitter`` for fitting accelerated
    failure time models. Docs have been added to our
@@ -1543,10 +1565,10 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-23:
+.. _api-changes-24:
 
 API changes
-'''''''''''
+~~~~~~~~~~~
 
 -  **Important**: we changed the ``.hazards_`` and ``.standard_errors_``
    on Cox models to be pandas Series (instead of Dataframes). This felt
@@ -1569,10 +1591,10 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-47:
+.. _bug-fixes-48:
 
 Bug Fixes
-'''''''''
+~~~~~~~~~
 
 -  Fixed a bug in the ``_log_likelihood_`` property of
    ``ParametericUnivariateFitter`` models. It was showing the “average”
@@ -1586,20 +1608,20 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-60:
+.. _section-61:
 
 0.18.6 - 2019-02-13
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  some improvements to the output of ``check_assumptions``.
    ``show_plots`` is turned to ``False`` by default now. It only shows
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-61:
+.. _section-62:
 
 0.18.5 - 2019-02-11
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  added new plotting methods to parametric univariate models:
    ``plot_survival_function``, ``plot_hazard`` and
@@ -1617,30 +1639,30 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-62:
+.. _section-63:
 
 0.18.4 - 2019-02-10
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  fixed confidence intervals in cumulative hazards for parametric
    univarite models. They were previously serverly depressed.
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-63:
+.. _section-64:
 
 0.18.3 - 2019-02-07
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Some performance improvements to parametric univariate models.
 -  Suppressing some irrelevant NumPy and autograd warnings, so lifeline
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-64:
+.. _section-65:
 
 0.18.2 - 2019-02-05
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  New univariate fitter ``PiecewiseExponentialFitter`` for creating a
    stepwise hazard model. See docs online.
@@ -1653,10 +1675,10 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-65:
+.. _section-66:
 
 0.18.1 - 2019-02-02
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  bug fixes in ``LogNormalFitter`` variance estimates
 -  improve convergence of ``LogNormalFitter``. We now model the log of
@@ -1664,10 +1686,10 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-66:
+.. _section-67:
 
 0.18.0 - 2019-01-31
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  ``LogNormalFitter`` is a new univariate fitter you can use.
 -  ``WeibullFitter`` now correctly returns the confidence intervals
@@ -1701,18 +1723,18 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-67:
+.. _section-68:
 
 0.17.5 - 2019-01-25
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-68:
+.. _section-69:
 
 0.17.4 -2019-01-25
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  Fix bug in ``plot_covariate_groups`` that wasn’t allowing for strata
    to be used.
@@ -1721,18 +1743,18 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-69:
+.. _section-70:
 
 0.17.3 - 2019-01-24
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-70:
+.. _section-71:
 
 0.17.2 2019-01-22
-^^^^^^^^^^^^^^^^^
+-----------------
 
 -  Another round of serious performance improvements for the Cox models.
    Up to 2x faster for CoxPHFitter and CoxTimeVaryingFitter. This was
@@ -1740,10 +1762,10 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-71:
+.. _section-72:
 
 0.17.1 - 2019-01-20
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  adding bottleneck as a dependency. This library is highly-recommended
    by Pandas, and in lifelines we see some nice performance improvements
@@ -1757,10 +1779,10 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-72:
+.. _section-73:
 
 0.17.0 - 2019-01-11
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  corrected behaviour in ``CoxPHFitter`` where ``score_`` was not being
    refreshed on every new ``fit``.
@@ -1778,18 +1800,18 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-73:
+.. _section-74:
 
 0.16.3 - 2019-01-03
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-74:
+.. _section-75:
 
 0.16.2 - 2019-01-02
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Fixed ``CoxTimeVaryingFitter`` to allow more than one variable to be
    stratafied
@@ -1797,17 +1819,17 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-75:
+.. _section-76:
 
 0.16.1 - 2019-01-01
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-76:
+.. _section-77:
 
 0.16.0 - 2019-01-01
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Drop Python 3.4 support.
 -  introduction of residual calculations in
@@ -1840,25 +1862,25 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-77:
+.. _section-78:
 
 0.15.4
-^^^^^^
+------
 
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-78:
+.. _section-79:
 
 0.15.3 - 2018-12-18
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-79:
+.. _section-80:
 
 0.15.2 - 2018-11-23
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  API changes to ``plotting.plot_lifetimes``
 -  ``cluster_col`` and ``strata`` can be used together in
@@ -1866,19 +1888,19 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-80:
+.. _section-81:
 
 0.15.1 - 2018-11-23
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Bug fixes for v0.15.0
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-81:
+.. _section-82:
 
 0.15.0 - 2018-11-22
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  adding ``robust`` params to ``CoxPHFitter``\ ’s ``fit``. This enables
    atleast i) using non-integer weights in the model (these could be
@@ -1946,26 +1968,26 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-82:
+.. _section-83:
 
 0.14.6 - 2018-07-02
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-83:
+.. _section-84:
 
 0.14.5 - 2018-06-29
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-84:
+.. _section-85:
 
 0.14.4 - 2018-06-14
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Adds ``baseline_cumulative_hazard_`` and ``baseline_survival_`` to
    ``CoxTimeVaryingFitter``. Because of this, new prediction methods are
@@ -1979,10 +2001,10 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-85:
+.. _section-86:
 
 0.14.3 - 2018-05-24
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  fixes a bug when subtracting or dividing two ``UnivariateFitters``
    with labels.
@@ -1991,18 +2013,18 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-86:
+.. _section-87:
 
 0.14.2 - 2018-05-18
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-87:
+.. _section-88:
 
 0.14.1 - 2018-04-01
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  fixed bug with using weights and strata in ``CoxPHFitter``
 -  fixed bug in using non-integer weights in ``KaplanMeierFitter``
@@ -2017,10 +2039,10 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-88:
+.. _section-89:
 
 0.14.0 - 2018-03-03
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  adding ``plot_covariate_groups`` to ``CoxPHFitter`` to visualize what
    happens to survival as we vary a covariate, all else being equal.
@@ -2039,10 +2061,10 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-89:
+.. _section-90:
 
 0.13.0 - 2017-12-22
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  removes ``is_significant`` and ``test_result`` from
    ``StatisticalResult``. Users can instead choose their significance
@@ -2068,10 +2090,10 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-90:
+.. _section-91:
 
 0.12.0
-^^^^^^
+------
 
 -  removes ``include_likelihood`` from ``CoxPHFitter.fit`` - it was not
    slowing things down much (empirically), and often I wanted it for
@@ -2085,10 +2107,10 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-91:
+.. _section-92:
 
 0.11.3
-^^^^^^
+------
 
 -  No longer support matplotlib 1.X
 -  Adding ``times`` argument to ``CoxPHFitter``\ ’s
@@ -2097,25 +2119,25 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-92:
+.. _section-93:
 
 0.11.2
-^^^^^^
+------
 
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-93:
+.. _section-94:
 
 0.11.1 - 2017-06-22
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-94:
+.. _section-95:
 
 0.11.0 - 2017-06-21
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  fixes regression in ``KaplanMeierFitter.plot`` when using Seaborn and
    lifelines.
@@ -2126,17 +2148,17 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-95:
+.. _section-96:
 
 0.10.1 - 2017-06-05
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-96:
+.. _section-97:
 
 0.10.0
-^^^^^^
+------
 
 -  corrected bug that was returning the wrong baseline survival and
    hazard values in ``CoxPHFitter`` when ``normalize=True``.
@@ -2148,10 +2170,10 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-97:
+.. _section-98:
 
 0.9.4
-^^^^^
+-----
 
 -  adding ``plot_loglogs`` to ``KaplanMeierFitter``
 -  added a (correct) check to see if some columns in a dataset will
@@ -2171,27 +2193,27 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-98:
+.. _section-99:
 
 0.9.2
-^^^^^
+-----
 
 -  deprecates Pandas versions before 0.18.
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-99:
+.. _section-100:
 
 0.9.1
-^^^^^
+-----
 
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-100:
+.. _section-101:
 
 0.9.0
-^^^^^
+-----
 
 -  new prediction function in ``CoxPHFitter``,
    ``predict_log_hazard_relative_to_mean``, that mimics what R’s
@@ -2204,10 +2226,10 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-101:
+.. _section-102:
 
 0.8.1 - 2015-08-01
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  supports matplotlib 1.5.
 -  introduction of a param ``nn_cumulative_hazards`` in
@@ -2221,10 +2243,10 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-102:
+.. _section-103:
 
 0.8.0
-^^^^^
+-----
 
 -  reorganized lifelines directories:
 
@@ -2240,10 +2262,10 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-103:
+.. _section-104:
 
 0.7.1
-^^^^^
+-----
 
 -  addition of a l2 ``penalizer`` to ``CoxPHFitter``.
 -  dropped Fortran implementation of efficient Python version. Lifelines
@@ -2259,10 +2281,10 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-104:
+.. _section-105:
 
 0.7.0 - 2015-03-01
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  allow for multiple fitters to be passed into
    ``k_fold_cross_validation``.
@@ -2278,10 +2300,10 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-105:
+.. _section-106:
 
 0.6.1
-^^^^^
+-----
 
 -  addition of ``median_`` property to ``WeibullFitter`` and
    ``ExponentialFitter``.
@@ -2290,10 +2312,10 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-106:
+.. _section-107:
 
 0.6.0 - 2015-02-04
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  Inclusion of the univariate fitters ``WeibullFitter`` and
    ``ExponentialFitter``.
@@ -2313,10 +2335,10 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-107:
+.. _section-108:
 
 0.5.1 - 2014-12-24
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  New API for ``CoxPHFitter`` and ``AalenAdditiveFitter``: the default
    arguments for ``event_col`` and ``duration_col``. ``duration_col`` is
@@ -2334,10 +2356,10 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-108:
+.. _section-109:
 
 0.5.0 - 2014-12-07
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  move testing to py.test
 -  refactor tests into smaller files
@@ -2347,10 +2369,10 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-109:
+.. _section-110:
 
 0.4.4 - 2014-11-27
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  Lots of improvements to numerical stability (but something things
    still need work)
@@ -2359,10 +2381,10 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-110:
+.. _section-111:
 
 0.4.3 - 2014-07-23
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  refactoring of ``qth_survival_times``: it can now accept an iterable
    (or a scalar still) of probabilities in the q argument, and will
@@ -2380,10 +2402,10 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-111:
+.. _section-112:
 
 0.4.2 - 2014-06-19
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  Massive speed improvements to CoxPHFitter.
 -  Additional prediction method: ``predict_percentile`` is available on
@@ -2400,10 +2422,10 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-112:
+.. _section-113:
 
 0.4.1.1
-^^^^^^^
+-------
 
 -  Ability to specify default printing in statistical tests with the
    ``suppress_print`` keyword argument (default False).
@@ -2413,10 +2435,10 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-113:
+.. _section-114:
 
 0.4.1 - 2014-06-11
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  ``CoxFitter`` is now known as ``CoxPHFitter``
 -  refactoring some tests that used redundant data from
@@ -2432,10 +2454,10 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-114:
+.. _section-115:
 
 0.4.0 - 2014-06-08
-^^^^^^^^^^^^^^^^^^
+------------------
 
 -  ``CoxFitter`` implements Cox Proportional Hazards model in lifelines.
 -  lifelines moves the wheels distributions.

--- a/docs/Survival Regression.rst
+++ b/docs/Survival Regression.rst
@@ -334,7 +334,7 @@ However, if you used the ``formula`` kwarg in fit, all the necessary transformat
 
 .. code:: python
 
-    cph.fit(rossi, 'week', 'arrest', formula="bs(prio, df=3)")
+    cph.fit(rossi, 'week', 'arrest', formula="prio + I(prio**2)")
 
     cph.plot_partial_effects_on_outcome(
         covariates=['prio'],

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -430,7 +430,7 @@ class ParametricUnivariateFitter(UnivariateFitter):
         # this diff can be 0 - we can't take the log of that.
         ll = (
             ll
-            + np.clip(
+            + anp.clip(
                 censored_weights
                 * anp.log(self._survival_function(params, censored_starts) - self._survival_function(params, censored_stops)),
                 -1e50,

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -2664,17 +2664,14 @@ class ParametricSplinePHFitter(ParametricCoxModelFitter, SplineFitterMixin):
         if self.strata is not None:
             params = {"beta_": np.zeros(len(Xs["beta_"].columns))}
             for stratum in self.strata_values:
-                params.update(
-                    {self._strata_labeler(stratum, 1): np.array([0.05]), self._strata_labeler(stratum, 2): np.array([-0.05])}
-                )
-                params.update({self._strata_labeler(stratum, i): np.array([0.01]) for i in range(3, self.n_baseline_knots + 1)})
+                params.update({self._strata_labeler(stratum, i): np.array([0.001]) for i in range(1, self.n_baseline_knots + 1)})
 
             return params
 
         else:
             return {
-                **{"beta_": np.zeros(len(Xs["beta_"].columns)), "phi1_": np.array([0.05]), "phi2_": np.array([-0.05])},
-                **{"phi%d_" % i: np.array([0.01]) for i in range(3, self.n_baseline_knots + 1)},
+                **{"beta_": np.zeros(len(Xs["beta_"].columns))},
+                **{"phi%d_" % i: np.array([0.001]) for i in range(1, self.n_baseline_knots + 1)},
             }
 
     def _cumulative_hazard_with_strata(self, params, T, Xs):
@@ -2775,15 +2772,14 @@ class ParametricPiecewiseBaselinePHFitter(ParametricCoxModelFitter, Proportional
         if self.strata is not None:
             params = {"beta_": np.zeros(len(Xs["beta_"].columns))}
             for stratum in self.strata_values:
-                params.update({self._strata_labeler(stratum, 2): np.array([-0.05])})
-                params.update({self._strata_labeler(stratum, i): np.array([0.0]) for i in range(3, self.n_breakpoints + 2)})
+                params.update({self._strata_labeler(stratum, i): np.array([0.001]) for i in range(2, self.n_breakpoints + 2)})
 
             return params
 
         else:
             return {
-                **{"beta_": np.zeros(len(Xs["beta_"].columns)), "log_lambda2_": np.array([-0.05])},
-                **{"log_lambda%d_" % i: np.array([0.0]) for i in range(3, self.n_breakpoints + 2)},
+                **{"beta_": np.zeros(len(Xs["beta_"].columns))},
+                **{"log_lambda%d_" % i: np.array([0.001]) for i in range(2, self.n_breakpoints + 2)},
             }
 
     def _cumulative_hazard_with_strata(self, params, T, Xs):

--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -205,7 +205,7 @@ class KaplanMeierFitter(NonParametricUnivariateFitter):
 
         self._label = coalesce(label, self._label, "NPMLE_estimate")
 
-        results = npmle(self.lower_bound, self.upper_bound, verbose=show_progress, tol=tol)
+        results = npmle(self.lower_bound, self.upper_bound, verbose=show_progress, tol=tol, weights=weights)
         self.survival_function_ = reconstruct_survival_function(*results, self.timeline, label=self._label).loc[self.timeline]
         self.cumulative_density_ = 1 - self.survival_function_
 

--- a/lifelines/fitters/mixins.py
+++ b/lifelines/fitters/mixins.py
@@ -26,7 +26,7 @@ class ProportionalHazardMixin:
         advice: bool = True,
         show_plots: bool = False,
         p_value_threshold: float = 0.01,
-        plot_n_bootstraps: int = 10,
+        plot_n_bootstraps: int = 15,
         columns: Optional[List[str]] = None,
     ) -> None:
         """

--- a/lifelines/fitters/mixins.py
+++ b/lifelines/fitters/mixins.py
@@ -42,7 +42,7 @@ class ProportionalHazardMixin:
         advice: bool, optional
             display advice as output to the user's screen
         show_plots: bool, optional
-            display plots of the scaled schoenfeld residuals and loess curves. This is an eyeball test for violations.
+            display plots of the scaled Schoenfeld residuals and loess curves. This is an eyeball test for violations.
             This will slow down the function significantly.
         p_value_threshold: float, optional
             the threshold to use to alert the user of violations. See note below.
@@ -51,6 +51,10 @@ class ProportionalHazardMixin:
             the function significantly.
         columns: list, optional
             specify a subset of columns to test.
+
+        Returns
+        --------
+            A list of list of axes objects.
 
 
         Examples
@@ -64,7 +68,7 @@ class ProportionalHazardMixin:
             rossi = load_rossi()
             cph = CoxPHFitter().fit(rossi, 'week', 'arrest')
 
-            cph.check_assumptions(rossi)
+            axes = cph.check_assumptions(rossi, show_plots=True)
 
 
         Notes
@@ -99,8 +103,9 @@ class ProportionalHazardMixin:
 
         counter = 0
         n = residuals_and_duration.shape[0]
+        axes = []
 
-        for variable in self.params_.index.intersection(columns or self.params_.index):
+        for variable in self.params_.index & (columns or self.params_.index):
             minumum_observed_p_value = test_results.summary.loc[variable, "p"].min()
             if np.round(minumum_observed_p_value, 2) > p_value_threshold:
                 continue
@@ -139,9 +144,9 @@ class ProportionalHazardMixin:
                 value_counts = values.value_counts()
                 n_uniques = value_counts.shape[0]
 
-                # Arbitrary chosen 10 and 4 to check for ability to use strata col.
+                # Arbitrary chosen to check for ability to use strata col.
                 # This should capture dichotomous / low cardinality values.
-                if n_uniques <= 10 and value_counts.min() >= 5:
+                if n_uniques <= 6 and value_counts.min() >= 5:
                     print(
                         fill(
                             "   Advice: with so few unique values (only {0}), you can include `strata=['{1}', ...]` in the call in `.fit`. See documentation in link [E] below.".format(
@@ -178,7 +183,10 @@ class ProportionalHazardMixin:
                     )
 
             if show_plots:
-                print("Bootstrapping lowess lines. May take a moment...")
+                axes.append([])
+                print()
+                print("   Bootstrapping lowess lines. May take a moment...")
+                print()
                 from matplotlib import pyplot as plt
 
                 fig = plt.figure()
@@ -209,6 +217,7 @@ class ProportionalHazardMixin:
                     ax.set_xlim(best_xlim)
 
                     ax.set_xlabel("%s-transformed time\n(p=%.4f)" % (transform_name, p_value), fontsize=10)
+                    axes[-1].append(ax)
 
                 fig.suptitle("Scaled Schoenfeld residuals of '%s'" % variable, fontsize=14)
                 plt.tight_layout()
@@ -230,6 +239,7 @@ class ProportionalHazardMixin:
 
         if counter == 0:
             print("Proportional hazard assumption looks okay.")
+        return axes
 
     @property
     def hazard_ratios_(self):

--- a/lifelines/fitters/spline_fitter.py
+++ b/lifelines/fitters/spline_fitter.py
@@ -89,7 +89,7 @@ class SplineFitter(KnownModelParametricUnivariateFitter, SplineFitterMixin):
         super(SplineFitter, self).__init__(*args, **kwargs)
 
     def _create_initial_point(self, Ts, E, entry, weights):
-        return 0.1 * np.ones(self.n_knots)
+        return 0.01 * np.ones(self.n_knots)
 
     def _cumulative_hazard(self, params, t):
         phis = params

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -503,6 +503,15 @@ class TestPlotting:
         self.plt.title("test_coxph_plot_partial_effects_on_outcome_with_strata")
         self.plt.show(block=block)
 
+    def test_aft_plot_partial_effects_on_outcome_with_categorical(self, block):
+        df = load_rossi()
+        df["cat"] = np.random.choice(["a", "b", "c"], size=df.shape[0])
+        aft = WeibullAFTFitter()
+        aft.fit(df, "week", "arrest", formula="cat + age + fin")
+        aft.plot_partial_effects_on_outcome("cat", values=["a", "b", "c"])
+        self.plt.title("test_aft_plot_partial_effects_on_outcome_with_categorical")
+        self.plt.show(block=block)
+
     def test_coxph_plot_partial_effects_on_outcome_with_strata_and_complicated_dtypes(self, block):
         # from https://github.com/CamDavidsonPilon/lifelines/blob/master/examples/Customer%20Churn.ipynb
         churn_data = pd.read_csv(
@@ -530,7 +539,7 @@ class TestPlotting:
 
     def test_spline_coxph_plot_partial_effects_on_outcome_with_strata(self, block):
         df = load_rossi()
-        cp = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=1)
+        cp = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2)
         cp.fit(df, "week", "arrest", strata=["wexp"])
         cp.plot_partial_effects_on_outcome("age", [10, 50, 80])
         self.plt.title("test_spline_coxph_plot_partial_effects_on_outcome_with_strata")

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -1015,8 +1015,8 @@ def test_rmst_exactely_with_known_solution():
 
 @flaky
 def test_rmst_approximate_solution():
-    T = np.random.exponential(2, 5000)
-    exp = ExponentialFitter().fit(T)
+    T = np.random.exponential(2, 4000)
+    exp = ExponentialFitter().fit(T, timeline=np.linspace(0, T.max(), 10000))
     lambda_ = exp.lambda_
 
     with pytest.warns(exceptions.ApproximationWarning) as w:

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -207,6 +207,24 @@ def test_datetimes_to_durations_will_handle_dates_above_fill_date():
     npt.assert_almost_equal(C, np.array([1, 1, 0], dtype=bool))
 
 
+def test_datetimes_to_durations_will_handle_dates_above_multi_fill_date():
+    start_date = ["2013-10-08", "2013-10-09", "2013-10-10"]
+    end_date = ["2013-10-10", None, None]
+    last_observation = ["2013-10-10", "2013-10-12", "2013-10-14"]
+    T, E = utils.datetimes_to_durations(start_date, end_date, freq="D", fill_date=last_observation)
+    npt.assert_almost_equal(E, np.array([1, 0, 0], dtype=bool))
+    npt.assert_almost_equal(T, np.array([2, 3, 4]))
+
+
+def test_datetimes_to_durations_will_handle_dates_above_multi_fill_date():
+    start_date = ["2013-10-08", "2013-10-09", "2013-10-10"]
+    end_date = ["2013-10-10", None, None]
+    last_observation = ["2013-10-10", "2013-10-12", "2013-10-14"]
+    T, E = utils.datetimes_to_durations(start_date, end_date, freq="D", fill_date=last_observation)
+    npt.assert_almost_equal(E, np.array([1, 0, 0], dtype=bool))
+    npt.assert_almost_equal(T, np.array([2, 3, 4]))
+
+
 def test_datetimes_to_durations_censor():
     start_date = ["2013-10-10", "2013-10-09", "2012-10-10"]
     end_date = ["2013-10-13", None, ""]

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -668,7 +668,7 @@ def datetimes_to_durations(
         E # array([ True, False,  True])
 
     """
-    fill_date_ = pd.Series(fill_date)
+    fill_date_ = pd.Series(fill_date).squeeze()
     freq_string = "timedelta64[%s]" % freq
     start_times = pd.Series(start_times).copy()
     end_times = pd.Series(end_times).copy()

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1097,7 +1097,7 @@ def check_complete_separation_low_variance(df: pd.DataFrame, events: np.ndarray,
     deaths_only = df.columns[_low_var(df.loc[events])]
     censors_only = df.columns[_low_var(df.loc[~events])]
     total = df.columns[_low_var(df)]
-    problem_columns = censors_only.union(deaths_only).difference(total).tolist()
+    problem_columns = (censors_only | deaths_only).difference(total).tolist()
     if problem_columns:
         warning_text = """Column {cols} have very low variance when conditioned on death event present or not. This may harm convergence. This could be a form of 'complete separation'. For example, try the following code:
 

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -276,7 +276,7 @@ def _expected_value_of_survival_up_to_t(model_or_survival_function, t: float = n
             sf = sf.reset_index()
             return (sf["index"].diff().shift(-1) * sf[model._label]).sum()
         else:
-            return quad(model.predict, 0, t)[0]
+            return quad(model.predict, 0, t, epsabs=1.49e-10, epsrel=1e-10)[0]
     else:
         raise ValueError("Can't compute RMST of object %s" % model_or_survival_function)
 

--- a/lifelines/utils/lowess.py
+++ b/lifelines/utils/lowess.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 This module implements the Lowess function for nonparametric regression.
 Functions:
@@ -19,6 +20,7 @@ Statistical Association, September 1988, volume 83, number 403, pp. 596-610.
 # Slight updates in lifelines 0.16.0, 2018
 
 from math import ceil
+import warnings
 import numpy as np
 from scipy import linalg
 
@@ -36,7 +38,7 @@ def lowess(x, y, f=2.0 / 3.0, iterations=3):
     """
     n = len(x)
     r = int(ceil(f * n))
-    h = [np.sort(np.abs(x - x[i]))[r] for i in range(n)]
+    h = np.clip([np.sort(np.abs(x - x[i]))[r] for i in range(n)], 1e-8, np.inf)
     w = np.clip(np.abs((x[:, None] - x[None, :]) / h), 0.0, 1.0)
     w = (1 - w ** 3) ** 3
     yest = np.zeros(n)
@@ -48,7 +50,10 @@ def lowess(x, y, f=2.0 / 3.0, iterations=3):
             A = np.array([[np.sum(weights), np.sum(weights * x)], [np.sum(weights * x), np.sum(weights * x * x)]])
             # I think it is safe to assume this.
             # pylint: disable=unexpected-keyword-arg
-            beta = linalg.solve(A, b, assume_a="pos", check_finite=False)
+            try:
+                beta = linalg.solve(A, b, assume_a="pos", check_finite=False)
+            except np.linalg.LinAlgError:
+                beta = [0, 0]
             yest[i] = beta[0] + beta[1] * x[i]
 
         residuals = y - yest

--- a/lifelines/utils/lowess.py
+++ b/lifelines/utils/lowess.py
@@ -17,7 +17,7 @@ Statistical Association, September 1988, volume 83, number 403, pp. 596-610.
 # License: BSD (3-clause)
 
 
-# Slight updates in lifelines 0.16.0, 2018
+# Slight updates in lifelines 0.16.0+, 2018
 
 from math import ceil
 import warnings
@@ -25,7 +25,7 @@ import numpy as np
 from scipy import linalg
 
 
-def lowess(x, y, f=2.0 / 3.0, iterations=3):
+def lowess(x, y, f=2.0 / 3.0, iterations=1):
     """lowess(x, y, f=2./3., iter=3) -> yest
     Lowess smoother: Robust locally weighted regression.
     The lowess function fits a nonparametric regression curve to a scatterplot.

--- a/lifelines/utils/printer.py
+++ b/lifelines/utils/printer.py
@@ -58,7 +58,7 @@ class Printer:
         if self.columns is None:
             columns = summary_df.columns
         else:
-            columns = summary_df.columns.intersection(self.columns)
+            columns = summary_df.columns & self.columns
         return summary_df[columns].to_latex(float_format="%." + str(self.decimals) + "f")
 
     def html_print(self):
@@ -71,7 +71,7 @@ class Printer:
         if self.columns is None:
             columns = summary_df.columns
         else:
-            columns = summary_df.columns.intersection(self.columns)
+            columns = summary_df.columns & self.columns
 
         headers = self.headers.copy()
         headers.insert(0, ("model", "lifelines." + self.model._class_name))
@@ -114,7 +114,7 @@ class Printer:
         df.columns = utils.map_leading_space(df.columns)
 
         if self.columns is not None:
-            columns = df.columns.intersection(utils.map_leading_space(self.columns))
+            columns = df.columns & utils.map_leading_space(self.columns)
         else:
             columns = df.columns
 

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.25.4"
+__version__ = "0.25.5"


### PR DESCRIPTION
#### 0.25.5 - 2020-09-23

##### API Changes
 - `check_assumptions` now returns a list of list of axes that can be manipulated

##### Bug fixes
 - fixed error when using `plot_partial_effects` with categorical data in AFT models
 - improved warning when Hessian matrix contains NaNs.
 - fixed performance regression in interval censoring fitting in parametric models
 - `weights` wasn't being applied properly in NPMLE