### PR TITLE
v0.25.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Changelog
 
+#### 0.25.6 - unreleased
+
+##### New features
+ - Parametric Cox models can now handle left and interval censoring datasets.
+
+##### Bug fixes
+ - "improved" the output of `add_at_risk_counts` by removing a call to `plt.tight_layout()` - this works better when you are calling `add_at_risk_counts` on multiple axes, but it is recommended you call `plt.tight_layout()` at the very end of your script.
+
+
+##### API Changes
+ - `check_assumptions` now returns a list of list of axes that can be manipulated
+
+##### Bug fixes
+ - fixed error when using `plot_partial_effects` with categorical data in AFT models
+ - improved warning when Hessian matrix contains NaNs.
+ - fixed performance regression in interval censoring fitting in parametric models
+ - `weights` wasn't being applied properly in NPMLE
+
 #### 0.25.5 - 2020-09-23
 
 ##### API Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ##### Bug fixes
  - "improved" the output of `add_at_risk_counts` by removing a call to `plt.tight_layout()` - this works better when you are calling `add_at_risk_counts` on multiple axes, but it is recommended you call `plt.tight_layout()` at the very end of your script.
+ - Fix bug in `KaplanMeierFitter`'s interval censoring where max(lower bound) < min(upper bound).
 
 
 #### 0.25.5 - 2020-09-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-#### 0.25.6 - unreleased
+#### 0.25.6 - 2020-10-26
 
 ##### New features
  - Parametric Cox models can now handle left and interval censoring datasets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,6 @@
  - "improved" the output of `add_at_risk_counts` by removing a call to `plt.tight_layout()` - this works better when you are calling `add_at_risk_counts` on multiple axes, but it is recommended you call `plt.tight_layout()` at the very end of your script.
 
 
-##### API Changes
- - `check_assumptions` now returns a list of list of axes that can be manipulated
-
-##### Bug fixes
- - fixed error when using `plot_partial_effects` with categorical data in AFT models
- - improved warning when Hessian matrix contains NaNs.
- - fixed performance regression in interval censoring fitting in parametric models
- - `weights` wasn't being applied properly in NPMLE
-
 #### 0.25.5 - 2020-09-23
 
 ##### API Changes

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,25 @@
 Changelog
 =========
 
+0.25.6 - unreleased
+-------------------
+
+New features
+~~~~~~~~~~~~
+
+-  Parametric Cox models can now handle left and interval censoring
+   datasets.
+
+Bug fixes
+~~~~~~~~~
+
+-  “improved” the output of ``add_at_risk_counts`` by removing a call to
+   ``plt.tight_layout()`` - this works better when you are calling
+   ``add_at_risk_counts`` on multiple axes, but it is recommended you
+   call ``plt.tight_layout()`` at the very end of your script.
+-  Fix bug in ``KaplanMeierFitter``\ ’s interval censoring where
+   max(lower bound) < min(upper bound).
+
 0.25.5 - 2020-09-23
 -------------------
 
@@ -9,6 +28,8 @@ API Changes
 
 -  ``check_assumptions`` now returns a list of list of axes that can be
    manipulated
+
+.. _bug-fixes-1:
 
 Bug fixes
 ~~~~~~~~~
@@ -25,6 +46,8 @@ Bug fixes
 0.25.4 - 2020-08-26
 -------------------
 
+.. _new-features-1:
+
 New features
 ~~~~~~~~~~~~
 
@@ -33,7 +56,7 @@ New features
    ``log_likelihood_ratio_test()`` and ``print_summary()``
 -  Better step-size defaults for Cox model -> more robust convergence.
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 ~~~~~~~~~
@@ -45,7 +68,7 @@ Bug fixes
 0.25.3 - 2020-08-24
 -------------------
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ~~~~~~~~~~~~
@@ -62,7 +85,7 @@ API Changes
 -  See note on ``survival_difference_at_fixed_point_in_time_test``
    above.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 ~~~~~~~~~
@@ -76,7 +99,7 @@ Bug fixes
 0.25.2 - 2020-08-08
 -------------------
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ~~~~~~~~~~~~
@@ -96,7 +119,7 @@ API Changes
    the author.). So add 2 to ``n_baseline_knots`` to recover the
    identical model as previously.
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 ~~~~~~~~~
@@ -110,7 +133,7 @@ Bug fixes
 0.25.1 - 2020-08-01
 -------------------
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 ~~~~~~~~~
@@ -126,7 +149,7 @@ Bug fixes
 0.25.0 - 2020-07-27
 -------------------
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ~~~~~~~~~~~~
@@ -183,7 +206,7 @@ API Changes
    `here <https://lifelines.readthedocs.io/en/latest/Survival%20Regression.html#plotting-the-effect-of-varying-a-covariate>`__.
 -  all exceptions and warnings have moved to ``lifelines.exceptions``
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 ~~~~~~~~~
@@ -204,7 +227,7 @@ Bug fixes
 0.24.16 - 2020-07-09
 --------------------
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ~~~~~~~~~~~~
@@ -212,7 +235,7 @@ New features
 -  improved algorithm choice for large DataFrames for Cox models. Should
    see a significant performance boost.
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 ~~~~~~~~~
@@ -224,7 +247,7 @@ Bug fixes
 0.24.15 - 2020-07-07
 --------------------
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 ~~~~~~~~~
@@ -240,7 +263,7 @@ Bug fixes
 0.24.14 - 2020-07-02
 --------------------
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 ~~~~~~~~~
@@ -257,7 +280,7 @@ Bug fixes
 0.24.13 - 2020-06-22
 --------------------
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 ~~~~~~~~~
@@ -272,7 +295,7 @@ Bug fixes
 0.24.12 - 2020-06-20
 --------------------
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ~~~~~~~~~~~~
@@ -284,7 +307,7 @@ New features
 0.24.11 - 2020-06-17
 --------------------
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ~~~~~~~~~~~~
@@ -312,7 +335,7 @@ API Changes
 0.24.10 - 2020-06-16
 --------------------
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ~~~~~~~~~~~~
@@ -329,7 +352,7 @@ API Changes
 -  Related to above: the fitted spline parameters are now available in
    the ``.summary`` and ``.print_summary`` methods.
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 ~~~~~~~~~
@@ -342,7 +365,7 @@ Bug fixes
 0.24.9 - 2020-06-05
 -------------------
 
-.. _new-features-8:
+.. _new-features-9:
 
 New features
 ~~~~~~~~~~~~
@@ -352,7 +375,7 @@ New features
    ``tarone-ware``, ``peto``, ``fleming-harrington``. Thanks @sean-reed
 -  new interval censored dataset: ``lifelines.datasets.load_mice``
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 ~~~~~~~~~
@@ -365,7 +388,7 @@ Bug fixes
 0.24.8 - 2020-05-17
 -------------------
 
-.. _new-features-9:
+.. _new-features-10:
 
 New features
 ~~~~~~~~~~~~
@@ -379,7 +402,7 @@ New features
 0.24.7 - 2020-05-17
 -------------------
 
-.. _new-features-10:
+.. _new-features-11:
 
 New features
 ~~~~~~~~~~~~
@@ -400,7 +423,7 @@ New features
 0.24.6 - 2020-05-05
 -------------------
 
-.. _new-features-11:
+.. _new-features-12:
 
 New features
 ~~~~~~~~~~~~
@@ -410,7 +433,7 @@ New features
 -  New ``lifelines.plotting.plot_interval_censored_lifetimes`` for
    plotting interval censored data - thanks @sean-reed!
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 ~~~~~~~~~
@@ -423,14 +446,14 @@ Bug fixes
 0.24.5 - 2020-05-01
 -------------------
 
-.. _new-features-12:
+.. _new-features-13:
 
 New features
 ~~~~~~~~~~~~
 
 -  ``plot_lifetimes`` accepts pandas Series.
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 ~~~~~~~~~
@@ -445,7 +468,7 @@ Bug fixes
 0.24.4 - 2020-04-13
 -------------------
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 ~~~~~~~~~
@@ -459,7 +482,7 @@ Bug fixes
 0.24.3 - 2020-03-25
 -------------------
 
-.. _new-features-13:
+.. _new-features-14:
 
 New features
 ~~~~~~~~~~~~
@@ -469,7 +492,7 @@ New features
    the hazard ratio would be at previous times. This is useful because
    the final hazard ratio is some weighted average of these.
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 ~~~~~~~~~
@@ -482,7 +505,7 @@ Bug fixes
 0.24.2 - 2020-03-15
 -------------------
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 ~~~~~~~~~
@@ -499,7 +522,7 @@ Bug fixes
 0.24.1 - 2020-03-05
 -------------------
 
-.. _new-features-14:
+.. _new-features-15:
 
 New features
 ~~~~~~~~~~~~
@@ -507,7 +530,7 @@ New features
 -  Stability improvements for GeneralizedGammaRegressionFitter and
    CoxPHFitter with spline estimation.
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 ~~~~~~~~~
@@ -523,7 +546,7 @@ This version and future versions of lifelines no longer support py35.
 Pandas 1.0 is fully supported, along with previous versions. Minimum
 Scipy has been bumped to 1.2.0.
 
-.. _new-features-15:
+.. _new-features-16:
 
 New features
 ~~~~~~~~~~~~
@@ -575,7 +598,7 @@ API Changes
    to ``scoring_method``.
 -  removed ``_score_`` and ``path`` from Cox model.
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 ~~~~~~~~~
@@ -593,7 +616,7 @@ Bug fixes
 0.23.9 - 2020-01-28
 -------------------
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 ~~~~~~~~~
@@ -609,7 +632,7 @@ Bug fixes
 0.23.8 - 2020-01-21
 -------------------
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
 ~~~~~~~~~
@@ -632,7 +655,7 @@ Bug fixes for py3.5.
 0.23.6 - 2020-01-07
 -------------------
 
-.. _new-features-16:
+.. _new-features-17:
 
 New features
 ~~~~~~~~~~~~
@@ -651,7 +674,7 @@ New features
 0.23.5 - 2020-01-05
 -------------------
 
-.. _new-features-17:
+.. _new-features-18:
 
 New features
 ~~~~~~~~~~~~
@@ -660,7 +683,7 @@ New features
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
 ~~~~~~~~~
@@ -682,14 +705,14 @@ Bug fixes
 0.23.3 - 2019-12-11
 -------------------
 
-.. _new-features-18:
+.. _new-features-19:
 
 New features
 ~~~~~~~~~~~~
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
 ~~~~~~~~~
@@ -702,7 +725,7 @@ Bug fixes
 0.23.2 - 2019-12-07
 -------------------
 
-.. _new-features-19:
+.. _new-features-20:
 
 New features
 ~~~~~~~~~~~~
@@ -714,7 +737,7 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
 ~~~~~~~~~
@@ -728,7 +751,7 @@ Bug fixes
 0.23.1 - 2019-11-27
 -------------------
 
-.. _new-features-20:
+.. _new-features-21:
 
 New features
 ~~~~~~~~~~~~
@@ -738,7 +761,7 @@ New features
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
 ~~~~~~~~~
@@ -755,7 +778,7 @@ Bug fixes
 0.23.0 - 2019-11-17
 -------------------
 
-.. _new-features-21:
+.. _new-features-22:
 
 New features
 ~~~~~~~~~~~~
@@ -764,7 +787,7 @@ New features
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
 ~~~~~~~~~
@@ -794,7 +817,7 @@ API Changes
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
 ~~~~~~~~~
@@ -809,7 +832,7 @@ Bug fixes
 0.22.9 - 2019-10-30
 -------------------
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
 ~~~~~~~~~
@@ -826,7 +849,7 @@ Bug fixes
 0.22.8 - 2019-10-06
 -------------------
 
-.. _new-features-22:
+.. _new-features-23:
 
 New features
 ~~~~~~~~~~~~
@@ -836,7 +859,7 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug fixes
 ~~~~~~~~~
@@ -848,7 +871,7 @@ Bug fixes
 0.22.7 - 2019-09-29
 -------------------
 
-.. _new-features-23:
+.. _new-features-24:
 
 New features
 ~~~~~~~~~~~~
@@ -856,7 +879,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-29:
+.. _bug-fixes-30:
 
 Bug fixes
 ~~~~~~~~~
@@ -880,14 +903,14 @@ API Changes
 0.22.6 - 2019-09-25
 -------------------
 
-.. _new-features-24:
+.. _new-features-25:
 
 New features
 ~~~~~~~~~~~~
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-30:
+.. _bug-fixes-31:
 
 Bug fixes
 ~~~~~~~~~
@@ -908,7 +931,7 @@ API Changes
 0.22.5 - 2019-09-20
 -------------------
 
-.. _new-features-25:
+.. _new-features-26:
 
 New features
 ~~~~~~~~~~~~
@@ -917,7 +940,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-31:
+.. _bug-fixes-32:
 
 Bug fixes
 ~~~~~~~~~
@@ -939,7 +962,7 @@ API Changes
 0.22.4 - 2019-09-04
 -------------------
 
-.. _new-features-26:
+.. _new-features-27:
 
 New features
 ~~~~~~~~~~~~
@@ -958,7 +981,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-32:
+.. _bug-fixes-33:
 
 Bug fixes
 ~~~~~~~~~
@@ -971,7 +994,7 @@ Bug fixes
 0.22.3 - 2019-08-08
 -------------------
 
-.. _new-features-27:
+.. _new-features-28:
 
 New features
 ~~~~~~~~~~~~
@@ -995,7 +1018,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-33:
+.. _bug-fixes-34:
 
 Bug fixes
 ~~~~~~~~~
@@ -1012,14 +1035,14 @@ Bug fixes
 0.22.2 - 2019-07-25
 -------------------
 
-.. _new-features-28:
+.. _new-features-29:
 
 New features
 ~~~~~~~~~~~~
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-34:
+.. _bug-fixes-35:
 
 Bug fixes
 ~~~~~~~~~
@@ -1035,7 +1058,7 @@ Bug fixes
 0.22.1 - 2019-07-14
 -------------------
 
-.. _new-features-29:
+.. _new-features-30:
 
 New features
 ~~~~~~~~~~~~
@@ -1063,7 +1086,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-35:
+.. _bug-fixes-36:
 
 Bug fixes
 ~~~~~~~~~
@@ -1078,7 +1101,7 @@ Bug fixes
 0.22.0 - 2019-07-03
 -------------------
 
-.. _new-features-30:
+.. _new-features-31:
 
 New features
 ~~~~~~~~~~~~
@@ -1112,7 +1135,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-36:
+.. _bug-fixes-37:
 
 Bug fixes
 ~~~~~~~~~
@@ -1128,14 +1151,14 @@ Bug fixes
 
 I’m skipping 0.21.4 version because of deployment issues.
 
-.. _new-features-31:
+.. _new-features-32:
 
 New features
 ~~~~~~~~~~~~
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-37:
+.. _bug-fixes-38:
 
 Bug fixes
 ~~~~~~~~~
@@ -1150,7 +1173,7 @@ Bug fixes
 0.21.3 - 2019-06-04
 -------------------
 
-.. _new-features-32:
+.. _new-features-33:
 
 New features
 ~~~~~~~~~~~~
@@ -1164,7 +1187,7 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-38:
+.. _bug-fixes-39:
 
 Bug fixes
 ~~~~~~~~~
@@ -1176,7 +1199,7 @@ Bug fixes
 0.21.2 - 2019-05-16
 -------------------
 
-.. _new-features-33:
+.. _new-features-34:
 
 New features
 ~~~~~~~~~~~~
@@ -1200,7 +1223,7 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-39:
+.. _bug-fixes-40:
 
 Bug fixes
 ~~~~~~~~~
@@ -1210,7 +1233,7 @@ Bug fixes
 0.21.1 - 2019-04-26
 -------------------
 
-.. _new-features-34:
+.. _new-features-35:
 
 New features
 ~~~~~~~~~~~~
@@ -1227,7 +1250,7 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-40:
+.. _bug-fixes-41:
 
 Bug fixes
 ~~~~~~~~~
@@ -1239,7 +1262,7 @@ Bug fixes
 0.21.0 - 2019-04-12
 -------------------
 
-.. _new-features-35:
+.. _new-features-36:
 
 New features
 ~~~~~~~~~~~~
@@ -1264,7 +1287,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-41:
+.. _bug-fixes-42:
 
 Bug fixes
 ~~~~~~~~~
@@ -1279,7 +1302,7 @@ Bug fixes
 0.20.5 - 2019-04-08
 -------------------
 
-.. _new-features-36:
+.. _new-features-37:
 
 New features
 ~~~~~~~~~~~~
@@ -1296,7 +1319,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-42:
+.. _bug-fixes-43:
 
 Bug fixes
 ~~~~~~~~~
@@ -1310,7 +1333,7 @@ Bug fixes
 0.20.4 - 2019-03-27
 -------------------
 
-.. _new-features-37:
+.. _new-features-38:
 
 New features
 ~~~~~~~~~~~~
@@ -1329,7 +1352,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-43:
+.. _bug-fixes-44:
 
 Bug fixes
 ~~~~~~~~~
@@ -1343,7 +1366,7 @@ Bug fixes
 0.20.3 - 2019-03-23
 -------------------
 
-.. _new-features-38:
+.. _new-features-39:
 
 New features
 ~~~~~~~~~~~~
@@ -1361,7 +1384,7 @@ New features
 0.20.2 - 2019-03-21
 -------------------
 
-.. _new-features-39:
+.. _new-features-40:
 
 New features
 ~~~~~~~~~~~~
@@ -1385,7 +1408,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-44:
+.. _bug-fixes-45:
 
 Bug fixes
 ~~~~~~~~~
@@ -1434,7 +1457,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-40:
+.. _new-features-41:
 
 New features
 ~~~~~~~~~~~~
@@ -1454,7 +1477,7 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-45:
+.. _bug-fixes-46:
 
 Bug fixes
 ~~~~~~~~~
@@ -1466,7 +1489,7 @@ Bug fixes
 0.19.5 - 2019-02-26
 -------------------
 
-.. _new-features-41:
+.. _new-features-42:
 
 New features
 ~~~~~~~~~~~~
@@ -1481,7 +1504,7 @@ New features
 0.19.4 - 2019-02-25
 -------------------
 
-.. _bug-fixes-46:
+.. _bug-fixes-47:
 
 Bug fixes
 ~~~~~~~~~
@@ -1493,7 +1516,7 @@ Bug fixes
 0.19.3 - 2019-02-25
 -------------------
 
-.. _new-features-42:
+.. _new-features-43:
 
 New features
 ~~~~~~~~~~~~
@@ -1510,7 +1533,7 @@ New features
 0.19.2 - 2019-02-22
 -------------------
 
-.. _new-features-43:
+.. _new-features-44:
 
 New features
 ~~~~~~~~~~~~
@@ -1518,7 +1541,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-47:
+.. _bug-fixes-48:
 
 Bug fixes
 ~~~~~~~~~
@@ -1533,7 +1556,7 @@ Bug fixes
 0.19.1 - 2019-02-21
 -------------------
 
-.. _new-features-44:
+.. _new-features-45:
 
 New features
 ~~~~~~~~~~~~
@@ -1555,7 +1578,7 @@ API changes
 0.19.0 - 2019-02-20
 -------------------
 
-.. _new-features-45:
+.. _new-features-46:
 
 New features
 ~~~~~~~~~~~~
@@ -1594,7 +1617,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-48:
+.. _bug-fixes-49:
 
 Bug Fixes
 ~~~~~~~~~

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.25.6 - unreleased
+0.25.6 - 2020-10-26
 -------------------
 
 New features
@@ -19,6 +19,8 @@ Bug fixes
    call ``plt.tight_layout()`` at the very end of your script.
 -  Fix bug in ``KaplanMeierFitter``\ ’s interval censoring where
    max(lower bound) < min(upper bound).
+
+.. _section-1:
 
 0.25.5 - 2020-09-23
 -------------------
@@ -41,7 +43,7 @@ Bug fixes
    parametric models
 -  ``weights`` wasn’t being applied properly in NPMLE
 
-.. _section-1:
+.. _section-2:
 
 0.25.4 - 2020-08-26
 -------------------
@@ -63,7 +65,7 @@ Bug fixes
 
 -  fix ``check_assumptions`` when using formulas.
 
-.. _section-2:
+.. _section-3:
 
 0.25.3 - 2020-08-24
 -------------------
@@ -94,7 +96,7 @@ Bug fixes
 -  fix Python error when calling ``plot_covariate_groups``
 -  fix dtype mismatches in ``plot_partial_effects_on_outcome``.
 
-.. _section-3:
+.. _section-4:
 
 0.25.2 - 2020-08-08
 -------------------
@@ -128,7 +130,7 @@ Bug fixes
 -  fix some exception imports I missed.
 -  fix log-likelihood p-value in splines ``CoxPHFitter``
 
-.. _section-4:
+.. _section-5:
 
 0.25.1 - 2020-08-01
 -------------------
@@ -144,7 +146,7 @@ Bug fixes
 -  put ``patsy`` as a proper dependency.
 -  suppress some Pandas 1.1 warnings.
 
-.. _section-5:
+.. _section-6:
 
 0.25.0 - 2020-07-27
 -------------------
@@ -222,7 +224,7 @@ Bug fixes
 -  fixed NaN bug in ``survival_table_from_events`` with intervals when
    no events would occur in a interval.
 
-.. _section-6:
+.. _section-7:
 
 0.24.16 - 2020-07-09
 --------------------
@@ -242,7 +244,7 @@ Bug fixes
 
 -  fixed ``utils.median_survival_time`` not accepting Pandas Series.
 
-.. _section-7:
+.. _section-8:
 
 0.24.15 - 2020-07-07
 --------------------
@@ -258,7 +260,7 @@ Bug fixes
 -  fixed bug where using ``conditional_after`` and ``times`` in
    ``CoxPHFitter("spline")`` prediction methods would be ignored.
 
-.. _section-8:
+.. _section-9:
 
 0.24.14 - 2020-07-02
 --------------------
@@ -275,7 +277,7 @@ Bug fixes
 -  fixed a bug where some columns would not be displayed in
    ``print_summary``
 
-.. _section-9:
+.. _section-10:
 
 0.24.13 - 2020-06-22
 --------------------
@@ -290,7 +292,7 @@ Bug fixes
 -  fixed a bug where ``CoxPHFitter`` would fail with working with
    ``sklearn_adapter``
 
-.. _section-10:
+.. _section-11:
 
 0.24.12 - 2020-06-20
 --------------------
@@ -302,7 +304,7 @@ New features
 
 -  improved convergence of ``GeneralizedGamma(Regression)Fitter``.
 
-.. _section-11:
+.. _section-12:
 
 0.24.11 - 2020-06-17
 --------------------
@@ -330,7 +332,7 @@ API Changes
    penalized by ``penalizer`` - we now penalizing everything except
    intercept terms in linear relationships.
 
-.. _section-12:
+.. _section-13:
 
 0.24.10 - 2020-06-16
 --------------------
@@ -360,7 +362,7 @@ Bug fixes
 -  fixed a bug in initialization of some interval-censoring models ->
    better convergence.
 
-.. _section-13:
+.. _section-14:
 
 0.24.9 - 2020-06-05
 -------------------
@@ -383,7 +385,7 @@ Bug fixes
 -  Cleared up some mislabeling in ``plot_loglogs``. Thanks @sean-reed!
 -  tuples are now able to be used as input in univariate models.
 
-.. _section-14:
+.. _section-15:
 
 0.24.8 - 2020-05-17
 -------------------
@@ -397,7 +399,7 @@ New features
    Not all edge cases are fully checked, and some features are missing.
    Try it under ``KaplanMeierFitter.fit_interval_censoring``
 
-.. _section-15:
+.. _section-16:
 
 0.24.7 - 2020-05-17
 -------------------
@@ -418,7 +420,7 @@ New features
 -  some convergence tweaks which should help recent performance
    regressions.
 
-.. _section-16:
+.. _section-17:
 
 0.24.6 - 2020-05-05
 -------------------
@@ -441,7 +443,7 @@ Bug fixes
 -  fixed bug where ``cdf_plot`` and ``qq_plot`` were not factoring in
    the weights correctly.
 
-.. _section-17:
+.. _section-18:
 
 0.24.5 - 2020-05-01
 -------------------
@@ -463,7 +465,7 @@ Bug fixes
 -  Improved ``at_risk_counts`` for subplots.
 -  More data validation checks for ``CoxTimeVaryingFitter``
 
-.. _section-18:
+.. _section-19:
 
 0.24.4 - 2020-04-13
 -------------------
@@ -477,7 +479,7 @@ Bug fixes
 -  setting a dataframe in ``ancillary_df`` works for interval censoring
 -  ``.score`` works for interval censored models
 
-.. _section-19:
+.. _section-20:
 
 0.24.3 - 2020-03-25
 -------------------
@@ -500,7 +502,7 @@ Bug fixes
 -  Fixed error in HTML printer that was hiding concordance index
    information.
 
-.. _section-20:
+.. _section-21:
 
 0.24.2 - 2020-03-15
 -------------------
@@ -517,7 +519,7 @@ Bug fixes
 -  Fixed a keyword bug in ``plot_covariate_groups`` for parametric
    models.
 
-.. _section-21:
+.. _section-22:
 
 0.24.1 - 2020-03-05
 -------------------
@@ -537,7 +539,7 @@ Bug fixes
 
 -  Fixed bug with plotting hazards in NelsonAalenFitter.
 
-.. _section-22:
+.. _section-23:
 
 0.24.0 - 2020-02-20
 -------------------
@@ -611,7 +613,7 @@ Bug fixes
 -  Cox models now incorporate any penalizers in their
    ``log_likelihood_``
 
-.. _section-23:
+.. _section-24:
 
 0.23.9 - 2020-01-28
 -------------------
@@ -627,7 +629,7 @@ Bug fixes
    of ``GeneralizedGammaRegressionFitter`` and any custom regression
    models should update their code as soon as possible.
 
-.. _section-24:
+.. _section-25:
 
 0.23.8 - 2020-01-21
 -------------------
@@ -643,14 +645,14 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-25:
+.. _section-26:
 
 0.23.7 - 2020-01-14
 -------------------
 
 Bug fixes for py3.5.
 
-.. _section-26:
+.. _section-27:
 
 0.23.6 - 2020-01-07
 -------------------
@@ -669,7 +671,7 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-27:
+.. _section-28:
 
 0.23.5 - 2020-01-05
 -------------------
@@ -693,14 +695,14 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-28:
+.. _section-29:
 
 0.23.4 - 2019-12-15
 -------------------
 
 -  Bug fix for PyPI
 
-.. _section-29:
+.. _section-30:
 
 0.23.3 - 2019-12-11
 -------------------
@@ -720,7 +722,7 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-30:
+.. _section-31:
 
 0.23.2 - 2019-12-07
 -------------------
@@ -746,7 +748,7 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-31:
+.. _section-32:
 
 0.23.1 - 2019-11-27
 -------------------
@@ -773,7 +775,7 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-32:
+.. _section-33:
 
 0.23.0 - 2019-11-17
 -------------------
@@ -809,7 +811,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-33:
+.. _section-34:
 
 0.22.10 - 2019-11-08
 --------------------
@@ -827,7 +829,7 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-34:
+.. _section-35:
 
 0.22.9 - 2019-10-30
 -------------------
@@ -844,7 +846,7 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-35:
+.. _section-36:
 
 0.22.8 - 2019-10-06
 -------------------
@@ -866,7 +868,7 @@ Bug fixes
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-36:
+.. _section-37:
 
 0.22.7 - 2019-09-29
 -------------------
@@ -898,7 +900,7 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-37:
+.. _section-38:
 
 0.22.6 - 2019-09-25
 -------------------
@@ -926,7 +928,7 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-38:
+.. _section-39:
 
 0.22.5 - 2019-09-20
 -------------------
@@ -957,7 +959,7 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-39:
+.. _section-40:
 
 0.22.4 - 2019-09-04
 -------------------
@@ -989,7 +991,7 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-40:
+.. _section-41:
 
 0.22.3 - 2019-08-08
 -------------------
@@ -1030,7 +1032,7 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-41:
+.. _section-42:
 
 0.22.2 - 2019-07-25
 -------------------
@@ -1053,7 +1055,7 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-42:
+.. _section-43:
 
 0.22.1 - 2019-07-14
 -------------------
@@ -1096,7 +1098,7 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-43:
+.. _section-44:
 
 0.22.0 - 2019-07-03
 -------------------
@@ -1144,7 +1146,7 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-44:
+.. _section-45:
 
 0.21.5 - 2019-06-22
 -------------------
@@ -1168,7 +1170,7 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-45:
+.. _section-46:
 
 0.21.3 - 2019-06-04
 -------------------
@@ -1194,7 +1196,7 @@ Bug fixes
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-46:
+.. _section-47:
 
 0.21.2 - 2019-05-16
 -------------------
@@ -1228,7 +1230,7 @@ API changes
 Bug fixes
 ~~~~~~~~~
 
-.. _section-47:
+.. _section-48:
 
 0.21.1 - 2019-04-26
 -------------------
@@ -1257,7 +1259,7 @@ Bug fixes
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-48:
+.. _section-49:
 
 0.21.0 - 2019-04-12
 -------------------
@@ -1297,7 +1299,7 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-49:
+.. _section-50:
 
 0.20.5 - 2019-04-08
 -------------------
@@ -1328,7 +1330,7 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-50:
+.. _section-51:
 
 0.20.4 - 2019-03-27
 -------------------
@@ -1361,7 +1363,7 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-51:
+.. _section-52:
 
 0.20.3 - 2019-03-23
 -------------------
@@ -1379,7 +1381,7 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-52:
+.. _section-53:
 
 0.20.2 - 2019-03-21
 -------------------
@@ -1424,7 +1426,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-53:
+.. _section-54:
 
 0.20.1 - 2019-03-16
 -------------------
@@ -1448,7 +1450,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-54:
+.. _section-55:
 
 0.20.0 - 2019-03-05
 -------------------
@@ -1484,7 +1486,7 @@ Bug fixes
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-55:
+.. _section-56:
 
 0.19.5 - 2019-02-26
 -------------------
@@ -1499,7 +1501,7 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-56:
+.. _section-57:
 
 0.19.4 - 2019-02-25
 -------------------
@@ -1511,7 +1513,7 @@ Bug fixes
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-57:
+.. _section-58:
 
 0.19.3 - 2019-02-25
 -------------------
@@ -1528,7 +1530,7 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-58:
+.. _section-59:
 
 0.19.2 - 2019-02-22
 -------------------
@@ -1551,7 +1553,7 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-59:
+.. _section-60:
 
 0.19.1 - 2019-02-21
 -------------------
@@ -1573,7 +1575,7 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-60:
+.. _section-61:
 
 0.19.0 - 2019-02-20
 -------------------
@@ -1634,7 +1636,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-61:
+.. _section-62:
 
 0.18.6 - 2019-02-13
 -------------------
@@ -1644,7 +1646,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-62:
+.. _section-63:
 
 0.18.5 - 2019-02-11
 -------------------
@@ -1665,7 +1667,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-63:
+.. _section-64:
 
 0.18.4 - 2019-02-10
 -------------------
@@ -1675,7 +1677,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-64:
+.. _section-65:
 
 0.18.3 - 2019-02-07
 -------------------
@@ -1685,7 +1687,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-65:
+.. _section-66:
 
 0.18.2 - 2019-02-05
 -------------------
@@ -1701,7 +1703,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-66:
+.. _section-67:
 
 0.18.1 - 2019-02-02
 -------------------
@@ -1712,7 +1714,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-67:
+.. _section-68:
 
 0.18.0 - 2019-01-31
 -------------------
@@ -1749,7 +1751,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-68:
+.. _section-69:
 
 0.17.5 - 2019-01-25
 -------------------
@@ -1757,7 +1759,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-69:
+.. _section-70:
 
 0.17.4 -2019-01-25
 ------------------
@@ -1769,7 +1771,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-70:
+.. _section-71:
 
 0.17.3 - 2019-01-24
 -------------------
@@ -1777,7 +1779,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-71:
+.. _section-72:
 
 0.17.2 2019-01-22
 -----------------
@@ -1788,7 +1790,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-72:
+.. _section-73:
 
 0.17.1 - 2019-01-20
 -------------------
@@ -1805,7 +1807,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-73:
+.. _section-74:
 
 0.17.0 - 2019-01-11
 -------------------
@@ -1826,7 +1828,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-74:
+.. _section-75:
 
 0.16.3 - 2019-01-03
 -------------------
@@ -1834,7 +1836,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-75:
+.. _section-76:
 
 0.16.2 - 2019-01-02
 -------------------
@@ -1845,14 +1847,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-76:
+.. _section-77:
 
 0.16.1 - 2019-01-01
 -------------------
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-77:
+.. _section-78:
 
 0.16.0 - 2019-01-01
 -------------------
@@ -1888,7 +1890,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-78:
+.. _section-79:
 
 0.15.4
 ------
@@ -1896,14 +1898,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-79:
+.. _section-80:
 
 0.15.3 - 2018-12-18
 -------------------
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-80:
+.. _section-81:
 
 0.15.2 - 2018-11-23
 -------------------
@@ -1914,7 +1916,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-81:
+.. _section-82:
 
 0.15.1 - 2018-11-23
 -------------------
@@ -1923,7 +1925,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-82:
+.. _section-83:
 
 0.15.0 - 2018-11-22
 -------------------
@@ -1994,7 +1996,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-83:
+.. _section-84:
 
 0.14.6 - 2018-07-02
 -------------------
@@ -2002,7 +2004,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-84:
+.. _section-85:
 
 0.14.5 - 2018-06-29
 -------------------
@@ -2010,7 +2012,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-85:
+.. _section-86:
 
 0.14.4 - 2018-06-14
 -------------------
@@ -2027,7 +2029,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-86:
+.. _section-87:
 
 0.14.3 - 2018-05-24
 -------------------
@@ -2039,7 +2041,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-87:
+.. _section-88:
 
 0.14.2 - 2018-05-18
 -------------------
@@ -2047,7 +2049,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-88:
+.. _section-89:
 
 0.14.1 - 2018-04-01
 -------------------
@@ -2065,7 +2067,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-89:
+.. _section-90:
 
 0.14.0 - 2018-03-03
 -------------------
@@ -2087,7 +2089,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-90:
+.. _section-91:
 
 0.13.0 - 2017-12-22
 -------------------
@@ -2116,7 +2118,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-91:
+.. _section-92:
 
 0.12.0
 ------
@@ -2133,7 +2135,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-92:
+.. _section-93:
 
 0.11.3
 ------
@@ -2145,7 +2147,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-93:
+.. _section-94:
 
 0.11.2
 ------
@@ -2153,14 +2155,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-94:
+.. _section-95:
 
 0.11.1 - 2017-06-22
 -------------------
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-95:
+.. _section-96:
 
 0.11.0 - 2017-06-21
 -------------------
@@ -2174,14 +2176,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-96:
+.. _section-97:
 
 0.10.1 - 2017-06-05
 -------------------
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-97:
+.. _section-98:
 
 0.10.0
 ------
@@ -2196,7 +2198,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-98:
+.. _section-99:
 
 0.9.4
 -----
@@ -2219,7 +2221,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-99:
+.. _section-100:
 
 0.9.2
 -----
@@ -2228,7 +2230,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-100:
+.. _section-101:
 
 0.9.1
 -----
@@ -2236,7 +2238,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-101:
+.. _section-102:
 
 0.9.0
 -----
@@ -2252,7 +2254,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-102:
+.. _section-103:
 
 0.8.1 - 2015-08-01
 ------------------
@@ -2269,7 +2271,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-103:
+.. _section-104:
 
 0.8.0
 -----
@@ -2288,7 +2290,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-104:
+.. _section-105:
 
 0.7.1
 -----
@@ -2307,7 +2309,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-105:
+.. _section-106:
 
 0.7.0 - 2015-03-01
 ------------------
@@ -2326,7 +2328,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-106:
+.. _section-107:
 
 0.6.1
 -----
@@ -2338,7 +2340,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-107:
+.. _section-108:
 
 0.6.0 - 2015-02-04
 ------------------
@@ -2361,7 +2363,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-108:
+.. _section-109:
 
 0.5.1 - 2014-12-24
 ------------------
@@ -2382,7 +2384,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-109:
+.. _section-110:
 
 0.5.0 - 2014-12-07
 ------------------
@@ -2395,7 +2397,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-110:
+.. _section-111:
 
 0.4.4 - 2014-11-27
 ------------------
@@ -2407,7 +2409,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-111:
+.. _section-112:
 
 0.4.3 - 2014-07-23
 ------------------
@@ -2428,7 +2430,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-112:
+.. _section-113:
 
 0.4.2 - 2014-06-19
 ------------------
@@ -2448,7 +2450,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-113:
+.. _section-114:
 
 0.4.1.1
 -------
@@ -2461,7 +2463,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-114:
+.. _section-115:
 
 0.4.1 - 2014-06-11
 ------------------
@@ -2480,7 +2482,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-115:
+.. _section-116:
 
 0.4.0 - 2014-06-08
 ------------------

--- a/docs/Examples.rst
+++ b/docs/Examples.rst
@@ -431,6 +431,7 @@ Displaying at-risk counts below plots
 
     kmf.fit(T, E, label="label name")
     kmf.plot(at_risk_counts=True)
+    plt.tight_layout()
 
 .. image:: /images/single_at_risk_plots.png
     :width: 500px
@@ -460,6 +461,7 @@ The function :func:`lifelines.plotting.add_at_risk_counts` allows you to add cou
 
     from lifelines.plotting import add_at_risk_counts
     add_at_risk_counts(kmf_exp, kmf_control, ax=ax)
+    plt.tight_layout()
 
 will display
 

--- a/docs/Survival analysis with lifelines.rst
+++ b/docs/Survival analysis with lifelines.rst
@@ -278,6 +278,7 @@ In *lifelines*, confidence intervals are automatically added, but there is the `
 
     kmf = KaplanMeierFitter().fit(T, E, label="all_regimes")
     kmf.plot(at_risk_counts=True)
+    plt.tight_layout()
 
 
 .. image:: images/intro_add_at_risk.png

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -2967,7 +2967,11 @@ class ParametricSplinePHFitter(ParametricCoxModelFitter, SplineFitterMixin):
         return
 
     def _pre_fit_model(self, Ts, E, df):
-        self._set_knots(Ts[0], E)
+        if E.sum() > 4:
+            self._set_knots(utils.coalesce(*Ts), E)
+        else:
+            # very few observations
+            self._set_knots(utils.coalesce(*Ts), pd.Series(np.ones_like(E)))
 
     def _create_initial_point(self, Ts, E, entries, weights, Xs):
         #  Some non-zero initial points. This is important as it nudges the model slightly away from the degenerate all-zeros model. Try setting it to 0, and watch the model fail to converge.

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -275,7 +275,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         self.strata = utils.coalesce(strata, self.strata)
         self._model = self._fit_model(
             df,
-            (duration_col, None),
+            duration_col,
             event_col=event_col,
             show_progress=show_progress,
             initial_point=initial_point,
@@ -563,7 +563,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         self.strata = utils.coalesce(strata, self.strata)
         self._model = self._fit_model(
             df,
-            (None, duration_col),
+            duration_col,
             event_col=event_col,
             show_progress=show_progress,
             initial_point=initial_point,

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -168,7 +168,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         entry_col: str = None,
     ) -> "CoxPHFitter":
         """
-        Fit the Cox proportional hazard model to a dataset.
+        Fit the Cox proportional hazard model to a right-censored dataset. Alias of `fit_right_censoring`.
 
         Parameters
         ----------
@@ -275,7 +275,295 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         self.strata = utils.coalesce(strata, self.strata)
         self._model = self._fit_model(
             df,
-            duration_col,
+            (duration_col, None),
+            event_col=event_col,
+            show_progress=show_progress,
+            initial_point=initial_point,
+            strata=self.strata,
+            step_size=step_size,
+            weights_col=weights_col,
+            cluster_col=cluster_col,
+            robust=robust,
+            batch_mode=batch_mode,
+            timeline=timeline,
+            formula=formula,
+            entry_col=entry_col,
+        )
+        return self
+
+    @utils.CensoringType.interval_censoring
+    def fit_interval_censoring(
+        self,
+        df: pd.DataFrame,
+        lower_bound_col: str,
+        upper_bound_col: str,
+        event_col: Optional[str] = None,
+        show_progress: bool = False,
+        initial_point: Optional[ndarray] = None,
+        strata: Optional[Union[str, List[str]]] = None,
+        step_size: Optional[float] = None,
+        weights_col: Optional[str] = None,
+        cluster_col: Optional[str] = None,
+        robust: bool = False,
+        batch_mode: Optional[bool] = None,
+        timeline: Optional[Iterator] = None,
+        formula: str = None,
+        entry_col: str = None,
+    ) -> "CoxPHFitter":
+        """
+        Fit the Cox proportional hazard model to an interval censored dataset.
+
+        Parameters
+        ----------
+        df: DataFrame
+            a Pandas DataFrame with necessary columns `duration_col` and
+            `event_col` (see below), covariates columns, and special columns (weights, strata).
+            `duration_col` refers to
+            the lifetimes of the subjects. `event_col` refers to whether
+            the 'death' events was observed: 1 if observed, 0 else (censored).
+
+        lower_bound_col: string
+            the name of the column in DataFrame that contains the lower bounds of the intervals.
+
+        upper_bound_col: string
+            the name of the column in DataFrame that contains the upper bounds of the intervals.
+
+        event_col: string, optional
+            the  name of the column in DataFrame that contains the subjects' death
+            observation. If left as None, this is inferred based on the upper and lower interval limits (equal
+            implies observed death.)
+
+        weights_col: string, optional
+            an optional column in the DataFrame, df, that denotes the weight per subject.
+            This column is expelled and not used as a covariate, but as a weight in the
+            final regression. Default weight is 1.
+            This can be used for case-weights. For example, a weight of 2 means there were two subjects with
+            identical observations.
+            This can be used for sampling weights. In that case, use ``robust=True`` to get more accurate standard errors.
+
+        cluster_col: string, optional
+            specifies what column has unique identifiers for clustering covariances. Using this forces the sandwich estimator (robust variance estimator) to
+            be used.
+
+        entry_col: str, optional
+            a column denoting when a subject entered the study, i.e. left-truncation.
+
+        strata: list or string, optional
+            specify a column or list of columns n to use in stratification. This is useful if a
+            categorical covariate does not obey the proportional hazard assumption. This
+            is used similar to the ``strata`` expression in R.
+            See http://courses.washington.edu/b515/l17.pdf.
+
+        robust: bool, optional (default=False)
+            Compute the robust errors using the Huber sandwich estimator, aka Wei-Lin estimate. This does not handle
+            ties, so if there are high number of ties, results may significantly differ. See
+            "The Robust Inference for the Cox Proportional Hazards Model", Journal of the American Statistical Association, Vol. 84, No. 408 (Dec., 1989), pp. 1074- 1078
+
+        formula: str, optional
+            an Wilkinson formula, like in R and statsmodels, for the right-hand-side. If left as None, all columns not assigned as durations, weights, etc. are used.
+
+        batch_mode: bool, optional
+            enabling batch_mode can be faster for datasets with a large number of ties. If left as None, lifelines will choose the best option.
+
+        step_size: float, optional
+            set an initial step size for the fitting algorithm. Setting to 1.0 may improve performance, but could also hurt convergence.
+
+        show_progress: bool, optional (default=False)
+            since the fitter is iterative, show convergence
+            diagnostics. Useful if convergence is failing.
+
+        initial_point: (d,) numpy array, optional
+            initialize the starting point of the iterative
+            algorithm. Default is the zero vector.
+
+        Returns
+        -------
+        self: CoxPHFitter
+            self with additional new properties: ``print_summary``, ``hazards_``, ``confidence_intervals_``, ``baseline_survival_``, etc.
+
+
+        Examples
+        --------
+        .. code:: python
+
+            from lifelines import CoxPHFitter
+
+            df = pd.DataFrame({
+                'T': [5, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+                'E': [1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0],
+                'var': [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2],
+                'age': [4, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+            })
+
+            cph = CoxPHFitter()
+            cph.fit(df, 'T', 'E')
+            cph.print_summary()
+            cph.predict_median(df)
+
+        .. code:: python
+
+            from lifelines import CoxPHFitter
+
+            df = pd.DataFrame({
+                'T': [5, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+                'E': [1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0],
+                'var': [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2],
+                'weights': [1.1, 0.5, 2.0, 1.6, 1.2, 4.3, 1.4, 4.5, 3.0, 3.2, 0.4, 6.2],
+                'month': [10, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+                'age': [4, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+            })
+
+            cph = CoxPHFitter()
+            cph.fit(df, 'T', 'E', strata=['month', 'age'], robust=True, weights_col='weights')
+            cph.print_summary()
+
+        """
+        self.strata = utils.coalesce(strata, self.strata)
+        self._model = self._fit_model(
+            df,
+            (lower_bound_col, upper_bound_col),
+            event_col=event_col,
+            show_progress=show_progress,
+            initial_point=initial_point,
+            strata=self.strata,
+            step_size=step_size,
+            weights_col=weights_col,
+            cluster_col=cluster_col,
+            robust=robust,
+            batch_mode=batch_mode,
+            timeline=timeline,
+            formula=formula,
+            entry_col=entry_col,
+        )
+        return self
+
+    @utils.CensoringType.left_censoring
+    def fit_left_censoring(
+        self,
+        df: pd.DataFrame,
+        duration_col: Optional[str] = None,
+        event_col: Optional[str] = None,
+        show_progress: bool = False,
+        initial_point: Optional[ndarray] = None,
+        strata: Optional[Union[str, List[str]]] = None,
+        step_size: Optional[float] = None,
+        weights_col: Optional[str] = None,
+        cluster_col: Optional[str] = None,
+        robust: bool = False,
+        batch_mode: Optional[bool] = None,
+        timeline: Optional[Iterator] = None,
+        formula: str = None,
+        entry_col: str = None,
+    ) -> "CoxPHFitter":
+        """
+        Fit the Cox proportional hazard model to a left censored dataset.
+
+        Parameters
+        ----------
+        df: DataFrame
+            a Pandas DataFrame with necessary columns `duration_col` and
+            `event_col` (see below), covariates columns, and special columns (weights, strata).
+            `duration_col` refers to
+            the lifetimes of the subjects. `event_col` refers to whether
+            the 'death' events was observed: 1 if observed, 0 else (censored).
+
+        duration_col: string
+            the name of the column in DataFrame that contains the subjects'
+            lifetimes.
+
+        event_col: string, optional
+            the  name of the column in DataFrame that contains the subjects' death
+            observation. If left as None, assume all individuals are uncensored.
+
+        weights_col: string, optional
+            an optional column in the DataFrame, df, that denotes the weight per subject.
+            This column is expelled and not used as a covariate, but as a weight in the
+            final regression. Default weight is 1.
+            This can be used for case-weights. For example, a weight of 2 means there were two subjects with
+            identical observations.
+            This can be used for sampling weights. In that case, use ``robust=True`` to get more accurate standard errors.
+
+        cluster_col: string, optional
+            specifies what column has unique identifiers for clustering covariances. Using this forces the sandwich estimator (robust variance estimator) to
+            be used.
+
+        entry_col: str, optional
+            a column denoting when a subject entered the study, i.e. left-truncation.
+
+        strata: list or string, optional
+            specify a column or list of columns n to use in stratification. This is useful if a
+            categorical covariate does not obey the proportional hazard assumption. This
+            is used similar to the ``strata`` expression in R.
+            See http://courses.washington.edu/b515/l17.pdf.
+
+        robust: bool, optional (default=False)
+            Compute the robust errors using the Huber sandwich estimator, aka Wei-Lin estimate. This does not handle
+            ties, so if there are high number of ties, results may significantly differ. See
+            "The Robust Inference for the Cox Proportional Hazards Model", Journal of the American Statistical Association, Vol. 84, No. 408 (Dec., 1989), pp. 1074- 1078
+
+        formula: str, optional
+            an Wilkinson formula, like in R and statsmodels, for the right-hand-side. If left as None, all columns not assigned as durations, weights, etc. are used.
+
+        batch_mode: bool, optional
+            enabling batch_mode can be faster for datasets with a large number of ties. If left as None, lifelines will choose the best option.
+
+        step_size: float, optional
+            set an initial step size for the fitting algorithm. Setting to 1.0 may improve performance, but could also hurt convergence.
+
+        show_progress: bool, optional (default=False)
+            since the fitter is iterative, show convergence
+            diagnostics. Useful if convergence is failing.
+
+        initial_point: (d,) numpy array, optional
+            initialize the starting point of the iterative
+            algorithm. Default is the zero vector.
+
+        Returns
+        -------
+        self: CoxPHFitter
+            self with additional new properties: ``print_summary``, ``hazards_``, ``confidence_intervals_``, ``baseline_survival_``, etc.
+
+
+        Examples
+        --------
+        .. code:: python
+
+            from lifelines import CoxPHFitter
+
+            df = pd.DataFrame({
+                'T': [5, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+                'E': [1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0],
+                'var': [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2],
+                'age': [4, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+            })
+
+            cph = CoxPHFitter()
+            cph.fit(df, 'T', 'E')
+            cph.print_summary()
+            cph.predict_median(df)
+
+        .. code:: python
+
+            from lifelines import CoxPHFitter
+
+            df = pd.DataFrame({
+                'T': [5, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+                'E': [1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0],
+                'var': [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2],
+                'weights': [1.1, 0.5, 2.0, 1.6, 1.2, 4.3, 1.4, 4.5, 3.0, 3.2, 0.4, 6.2],
+                'month': [10, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+                'age': [4, 3, 9, 8, 7, 4, 4, 3, 2, 5, 6, 7],
+            })
+
+            cph = CoxPHFitter()
+            cph.fit(df, 'T', 'E', strata=['month', 'age'], robust=True, weights_col='weights')
+            cph.print_summary()
+
+        """
+        self.strata = utils.coalesce(strata, self.strata)
+        self._model = self._fit_model(
+            df,
+            (None, duration_col),
             event_col=event_col,
             show_progress=show_progress,
             initial_point=initial_point,
@@ -318,8 +606,13 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         model = SemiParametricPHFitter(
             penalizer=self.penalizer, l1_ratio=self.l1_ratio, strata=self.strata, alpha=self.alpha, label=self._label
         )
-        model.fit(*args, **kwargs)
-        return model
+        if utils.CensoringType.is_right_censoring(self):
+            model.fit(*args, **kwargs)
+            return model
+        else:
+            raise ValueError(
+                "Left or interval censoring is not supported for the semi-parametric Cox model. Try changing the baseline estimation method to something else, ex: `CoxPHFitter(baseline_estimation_method='spline').fit_...."
+            )
 
     def _fit_model_piecewise(self, *args, **kwargs):
         df = args[0].copy()
@@ -365,7 +658,13 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
             alpha=self.alpha,
             label=self._label,
         )
-        model.fit(df, *args[1:], regressors=regressors, **kwargs)
+        if utils.CensoringType.is_right_censoring(self):
+            model.fit_right_censoring(df, *args[1:], regressors=regressors, **kwargs)
+        elif utils.CensoringType.is_left_censoring(self):
+            model.fit_left_censoring(df, *args[1:], regressors=regressors, **kwargs)
+        elif utils.CensoringType.is_interval_censoring(self):
+            lb, ub = args[1]
+            model.fit_interval_censoring(df, lb, ub, *args[2:], regressors=regressors, **kwargs)
         return model
 
     def _fit_model_spline(self, *args, **kwargs):
@@ -414,7 +713,13 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
             alpha=self.alpha,
             label=self._label,
         )
-        model.fit(df, *args[1:], regressors=regressors, **kwargs)
+        if utils.CensoringType.is_right_censoring(self):
+            model.fit_right_censoring(df, *args[1:], regressors=regressors, **kwargs)
+        elif utils.CensoringType.is_left_censoring(self):
+            model.fit_left_censoring(df, *args[1:], regressors=regressors, **kwargs)
+        elif utils.CensoringType.is_interval_censoring(self):
+            lb, ub = args[1]
+            model.fit_interval_censoring(df, lb, ub, *args[2:], regressors=regressors, **kwargs)
         return model
 
     def print_summary(self, decimals=2, style=None, columns=None, **kwargs):
@@ -439,7 +744,12 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         justify = utils.string_rjustify(25)
 
         headers = []
-        headers.append(("duration col", "'%s'" % self.duration_col))
+
+        if utils.CensoringType.is_interval_censoring(self):
+            headers.append(("lower bound col", "'%s'" % self.lower_bound_col))
+            headers.append(("upper bound col", "'%s'" % self.upper_bound_col))
+        else:
+            headers.append(("duration col", "'%s'" % self.duration_col))
 
         if self.event_col:
             headers.append(("event col", "'%s'" % self.event_col))

--- a/lifelines/fitters/crc_spline_fitter.py
+++ b/lifelines/fitters/crc_spline_fitter.py
@@ -20,8 +20,9 @@ class CRCSplineFitter(SplineFitterMixin, ParametricRegressionFitter):
     n_baseline_knots: int
         the number of knots in the cubic spline. If equal to 2, then the model is equal to the WeibullAFT model.
 
-    Reference
-    ----------
+
+    References
+    ------------
     Crowther MJ, Royston P, Clements M. A flexible parametric accelerated failure time model.
 
 

--- a/lifelines/fitters/npmle.py
+++ b/lifelines/fitters/npmle.py
@@ -221,7 +221,6 @@ def scipy_minimize_fit(turnbull_interval_lookup, turnbull_intervals, weights, to
 def expectation_maximization_fit(
     observation_intervals, turnbull_intervals, turnbull_lookup, weights, tol, max_iter, optimize, verbose
 ):
-
     # convergence init
     converged = False
     i = 0
@@ -235,7 +234,7 @@ def expectation_maximization_fit(
         converged = check_convergence(new_p, p, turnbull_lookup, weights, tol, i, verbose=verbose)
 
         # find alpha that maximizes ll using a line search
-        best_p, best_ll = None, -np.inf
+        best_p, best_ll = p, -np.inf
         delta = log_odds(new_p) - log_odds(p)
         for alpha in np.array([1.0, 1.25, 1.95]):
             p_temp = probs(log_odds(p) + alpha * delta)
@@ -249,7 +248,7 @@ def expectation_maximization_fit(
         i += 1
 
     if i >= max_iter:
-        warnings.warn("Exceeded max iterations", ConvergenceWarning)
+        warnings.warn("Exceeded max iterations.", ConvergenceWarning)
 
     return p
 

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -443,7 +443,7 @@ def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None,
     # Move the ticks below existing axes
     # Appropriate length scaled for 6 inches. Adjust for figure size.
     ax_height = (ax.get_position().y1 - ax.get_position().y0) * fig.get_figheight()  # axis height
-    ax2_ypos = -ypos / ax_height
+    ax2_ypos = ypos / ax_height
 
     move_spines(ax2, ["bottom"], [ax2_ypos])
     # Hide all fluff

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -363,10 +363,12 @@ def remove_ticks(ax, x=False, y=False):
     return ax
 
 
-def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None, rows_to_show=None, ax=None, **kwargs):
+def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None, rows_to_show=None, ypos=-0.6, ax=None, **kwargs):
     """
     Add counts showing how many individuals were at risk, censored, and observed, at each time point in
     survival/hazard plots.
+
+    Tip: you may want to call ``plt.tight_layout()`` afterwards.
 
     Parameters
     ----------
@@ -380,6 +382,8 @@ def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None,
         False for no labels.
     rows_to_show: list
         list of a subset of {'At risk', 'Censored', 'Events'}. Default shows all columns.
+    ypos:
+        increase to move the table down further.
 
     Returns
     --------
@@ -439,7 +443,8 @@ def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None,
     # Move the ticks below existing axes
     # Appropriate length scaled for 6 inches. Adjust for figure size.
     ax_height = (ax.get_position().y1 - ax.get_position().y0) * fig.get_figheight()  # axis height
-    ax2_ypos = -0.1 * 3.0 / ax_height
+    ax2_ypos = -ypos / ax_height
+
     move_spines(ax2, ["bottom"], [ax2_ypos])
     # Hide all fluff
     remove_spines(ax2, ["top", "right", "bottom", "left"])
@@ -505,7 +510,6 @@ def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None,
     # Align labels to the right so numbers can be compared easily
     ax2.set_xticklabels(ticklabels, ha="right", **kwargs)
 
-    plt.tight_layout()
     return ax
 
 
@@ -892,6 +896,7 @@ def _plot_estimate(
 
     if at_risk_counts:
         add_at_risk_counts(cls, ax=plot_estimate_config.ax)
+        plt.tight_layout()
 
     return plot_estimate_config.ax
 

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -2872,11 +2872,24 @@ class TestCoxPHFitter:
 
     @pytest.fixture
     def cph_spline(self):
-        return CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2)
+        return CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=3)
 
     @pytest.fixture
     def cph_pieces(self):
         return CoxPHFitter(baseline_estimation_method="piecewise", breakpoints=[25])
+
+    def test_parametric_models_can_do_left_and_right_censoring(self, cph_spline, cph_pieces):
+        df = load_diabetes().loc[:100]
+        df["gender"] = df["gender"] == "male"
+        df["gender"] = df["gender"].astype(int)
+
+        cph_spline = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2, penalizer=0.001)
+        # cph_spline._scipy_fit_method = "BFGS"
+        cph_spline.fit_interval_censoring(df, "left", "right", formula="gender + 1", show_progress=True)
+        cph_spline.print_summary()
+
+        cph_pieces.fit_interval_censoring(df, "left", "right")
+        cph_spline.print_summary()
 
     def test_parametric_strata_null_dof(self, cph_spline, cph_pieces, rossi):
         cph_spline.fit(rossi, "week", "arrest", strata="paro", formula="age")

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -2872,23 +2872,37 @@ class TestCoxPHFitter:
 
     @pytest.fixture
     def cph_spline(self):
-        return CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=3)
+        return CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2)
 
     @pytest.fixture
     def cph_pieces(self):
         return CoxPHFitter(baseline_estimation_method="piecewise", breakpoints=[25])
 
-    def test_parametric_models_can_do_left_and_right_censoring(self, cph_spline, cph_pieces):
-        df = load_diabetes().loc[:100]
+    def test_parametric_models_can_do_interval_censoring(self, cph_spline, cph_pieces):
+        df = load_diabetes()
         df["gender"] = df["gender"] == "male"
         df["gender"] = df["gender"].astype(int)
 
         cph_spline = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2, penalizer=0.001)
-        # cph_spline._scipy_fit_method = "BFGS"
         cph_spline.fit_interval_censoring(df, "left", "right", formula="gender + 1", show_progress=True)
         cph_spline.print_summary()
 
         cph_pieces.fit_interval_censoring(df, "left", "right")
+        cph_spline.print_summary()
+
+    def test_parametric_models_can_do_left_censoring(self, cph_spline, cph_pieces):
+        df = load_diabetes()
+        df = df.drop("left", axis=1)
+        df["E"] = 0
+
+        df["gender"] = df["gender"] == "male"
+        df["gender"] = df["gender"].astype(int)
+
+        cph_spline = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2, penalizer=0.001)
+        cph_spline.fit_left_censoring(df, "right", "E", formula="gender + 1")
+        cph_spline.print_summary()
+
+        cph_pieces.fit_left_censoring(df, "right", "E")
         cph_spline.print_summary()
 
     def test_parametric_strata_null_dof(self, cph_spline, cph_pieces, rossi):

--- a/lifelines/tests/test_npmle.py
+++ b/lifelines/tests/test_npmle.py
@@ -3,6 +3,7 @@ import pytest
 from lifelines.fitters.npmle import npmle, is_subset, create_turnbull_intervals, interval, reconstruct_survival_function
 from numpy import testing as npt
 from lifelines.datasets import load_mice
+from lifelines import KaplanMeierFitter
 import numpy as np
 import pandas as pd
 
@@ -77,3 +78,21 @@ def test_mice_scipy():
     results = npmle(df["l"], df["u"], verbose=True, fit_method="scipy")
     npt.assert_allclose(results[0][0], 1 - 0.8571429, rtol=1e-4)
     npt.assert_allclose(results[0][-1], 0.166667, rtol=1e-4)
+
+
+def test_max_lower_bound_less_than_min_upper_bound():
+    # https://github.com/CamDavidsonPilon/lifelines/issues/1151
+    import numpy as np
+    import pandas as pd
+    from lifelines import KaplanMeierFitter
+
+    # Data
+    np.random.seed(1)
+    left0 = np.random.normal(loc=60, scale=2, size=20)
+    add_time = np.random.normal(loc=100, scale=2, size=10)
+    right1 = left0[0:10] + add_time
+    right0 = right1.tolist() + [np.inf] * 10
+
+    # KaplanMeier
+    model = KaplanMeierFitter()
+    model.fit_interval_censoring(lower_bound=left0, upper_bound=right0)

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.25.5"
+__version__ = "0.25.6"


### PR DESCRIPTION
#### 0.25.6 - 2020-10-26

##### New features
 - Parametric Cox models can now handle left and interval censoring datasets.

##### Bug fixes
 - "improved" the output of `add_at_risk_counts` by removing a call to `plt.tight_layout()` - this works better when you are calling `add_at_risk_counts` on multiple axes, but it is recommended you call `plt.tight_layout()` at the very end of your script.
 - Fix bug in `KaplanMeierFitter`'s interval censoring where max(lower bound) < min(upper bound).

closes #1151,
closes #1158,
closes #1155 