### PR TITLE
Correct Code Used in Left Censoring Example

### DIFF
--- a/docs/Survival analysis with lifelines.rst
+++ b/docs/Survival analysis with lifelines.rst
@@ -689,7 +689,7 @@ Instead of producing a survival function, left-censored data analysis is more in
 
     print(kmf.cumulative_density_.head())
 
-    kmf.plot() #will plot the CDF
+    kmf.plot_cumulative_density() #will plot the CDF
     plt.xlabel("Concentration of NH_4")
 
     """


### PR DESCRIPTION
Per conversation in Gitter channel, changing the example from kmf.plot() to kmf.plot_cumulative_density in the left-censoring example.