### PR TITLE
Silence deprecation warning

### DIFF
--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1250,7 +1250,7 @@ class RegressionFitter(BaseFitter):
             return v
 
         else:
-            described = df.describe(include="all")
+            described = df.describe(include="all", datetime_is_numeric=True)
             if "top" in described.index and "50%" not in described.index:
                 central_stats = described.loc["top"].copy()
             elif "50%" in described.index and "top" not in described.index:

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1250,7 +1250,13 @@ class RegressionFitter(BaseFitter):
             return v
 
         else:
-            described = df.describe(include="all", datetime_is_numeric=True)
+            from distutils.version import LooseVersion
+            if LooseVersion(pd.__version__) >= '1.1.0':
+                # silence deprecation warning
+                describe_kwarg = {'datetime_is_numeric': True}
+            else:
+                describe_kwarg = {}
+            described = df.describe(include="all", **describe_kwarg)
             if "top" in described.index and "50%" not in described.index:
                 central_stats = described.loc["top"].copy()
             elif "50%" in described.index and "top" not in described.index:


### PR DESCRIPTION
Adopt new pandas behavior and silence deprecation warning. This can be quite noisy in fit if there's a datetime in your DataFrame for pandas >= 1.1.0.

Cf. https://github.com/pandas-dev/pandas/pull/34798