### PR TITLE
Update Modelling time-lagged conversion rates.ipynb

### DIFF
--- a/docs/jupyter_notebooks/Modelling time-lagged conversion rates.ipynb
+++ b/docs/jupyter_notebooks/Modelling time-lagged conversion rates.ipynb
@@ -471,7 +471,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "I wasn't expect this good of a fit. But there it is. This was some artificial data, but let's try this technique on some real life data. "
+    "I wasn't expecting this good of a fit. But there it is. This was some artificial data, but let's try this technique on some real life data. "
    ]
   },
   {


### PR DESCRIPTION
On line 474, I fixed a typo.
"I wasn't expect this good of a fit." -> "I wasn't expecting this good of a fit."