### PR TITLE
0.25.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Changelog
 
+#### 0.25.7 - 2020-12-09
+
+##### API Changes
+ - Adding `cumulative_hazard_at_times` to NelsonAalenFitter
+
+
+##### Bug fixes
+ - Fixed error in `CoxPHFitter` when entry time == event time.
+ - Fixed formulas in AFT interval censoring regression.
+ - Fixed `concordance_index_` when no events observed
+ - Fixed label being overwritten in ParametricUnivariate models
+
+
 #### 0.25.6 - 2020-10-26
 
 ##### New features

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+0.25.7 - 2020-12-09
+-------------------
+
+API Changes
+~~~~~~~~~~~
+
+-  Adding ``cumulative_hazard_at_times`` to NelsonAalenFitter
+
+Bug fixes
+~~~~~~~~~
+
+-  Fixed error in ``CoxPHFitter`` when entry time == event time.
+-  Fixed formulas in AFT interval censoring regression.
+-  Fixed ``concordance_index_`` when no events observed
+-  Fixed label being overwritten in ParametricUnivariate models
+
+.. _section-1:
+
 0.25.6 - 2020-10-26
 -------------------
 
@@ -9,6 +27,8 @@ New features
 
 -  Parametric Cox models can now handle left and interval censoring
    datasets.
+
+.. _bug-fixes-1:
 
 Bug fixes
 ~~~~~~~~~
@@ -20,10 +40,12 @@ Bug fixes
 -  Fix bug in ``KaplanMeierFitter``\ ’s interval censoring where
    max(lower bound) < min(upper bound).
 
-.. _section-1:
+.. _section-2:
 
 0.25.5 - 2020-09-23
 -------------------
+
+.. _api-changes-1:
 
 API Changes
 ~~~~~~~~~~~
@@ -31,7 +53,7 @@ API Changes
 -  ``check_assumptions`` now returns a list of list of axes that can be
    manipulated
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 ~~~~~~~~~
@@ -43,7 +65,7 @@ Bug fixes
    parametric models
 -  ``weights`` wasn’t being applied properly in NPMLE
 
-.. _section-2:
+.. _section-3:
 
 0.25.4 - 2020-08-26
 -------------------
@@ -58,14 +80,14 @@ New features
    ``log_likelihood_ratio_test()`` and ``print_summary()``
 -  Better step-size defaults for Cox model -> more robust convergence.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 ~~~~~~~~~
 
 -  fix ``check_assumptions`` when using formulas.
 
-.. _section-3:
+.. _section-4:
 
 0.25.3 - 2020-08-24
 -------------------
@@ -79,7 +101,7 @@ New features
    fitters instead of raw data, meaning that you can use this function
    on left, right or interval censored data.
 
-.. _api-changes-1:
+.. _api-changes-2:
 
 API Changes
 ~~~~~~~~~~~
@@ -87,7 +109,7 @@ API Changes
 -  See note on ``survival_difference_at_fixed_point_in_time_test``
    above.
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 ~~~~~~~~~
@@ -96,7 +118,7 @@ Bug fixes
 -  fix Python error when calling ``plot_covariate_groups``
 -  fix dtype mismatches in ``plot_partial_effects_on_outcome``.
 
-.. _section-4:
+.. _section-5:
 
 0.25.2 - 2020-08-08
 -------------------
@@ -108,7 +130,7 @@ New features
 
 -  Spline ``CoxPHFitter`` can now use ``strata``.
 
-.. _api-changes-2:
+.. _api-changes-3:
 
 API Changes
 ~~~~~~~~~~~
@@ -121,7 +143,7 @@ API Changes
    the author.). So add 2 to ``n_baseline_knots`` to recover the
    identical model as previously.
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 ~~~~~~~~~
@@ -130,12 +152,12 @@ Bug fixes
 -  fix some exception imports I missed.
 -  fix log-likelihood p-value in splines ``CoxPHFitter``
 
-.. _section-5:
+.. _section-6:
 
 0.25.1 - 2020-08-01
 -------------------
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 ~~~~~~~~~
@@ -146,7 +168,7 @@ Bug fixes
 -  put ``patsy`` as a proper dependency.
 -  suppress some Pandas 1.1 warnings.
 
-.. _section-6:
+.. _section-7:
 
 0.25.0 - 2020-07-27
 -------------------
@@ -169,7 +191,7 @@ New features
    on the terminal.
 -  ``add_at_risk_counts`` now follows the cool new KMunicate suggestions
 
-.. _api-changes-3:
+.. _api-changes-4:
 
 API Changes
 ~~~~~~~~~~~
@@ -208,7 +230,7 @@ API Changes
    `here <https://lifelines.readthedocs.io/en/latest/Survival%20Regression.html#plotting-the-effect-of-varying-a-covariate>`__.
 -  all exceptions and warnings have moved to ``lifelines.exceptions``
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 ~~~~~~~~~
@@ -224,7 +246,7 @@ Bug fixes
 -  fixed NaN bug in ``survival_table_from_events`` with intervals when
    no events would occur in a interval.
 
-.. _section-7:
+.. _section-8:
 
 0.24.16 - 2020-07-09
 --------------------
@@ -237,19 +259,19 @@ New features
 -  improved algorithm choice for large DataFrames for Cox models. Should
    see a significant performance boost.
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 ~~~~~~~~~
 
 -  fixed ``utils.median_survival_time`` not accepting Pandas Series.
 
-.. _section-8:
+.. _section-9:
 
 0.24.15 - 2020-07-07
 --------------------
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 ~~~~~~~~~
@@ -260,12 +282,12 @@ Bug fixes
 -  fixed bug where using ``conditional_after`` and ``times`` in
    ``CoxPHFitter("spline")`` prediction methods would be ignored.
 
-.. _section-9:
+.. _section-10:
 
 0.24.14 - 2020-07-02
 --------------------
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 ~~~~~~~~~
@@ -277,12 +299,12 @@ Bug fixes
 -  fixed a bug where some columns would not be displayed in
    ``print_summary``
 
-.. _section-10:
+.. _section-11:
 
 0.24.13 - 2020-06-22
 --------------------
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 ~~~~~~~~~
@@ -292,7 +314,7 @@ Bug fixes
 -  fixed a bug where ``CoxPHFitter`` would fail with working with
    ``sklearn_adapter``
 
-.. _section-11:
+.. _section-12:
 
 0.24.12 - 2020-06-20
 --------------------
@@ -304,7 +326,7 @@ New features
 
 -  improved convergence of ``GeneralizedGamma(Regression)Fitter``.
 
-.. _section-12:
+.. _section-13:
 
 0.24.11 - 2020-06-17
 --------------------
@@ -323,7 +345,7 @@ New features
    and the integrated calibration index (ICI) for survival models” by P.
    Austin, F. Harrell, and D. van Klaveren.
 
-.. _api-changes-4:
+.. _api-changes-5:
 
 API Changes
 ~~~~~~~~~~~
@@ -332,7 +354,7 @@ API Changes
    penalized by ``penalizer`` - we now penalizing everything except
    intercept terms in linear relationships.
 
-.. _section-13:
+.. _section-14:
 
 0.24.10 - 2020-06-16
 --------------------
@@ -346,7 +368,7 @@ New features
    offer much better prediction and baseline-hazard estimation,
    including extrapolation and interpolation.
 
-.. _api-changes-5:
+.. _api-changes-6:
 
 API Changes
 ~~~~~~~~~~~
@@ -354,7 +376,7 @@ API Changes
 -  Related to above: the fitted spline parameters are now available in
    the ``.summary`` and ``.print_summary`` methods.
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 ~~~~~~~~~
@@ -362,7 +384,7 @@ Bug fixes
 -  fixed a bug in initialization of some interval-censoring models ->
    better convergence.
 
-.. _section-14:
+.. _section-15:
 
 0.24.9 - 2020-06-05
 -------------------
@@ -377,7 +399,7 @@ New features
    ``tarone-ware``, ``peto``, ``fleming-harrington``. Thanks @sean-reed
 -  new interval censored dataset: ``lifelines.datasets.load_mice``
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 ~~~~~~~~~
@@ -385,7 +407,7 @@ Bug fixes
 -  Cleared up some mislabeling in ``plot_loglogs``. Thanks @sean-reed!
 -  tuples are now able to be used as input in univariate models.
 
-.. _section-15:
+.. _section-16:
 
 0.24.8 - 2020-05-17
 -------------------
@@ -399,7 +421,7 @@ New features
    Not all edge cases are fully checked, and some features are missing.
    Try it under ``KaplanMeierFitter.fit_interval_censoring``
 
-.. _section-16:
+.. _section-17:
 
 0.24.7 - 2020-05-17
 -------------------
@@ -420,7 +442,7 @@ New features
 -  some convergence tweaks which should help recent performance
    regressions.
 
-.. _section-17:
+.. _section-18:
 
 0.24.6 - 2020-05-05
 -------------------
@@ -435,7 +457,7 @@ New features
 -  New ``lifelines.plotting.plot_interval_censored_lifetimes`` for
    plotting interval censored data - thanks @sean-reed!
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 ~~~~~~~~~
@@ -443,7 +465,7 @@ Bug fixes
 -  fixed bug where ``cdf_plot`` and ``qq_plot`` were not factoring in
    the weights correctly.
 
-.. _section-18:
+.. _section-19:
 
 0.24.5 - 2020-05-01
 -------------------
@@ -455,7 +477,7 @@ New features
 
 -  ``plot_lifetimes`` accepts pandas Series.
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 ~~~~~~~~~
@@ -465,12 +487,12 @@ Bug fixes
 -  Improved ``at_risk_counts`` for subplots.
 -  More data validation checks for ``CoxTimeVaryingFitter``
 
-.. _section-19:
+.. _section-20:
 
 0.24.4 - 2020-04-13
 -------------------
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 ~~~~~~~~~
@@ -479,7 +501,7 @@ Bug fixes
 -  setting a dataframe in ``ancillary_df`` works for interval censoring
 -  ``.score`` works for interval censored models
 
-.. _section-20:
+.. _section-21:
 
 0.24.3 - 2020-03-25
 -------------------
@@ -494,7 +516,7 @@ New features
    the hazard ratio would be at previous times. This is useful because
    the final hazard ratio is some weighted average of these.
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 ~~~~~~~~~
@@ -502,12 +524,12 @@ Bug fixes
 -  Fixed error in HTML printer that was hiding concordance index
    information.
 
-.. _section-21:
+.. _section-22:
 
 0.24.2 - 2020-03-15
 -------------------
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 ~~~~~~~~~
@@ -519,7 +541,7 @@ Bug fixes
 -  Fixed a keyword bug in ``plot_covariate_groups`` for parametric
    models.
 
-.. _section-22:
+.. _section-23:
 
 0.24.1 - 2020-03-05
 -------------------
@@ -532,14 +554,14 @@ New features
 -  Stability improvements for GeneralizedGammaRegressionFitter and
    CoxPHFitter with spline estimation.
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 ~~~~~~~~~
 
 -  Fixed bug with plotting hazards in NelsonAalenFitter.
 
-.. _section-23:
+.. _section-24:
 
 0.24.0 - 2020-02-20
 -------------------
@@ -572,7 +594,7 @@ New features
 -  new ``lifelines.fitters.mixins.ProportionalHazardMixin`` that
    implements proportional hazard checks.
 
-.. _api-changes-6:
+.. _api-changes-7:
 
 API Changes
 ~~~~~~~~~~~
@@ -600,7 +622,7 @@ API Changes
    to ``scoring_method``.
 -  removed ``_score_`` and ``path`` from Cox model.
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 ~~~~~~~~~
@@ -613,12 +635,12 @@ Bug fixes
 -  Cox models now incorporate any penalizers in their
    ``log_likelihood_``
 
-.. _section-24:
+.. _section-25:
 
 0.23.9 - 2020-01-28
 -------------------
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
 ~~~~~~~~~
@@ -629,12 +651,12 @@ Bug fixes
    of ``GeneralizedGammaRegressionFitter`` and any custom regression
    models should update their code as soon as possible.
 
-.. _section-25:
+.. _section-26:
 
 0.23.8 - 2020-01-21
 -------------------
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
 ~~~~~~~~~
@@ -645,14 +667,14 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-26:
+.. _section-27:
 
 0.23.7 - 2020-01-14
 -------------------
 
 Bug fixes for py3.5.
 
-.. _section-27:
+.. _section-28:
 
 0.23.6 - 2020-01-07
 -------------------
@@ -671,7 +693,7 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-28:
+.. _section-29:
 
 0.23.5 - 2020-01-05
 -------------------
@@ -685,7 +707,7 @@ New features
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
 ~~~~~~~~~
@@ -695,14 +717,14 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-29:
+.. _section-30:
 
 0.23.4 - 2019-12-15
 -------------------
 
 -  Bug fix for PyPI
 
-.. _section-30:
+.. _section-31:
 
 0.23.3 - 2019-12-11
 -------------------
@@ -714,7 +736,7 @@ New features
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
 ~~~~~~~~~
@@ -722,7 +744,7 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-31:
+.. _section-32:
 
 0.23.2 - 2019-12-07
 -------------------
@@ -739,7 +761,7 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
 ~~~~~~~~~
@@ -748,7 +770,7 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-32:
+.. _section-33:
 
 0.23.1 - 2019-11-27
 -------------------
@@ -763,7 +785,7 @@ New features
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
 ~~~~~~~~~
@@ -775,7 +797,7 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-33:
+.. _section-34:
 
 0.23.0 - 2019-11-17
 -------------------
@@ -789,7 +811,7 @@ New features
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
 ~~~~~~~~~
@@ -799,7 +821,7 @@ Bug fixes
    now fixed.
 -  fixed a NaN error in confidence intervals for KaplanMeierFitter
 
-.. _api-changes-7:
+.. _api-changes-8:
 
 API Changes
 ~~~~~~~~~~~
@@ -811,7 +833,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-34:
+.. _section-35:
 
 0.22.10 - 2019-11-08
 --------------------
@@ -819,7 +841,7 @@ API Changes
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
 ~~~~~~~~~
@@ -829,12 +851,12 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-35:
+.. _section-36:
 
 0.22.9 - 2019-10-30
 -------------------
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug fixes
 ~~~~~~~~~
@@ -846,7 +868,7 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-36:
+.. _section-37:
 
 0.22.8 - 2019-10-06
 -------------------
@@ -861,14 +883,14 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-29:
+.. _bug-fixes-30:
 
 Bug fixes
 ~~~~~~~~~
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-37:
+.. _section-38:
 
 0.22.7 - 2019-09-29
 -------------------
@@ -881,7 +903,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-30:
+.. _bug-fixes-31:
 
 Bug fixes
 ~~~~~~~~~
@@ -890,7 +912,7 @@ Bug fixes
 -  realigned values in ``print_summary``.
 -  fixed bug in ``survival_difference_at_fixed_point_in_time_test``
 
-.. _api-changes-8:
+.. _api-changes-9:
 
 API Changes
 ~~~~~~~~~~~
@@ -900,7 +922,7 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-38:
+.. _section-39:
 
 0.22.6 - 2019-09-25
 -------------------
@@ -912,12 +934,12 @@ New features
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-31:
+.. _bug-fixes-32:
 
 Bug fixes
 ~~~~~~~~~
 
-.. _api-changes-9:
+.. _api-changes-10:
 
 API Changes
 ~~~~~~~~~~~
@@ -928,7 +950,7 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-39:
+.. _section-40:
 
 0.22.5 - 2019-09-20
 -------------------
@@ -942,7 +964,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-32:
+.. _bug-fixes-33:
 
 Bug fixes
 ~~~~~~~~~
@@ -951,7 +973,7 @@ Bug fixes
 -  Fixed an issue with ``AalenJohansenFitter`` failing to plot
    confidence intervals.
 
-.. _api-changes-10:
+.. _api-changes-11:
 
 API Changes
 ~~~~~~~~~~~
@@ -959,7 +981,7 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-40:
+.. _section-41:
 
 0.22.4 - 2019-09-04
 -------------------
@@ -975,7 +997,7 @@ New features
 -  new ``utils.restricted_mean_survival_time`` that approximates the
    RMST using numerical integration against survival functions.
 
-.. _api-changes-11:
+.. _api-changes-12:
 
 API changes
 ~~~~~~~~~~~
@@ -983,7 +1005,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-33:
+.. _bug-fixes-34:
 
 Bug fixes
 ~~~~~~~~~
@@ -991,7 +1013,7 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-41:
+.. _section-42:
 
 0.22.3 - 2019-08-08
 -------------------
@@ -1009,7 +1031,7 @@ New features
 -  smarter initial conditions for parametric regression models.
 -  New regression model: ``GeneralizedGammaRegressionFitter``
 
-.. _api-changes-12:
+.. _api-changes-13:
 
 API changes
 ~~~~~~~~~~~
@@ -1020,7 +1042,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-34:
+.. _bug-fixes-35:
 
 Bug fixes
 ~~~~~~~~~
@@ -1032,7 +1054,7 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-42:
+.. _section-43:
 
 0.22.2 - 2019-07-25
 -------------------
@@ -1044,7 +1066,7 @@ New features
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-35:
+.. _bug-fixes-36:
 
 Bug fixes
 ~~~~~~~~~
@@ -1055,7 +1077,7 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-43:
+.. _section-44:
 
 0.22.1 - 2019-07-14
 -------------------
@@ -1075,7 +1097,7 @@ New features
    right censoring)
 -  improvements to ``lifelines.utils.gamma``
 
-.. _api-changes-13:
+.. _api-changes-14:
 
 API changes
 ~~~~~~~~~~~
@@ -1088,7 +1110,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-36:
+.. _bug-fixes-37:
 
 Bug fixes
 ~~~~~~~~~
@@ -1098,7 +1120,7 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-44:
+.. _section-45:
 
 0.22.0 - 2019-07-03
 -------------------
@@ -1115,7 +1137,7 @@ New features
 -  for parametric univariate models, the ``conditional_time_to_event_``
    is now exact instead of an approximation.
 
-.. _api-changes-14:
+.. _api-changes-15:
 
 API changes
 ~~~~~~~~~~~
@@ -1137,7 +1159,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-37:
+.. _bug-fixes-38:
 
 Bug fixes
 ~~~~~~~~~
@@ -1146,7 +1168,7 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-45:
+.. _section-46:
 
 0.21.5 - 2019-06-22
 -------------------
@@ -1160,7 +1182,7 @@ New features
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-38:
+.. _bug-fixes-39:
 
 Bug fixes
 ~~~~~~~~~
@@ -1170,7 +1192,7 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-46:
+.. _section-47:
 
 0.21.3 - 2019-06-04
 -------------------
@@ -1189,14 +1211,14 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-39:
+.. _bug-fixes-40:
 
 Bug fixes
 ~~~~~~~~~
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-47:
+.. _section-48:
 
 0.21.2 - 2019-05-16
 -------------------
@@ -1213,7 +1235,7 @@ New features
    that computes, you guessed it, the log-likelihood ratio test.
    Previously this was an internal API that is being exposed.
 
-.. _api-changes-15:
+.. _api-changes-16:
 
 API changes
 ~~~~~~~~~~~
@@ -1225,12 +1247,12 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-40:
+.. _bug-fixes-41:
 
 Bug fixes
 ~~~~~~~~~
 
-.. _section-48:
+.. _section-49:
 
 0.21.1 - 2019-04-26
 -------------------
@@ -1244,7 +1266,7 @@ New features
    ``add_covariate_to_timeline``
 -  PiecewiseExponentialFitter now allows numpy arrays as breakpoints
 
-.. _api-changes-16:
+.. _api-changes-17:
 
 API changes
 ~~~~~~~~~~~
@@ -1252,14 +1274,14 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-41:
+.. _bug-fixes-42:
 
 Bug fixes
 ~~~~~~~~~
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-49:
+.. _section-50:
 
 0.21.0 - 2019-04-12
 -------------------
@@ -1278,7 +1300,7 @@ New features
 -  a new interval censored dataset is available under
    ``lifelines.datasets.load_diabetes``
 
-.. _api-changes-17:
+.. _api-changes-18:
 
 API changes
 ~~~~~~~~~~~
@@ -1289,7 +1311,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-42:
+.. _bug-fixes-43:
 
 Bug fixes
 ~~~~~~~~~
@@ -1299,7 +1321,7 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-50:
+.. _section-51:
 
 0.20.5 - 2019-04-08
 -------------------
@@ -1311,7 +1333,7 @@ New features
 
 -  performance improvements for ``print_summary``.
 
-.. _api-changes-18:
+.. _api-changes-19:
 
 API changes
 ~~~~~~~~~~~
@@ -1321,7 +1343,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-43:
+.. _bug-fixes-44:
 
 Bug fixes
 ~~~~~~~~~
@@ -1330,7 +1352,7 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-51:
+.. _section-52:
 
 0.20.4 - 2019-03-27
 -------------------
@@ -1346,7 +1368,7 @@ New features
    generating piecewise exp. data
 -  Faster ``print_summary`` for AFT models.
 
-.. _api-changes-19:
+.. _api-changes-20:
 
 API changes
 ~~~~~~~~~~~
@@ -1354,7 +1376,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-44:
+.. _bug-fixes-45:
 
 Bug fixes
 ~~~~~~~~~
@@ -1363,7 +1385,7 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-52:
+.. _section-53:
 
 0.20.3 - 2019-03-23
 -------------------
@@ -1381,7 +1403,7 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-53:
+.. _section-54:
 
 0.20.2 - 2019-03-21
 -------------------
@@ -1401,7 +1423,7 @@ New features
 -  add a ``lifelines.plotting.qq_plot`` for univariate parametric models
    that handles censored data.
 
-.. _api-changes-20:
+.. _api-changes-21:
 
 API changes
 ~~~~~~~~~~~
@@ -1410,7 +1432,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-45:
+.. _bug-fixes-46:
 
 Bug fixes
 ~~~~~~~~~
@@ -1426,7 +1448,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-54:
+.. _section-55:
 
 0.20.1 - 2019-03-16
 -------------------
@@ -1440,7 +1462,7 @@ Bug fixes
    decades of development.
 -  suppressed unimportant warnings
 
-.. _api-changes-21:
+.. _api-changes-22:
 
 API changes
 ~~~~~~~~~~~
@@ -1450,7 +1472,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-55:
+.. _section-56:
 
 0.20.0 - 2019-03-05
 -------------------
@@ -1467,7 +1489,7 @@ New features
 -  smarter initialization for AFT models which should improve
    convergence.
 
-.. _api-changes-22:
+.. _api-changes-23:
 
 API changes
 ~~~~~~~~~~~
@@ -1479,14 +1501,14 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-46:
+.. _bug-fixes-47:
 
 Bug fixes
 ~~~~~~~~~
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-56:
+.. _section-57:
 
 0.19.5 - 2019-02-26
 -------------------
@@ -1501,19 +1523,19 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-57:
+.. _section-58:
 
 0.19.4 - 2019-02-25
 -------------------
 
-.. _bug-fixes-47:
+.. _bug-fixes-48:
 
 Bug fixes
 ~~~~~~~~~
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-58:
+.. _section-59:
 
 0.19.3 - 2019-02-25
 -------------------
@@ -1530,7 +1552,7 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-59:
+.. _section-60:
 
 0.19.2 - 2019-02-22
 -------------------
@@ -1543,7 +1565,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-48:
+.. _bug-fixes-49:
 
 Bug fixes
 ~~~~~~~~~
@@ -1553,7 +1575,7 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-60:
+.. _section-61:
 
 0.19.1 - 2019-02-21
 -------------------
@@ -1566,7 +1588,7 @@ New features
 -  improved stability of ``LogNormalFitter``
 -  Matplotlib for Python3 users are not longer forced to use 2.x.
 
-.. _api-changes-23:
+.. _api-changes-24:
 
 API changes
 ~~~~~~~~~~~
@@ -1575,7 +1597,7 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-61:
+.. _section-62:
 
 0.19.0 - 2019-02-20
 -------------------
@@ -1593,7 +1615,7 @@ New features
 -  ``CoxPHFitter`` performance improvements (about 10%)
 -  ``CoxTimeVaryingFitter`` performance improvements (about 10%)
 
-.. _api-changes-24:
+.. _api-changes-25:
 
 API changes
 ~~~~~~~~~~~
@@ -1619,7 +1641,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-49:
+.. _bug-fixes-50:
 
 Bug Fixes
 ~~~~~~~~~
@@ -1636,7 +1658,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-62:
+.. _section-63:
 
 0.18.6 - 2019-02-13
 -------------------
@@ -1646,7 +1668,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-63:
+.. _section-64:
 
 0.18.5 - 2019-02-11
 -------------------
@@ -1667,7 +1689,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-64:
+.. _section-65:
 
 0.18.4 - 2019-02-10
 -------------------
@@ -1677,7 +1699,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-65:
+.. _section-66:
 
 0.18.3 - 2019-02-07
 -------------------
@@ -1687,7 +1709,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-66:
+.. _section-67:
 
 0.18.2 - 2019-02-05
 -------------------
@@ -1703,7 +1725,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-67:
+.. _section-68:
 
 0.18.1 - 2019-02-02
 -------------------
@@ -1714,7 +1736,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-68:
+.. _section-69:
 
 0.18.0 - 2019-01-31
 -------------------
@@ -1751,7 +1773,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-69:
+.. _section-70:
 
 0.17.5 - 2019-01-25
 -------------------
@@ -1759,7 +1781,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-70:
+.. _section-71:
 
 0.17.4 -2019-01-25
 ------------------
@@ -1771,7 +1793,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-71:
+.. _section-72:
 
 0.17.3 - 2019-01-24
 -------------------
@@ -1779,7 +1801,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-72:
+.. _section-73:
 
 0.17.2 2019-01-22
 -----------------
@@ -1790,7 +1812,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-73:
+.. _section-74:
 
 0.17.1 - 2019-01-20
 -------------------
@@ -1807,7 +1829,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-74:
+.. _section-75:
 
 0.17.0 - 2019-01-11
 -------------------
@@ -1828,7 +1850,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-75:
+.. _section-76:
 
 0.16.3 - 2019-01-03
 -------------------
@@ -1836,7 +1858,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-76:
+.. _section-77:
 
 0.16.2 - 2019-01-02
 -------------------
@@ -1847,14 +1869,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-77:
+.. _section-78:
 
 0.16.1 - 2019-01-01
 -------------------
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-78:
+.. _section-79:
 
 0.16.0 - 2019-01-01
 -------------------
@@ -1890,7 +1912,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-79:
+.. _section-80:
 
 0.15.4
 ------
@@ -1898,14 +1920,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-80:
+.. _section-81:
 
 0.15.3 - 2018-12-18
 -------------------
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-81:
+.. _section-82:
 
 0.15.2 - 2018-11-23
 -------------------
@@ -1916,7 +1938,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-82:
+.. _section-83:
 
 0.15.1 - 2018-11-23
 -------------------
@@ -1925,7 +1947,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-83:
+.. _section-84:
 
 0.15.0 - 2018-11-22
 -------------------
@@ -1996,7 +2018,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-84:
+.. _section-85:
 
 0.14.6 - 2018-07-02
 -------------------
@@ -2004,7 +2026,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-85:
+.. _section-86:
 
 0.14.5 - 2018-06-29
 -------------------
@@ -2012,7 +2034,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-86:
+.. _section-87:
 
 0.14.4 - 2018-06-14
 -------------------
@@ -2029,7 +2051,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-87:
+.. _section-88:
 
 0.14.3 - 2018-05-24
 -------------------
@@ -2041,7 +2063,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-88:
+.. _section-89:
 
 0.14.2 - 2018-05-18
 -------------------
@@ -2049,7 +2071,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-89:
+.. _section-90:
 
 0.14.1 - 2018-04-01
 -------------------
@@ -2067,7 +2089,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-90:
+.. _section-91:
 
 0.14.0 - 2018-03-03
 -------------------
@@ -2089,7 +2111,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-91:
+.. _section-92:
 
 0.13.0 - 2017-12-22
 -------------------
@@ -2118,7 +2140,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-92:
+.. _section-93:
 
 0.12.0
 ------
@@ -2135,7 +2157,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-93:
+.. _section-94:
 
 0.11.3
 ------
@@ -2147,7 +2169,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-94:
+.. _section-95:
 
 0.11.2
 ------
@@ -2155,14 +2177,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-95:
+.. _section-96:
 
 0.11.1 - 2017-06-22
 -------------------
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-96:
+.. _section-97:
 
 0.11.0 - 2017-06-21
 -------------------
@@ -2176,14 +2198,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-97:
+.. _section-98:
 
 0.10.1 - 2017-06-05
 -------------------
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-98:
+.. _section-99:
 
 0.10.0
 ------
@@ -2198,7 +2220,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-99:
+.. _section-100:
 
 0.9.4
 -----
@@ -2221,7 +2243,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-100:
+.. _section-101:
 
 0.9.2
 -----
@@ -2230,7 +2252,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-101:
+.. _section-102:
 
 0.9.1
 -----
@@ -2238,7 +2260,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-102:
+.. _section-103:
 
 0.9.0
 -----
@@ -2254,7 +2276,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-103:
+.. _section-104:
 
 0.8.1 - 2015-08-01
 ------------------
@@ -2271,7 +2293,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-104:
+.. _section-105:
 
 0.8.0
 -----
@@ -2290,7 +2312,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-105:
+.. _section-106:
 
 0.7.1
 -----
@@ -2309,7 +2331,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-106:
+.. _section-107:
 
 0.7.0 - 2015-03-01
 ------------------
@@ -2328,7 +2350,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-107:
+.. _section-108:
 
 0.6.1
 -----
@@ -2340,7 +2362,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-108:
+.. _section-109:
 
 0.6.0 - 2015-02-04
 ------------------
@@ -2363,7 +2385,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-109:
+.. _section-110:
 
 0.5.1 - 2014-12-24
 ------------------
@@ -2384,7 +2406,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-110:
+.. _section-111:
 
 0.5.0 - 2014-12-07
 ------------------
@@ -2397,7 +2419,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-111:
+.. _section-112:
 
 0.4.4 - 2014-11-27
 ------------------
@@ -2409,7 +2431,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-112:
+.. _section-113:
 
 0.4.3 - 2014-07-23
 ------------------
@@ -2430,7 +2452,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-113:
+.. _section-114:
 
 0.4.2 - 2014-06-19
 ------------------
@@ -2450,7 +2472,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-114:
+.. _section-115:
 
 0.4.1.1
 -------
@@ -2463,7 +2485,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-115:
+.. _section-116:
 
 0.4.1 - 2014-06-11
 ------------------
@@ -2482,7 +2504,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-116:
+.. _section-117:
 
 0.4.0 - 2014-06-08
 ------------------

--- a/docs/Examples.rst
+++ b/docs/Examples.rst
@@ -326,10 +326,10 @@ When ``.plot`` is called, an ``axis`` object is returned which can be passed int
 .. code-block:: python
 
     kmf.fit(data1)
-    ax = kmf.plot()
+    ax = kmf.plot_survival_function()
 
     kmf.fit(data2)
-    ax = kmf.plot(ax=ax)
+    ax = kmf.plot_survival_function(ax=ax)
 
 
 If you have a pandas DataFrame with columns "T", "E", and some categorical variable, then something like the following would work:
@@ -347,7 +347,7 @@ If you have a pandas DataFrame with columns "T", "E", and some categorical varia
 
     for name, grouped_df in df.groupby('group'):
         kmf.fit(grouped_df["T"], grouped_df["E"], label=name)
-        kmf.plot(ax=ax)
+        kmf.plot_survival_function(ax=ax)
 
 
 Plotting interval censored data
@@ -391,8 +391,8 @@ Standard
 
 
     kmf = KaplanMeierFitter()
-    kmf.fit(T, E, label="kmf.plot()")
-    kmf.plot()
+    kmf.fit(T, E, label="kmf.plot_survival_function()")
+    kmf.plot_survival_function()
 
 .. image:: /images/normal_plot.png
     :width: 500px
@@ -403,8 +403,8 @@ Show censors and edit markers
 
 .. code-block:: python
 
-    kmf.fit(T, E, label="kmf.plot(show_censors=True, \ncensor_styles={'ms': 6, 'marker': 's'})")
-    kmf.plot(show_censors=True, censor_styles={'ms': 6, 'marker': 's'})
+    kmf.fit(T, E, label="kmf.plot_survival_function(show_censors=True, \ncensor_styles={'ms': 6, 'marker': 's'})")
+    kmf.plot_survival_function(show_censors=True, censor_styles={'ms': 6, 'marker': 's'})
 
 .. image:: images/flat_plot.png
     :width: 500px
@@ -416,8 +416,8 @@ Hide confidence intervals
 
 .. code-block:: python
 
-    kmf.fit(T, E, label="kmf.plot(ci_show=False)")
-    kmf.plot(ci_show=False)
+    kmf.fit(T, E, label="kmf.plot_survival_function(ci_show=False)")
+    kmf.plot_survival_function(ci_show=False)
 
 .. image:: /images/ci_show_plot.png
     :width: 500px
@@ -430,8 +430,10 @@ Displaying at-risk counts below plots
 .. code-block:: python
 
     kmf.fit(T, E, label="label name")
-    kmf.plot(at_risk_counts=True)
+    kmf.plot_survival_function(at_risk_counts=True)
     plt.tight_layout()
+
+
 
 .. image:: /images/single_at_risk_plots.png
     :width: 500px
@@ -453,10 +455,10 @@ The function :func:`lifelines.plotting.add_at_risk_counts` allows you to add cou
     ax = plt.subplot(111)
 
     kmf_control = KaplanMeierFitter()
-    ax = kmf_control.fit(waltons.loc[ix]['T'], waltons.loc[ix]['E'], label='control').plot(ax=ax)
+    ax = kmf_control.fit(waltons.loc[ix]['T'], waltons.loc[ix]['E'], label='control').plot_survival_function(ax=ax)
 
     kmf_exp = KaplanMeierFitter()
-    ax = kmf_exp.fit(waltons.loc[~ix]['T'], waltons.loc[~ix]['E'], label='exp').plot(ax=ax)
+    ax = kmf_exp.fit(waltons.loc[~ix]['T'], waltons.loc[~ix]['E'], label='exp').plot_survival_function(ax=ax)
 
 
     from lifelines.plotting import add_at_risk_counts

--- a/docs/Quickstart.rst
+++ b/docs/Quickstart.rst
@@ -70,7 +70,7 @@ After calling the :meth:`~lifelines.fitters.kaplan_meier_fitter.KaplanMeierFitte
 
     kmf.survival_function_
     kmf.cumulative_density_
-    kmf.plot_survival_function() # or just kmf.plot()
+    kmf.plot_survival_function()
 
 
 .. image:: images/quickstart_kmf.png
@@ -147,10 +147,10 @@ Multiple groups
     ix = (groups == 'miR-137')
 
     kmf.fit(T[~ix], E[~ix], label='control')
-    ax = kmf.plot()
+    ax = kmf.plot_survival_function()
 
     kmf.fit(T[ix], E[ix], label='miR-137')
-    ax = kmf.plot(ax=ax)
+    ax = kmf.plot_survival_function(ax=ax)
 
 
 .. image:: images/quickstart_multi.png
@@ -168,7 +168,7 @@ Alternatively, for many more groups and more "pandas-esque":
 
     for name, grouped_df in df.groupby('group'):
         kmf.fit(grouped_df["T"], grouped_df["E"], label=name)
-        kmf.plot(ax=ax)
+        kmf.plot_survival_function(ax=ax)
 
 
 Similar functionality exists for the :class:`~lifelines.fitters.nelson_aalen_fitter.NelsonAalenFitter`:

--- a/docs/Survival analysis with lifelines.rst
+++ b/docs/Survival analysis with lifelines.rst
@@ -690,11 +690,7 @@ Instead of producing a survival function, left-censored data analysis is more in
 
     print(kmf.cumulative_density_.head())
 
-<<<<<<< HEAD
     kmf.plot_cumulative_density() #will plot the CDF
-=======
-    kmf.plot_survival_function() #will plot the CDF
->>>>>>> start #1186
     plt.xlabel("Concentration of NH_4")
 
     """

--- a/docs/Survival analysis with lifelines.rst
+++ b/docs/Survival analysis with lifelines.rst
@@ -125,7 +125,7 @@ property. (The method uses exponential Greenwood confidence interval. The mathem
 
 .. code:: python
 
-    kmf.plot()
+    kmf.plot_survival_function()
 
 .. image:: images/lifelines_intro_kmf_fitter.png
     :width: 600px
@@ -160,10 +160,10 @@ an ``axis`` object, that can be used for plotting further estimates:
     dem = (data["democracy"] == "Democracy")
 
     kmf.fit(T[dem], event_observed=E[dem], label="Democratic Regimes")
-    kmf.plot(ax=ax)
+    kmf.plot_survival_function(ax=ax)
 
     kmf.fit(T[~dem], event_observed=E[~dem], label="Non-democratic Regimes")
-    kmf.plot(ax=ax)
+    kmf.plot_survival_function(ax=ax)
 
     plt.title("Lifespans of different global regimes");
 
@@ -185,10 +185,10 @@ probabilities of survival at those points:
 
     t = np.linspace(0, 50, 51)
     kmf.fit(T[dem], event_observed=E[dem], timeline=t, label="Democratic Regimes")
-    ax = kmf.plot(ax=ax)
+    ax = kmf.plot_survival_function(ax=ax)
 
     kmf.fit(T[~dem], event_observed=E[~dem], timeline=t, label="Non-democratic Regimes")
-    ax = kmf.plot(ax=ax)
+    ax = kmf.plot_survival_function(ax=ax)
 
     plt.title("Lifespans of different global regimes");
 
@@ -251,7 +251,7 @@ Lets compare the different *types* of regimes present in the dataset:
 
         ix = data['regime'] == regime_type
         kmf.fit(T[ix], E[ix], label=regime_type)
-        kmf.plot(ax=ax, legend=False)
+        kmf.plot_survival_function(ax=ax, legend=False)
 
         plt.title(regime_type)
         plt.xlim(0, 50)
@@ -277,8 +277,9 @@ In *lifelines*, confidence intervals are automatically added, but there is the `
 .. code:: python
 
     kmf = KaplanMeierFitter().fit(T, E, label="all_regimes")
-    kmf.plot(at_risk_counts=True)
+    kmf.plot_survival_function(at_risk_counts=True)
     plt.tight_layout()
+
 
 
 .. image:: images/intro_add_at_risk.png
@@ -369,7 +370,7 @@ a DataFrame:
 .. code:: python
 
     print(naf.cumulative_hazard_.head())
-    naf.plot()
+    naf.plot_cumulative_hazard()
 
 .. parsed-literal::
 
@@ -400,15 +401,15 @@ gets smaller (as seen by the decreasing rate of change). Let's break the
 regimes down between democratic and non-democratic, during the first 20
 years:
 
-.. note::  We are using the ``loc`` argument in the call to ``plot`` here: it accepts a ``slice`` and plots only points within that slice.
+.. note::  We are using the ``loc`` argument in the call to ``plot_cumulative_hazard`` here: it accepts a ``slice`` and plots only points within that slice.
 
 .. code:: python
 
     naf.fit(T[dem], event_observed=E[dem], label="Democratic Regimes")
-    ax = naf.plot(loc=slice(0, 20))
+    ax = naf.plot_cumulative_hazard(loc=slice(0, 20))
 
     naf.fit(T[~dem], event_observed=E[~dem], label="Non-democratic Regimes")
-    naf.plot(ax=ax, loc=slice(0, 20))
+    naf.plot_cumulative_hazard(ax=ax, loc=slice(0, 20))
 
     plt.title("Cumulative hazard function of different global regimes");
 
@@ -516,7 +517,7 @@ In lifelines, estimation is available using the :class:`~lifelines.fitters.weibu
     wf = WeibullFitter().fit(T, E)
 
     wf.print_summary()
-    ax = wf.plot()
+    ax = wf.plot_cumulative_hazard()
     ax.set_title("Cumulative hazard of Weibull model; estimated parameters")
 
 
@@ -689,7 +690,11 @@ Instead of producing a survival function, left-censored data analysis is more in
 
     print(kmf.cumulative_density_.head())
 
+<<<<<<< HEAD
     kmf.plot_cumulative_density() #will plot the CDF
+=======
+    kmf.plot_survival_function() #will plot the CDF
+>>>>>>> start #1186
     plt.xlabel("Concentration of NH_4")
 
     """
@@ -832,10 +837,10 @@ So subject #77, the subject at the top, was diagnosed with AIDS 7.5 years ago, b
 
         kmf = KaplanMeierFitter()
         kmf.fit(df["T"], event_observed=df["D"], entry=df["W"], label='modeling late entries')
-        ax = kmf.plot()
+        ax = kmf.plot_survival_function()
 
         kmf.fit(df["T"], event_observed=df["D"], label='ignoring late entries')
-        kmf.plot(ax=ax)
+        kmf.plot_survival_function(ax=ax)
 
 
 .. image:: images/kmf_mcas.png

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -2944,7 +2944,7 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
             raise ValueError("All upper bound measurements must be greater than or equal to lower bound measurements.")
 
         if formula:
-            primary_columns_or_formula = [formula]
+            primary_columns_or_formula = formula
         else:
             primary_columns_or_formula = df.columns.difference(
                 [self.lower_bound_col, self.upper_bound_col, self.event_col, self.entry_col, self.weights_col]

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -2626,9 +2626,13 @@ class ParametricRegressionFitter(RegressionFitter):
         """
         # pylint: disable=access-member-before-definition
         if not hasattr(self, "_concordance_index_"):
-            self._concordance_index_ = utils.concordance_index(self.durations, self._predicted_median, self.event_observed)
-            del self._predicted_median
-            return self.concordance_index_
+            try:
+                self._concordance_index_ = utils.concordance_index(self.durations, self._predicted_median, self.event_observed)
+                del self._predicted_median
+                return self.concordance_index_
+            except ZeroDivisionError:
+                # this can happen if there are no observations, see #1172
+                return 0.5
         return self._concordance_index_
 
     @property

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -916,7 +916,6 @@ class ParametricUnivariateFitter(UnivariateFitter):
         initial_point=None,
     ) -> "ParametricUnivariateFitter":
 
-        label = utils.coalesce(label, self._class_name.replace("Fitter", "") + "_estimate")
         n = len(utils.coalesce(*Ts))
 
         if event_observed is not None:
@@ -933,7 +932,7 @@ class ParametricUnivariateFitter(UnivariateFitter):
         else:
             self.timeline = np.linspace(utils.coalesce(*Ts).min(), utils.coalesce(*Ts).max(), min(n, 500))
 
-        self._label = utils.coalesce(label, self._label)
+        self._label = utils.coalesce(label, self._label, self._class_name.replace("Fitter", "") + "_estimate")
         self._ci_labels = ci_labels
         self.alpha = utils.coalesce(alpha, self.alpha)
 

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -131,6 +131,10 @@ class UnivariateFitter(BaseFitter):
         ax:
             a pyplot axis object
         """
+        warnings.warn(
+            "The `plot` function is deprecated, and will be removed in future versions. Use `plot_%s`" % self._estimate_name,
+            DeprecationWarning,
+        )
         return _plot_estimate(self, estimate=self._estimate_name, **kwargs)
 
     def subtract(self, other) -> pd.DataFrame:
@@ -1138,11 +1142,15 @@ class ParametricUnivariateFitter(UnivariateFitter):
         Produce a pretty-plot of the estimate.
         """
         set_kwargs_drawstyle(kwargs, "default")
+        warnings.warn(
+            "The `plot` function is deprecated, and will be removed in future versions. Use `plot_%s`" % self._estimate_name,
+            DeprecationWarning,
+        )
         return _plot_estimate(self, estimate=self._estimate_name, **kwargs)
 
     def plot_cumulative_hazard(self, **kwargs):
         set_kwargs_drawstyle(kwargs, "default")
-        return self.plot(**kwargs)
+        return _plot_estimate(self, estimate="cumulative_hazard_", **kwargs)
 
     def plot_survival_function(self, **kwargs):
         set_kwargs_drawstyle(kwargs, "default")

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -565,10 +565,6 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             else:
                 # no tensors here, but do some casting to make it easier in the converging step next.
                 denom = 1.0 / np.array([risk_phi])
-                if risk_phi == 0:
-                    import pdb
-
-                    pdb.set_trace()
                 numer = risk_phi_x
                 a1 = risk_phi_x_x * denom
 

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -504,7 +504,6 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
         hessian = np.zeros((d, d))
         gradient = np.zeros(d)
         log_lik = 0
-        # weights = weights[:, None]
         unique_death_times = np.unique(stop[events])
 
         for t in unique_death_times:
@@ -566,6 +565,10 @@ See https://stats.stackexchange.com/questions/11109/how-to-deal-with-perfect-sep
             else:
                 # no tensors here, but do some casting to make it easier in the converging step next.
                 denom = 1.0 / np.array([risk_phi])
+                if risk_phi == 0:
+                    import pdb
+
+                    pdb.set_trace()
                 numer = risk_phi_x
                 a1 = risk_phi_x_x * denom
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -2988,7 +2988,7 @@ class ParametricSplinePHFitter(ParametricCoxModelFitter, SplineFitterMixin):
         else:
             return {
                 **{"beta_": np.zeros(len(Xs["beta_"].columns))},
-                **{"phi%d_" % i: np.array([0.001]) for i in range(1, self.n_baseline_knots + 1)},
+                **{"phi%d_" % i: np.array([0.01]) for i in range(1, self.n_baseline_knots + 1)},
             }
 
     def _cumulative_hazard_with_strata(self, params, T, Xs):

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1306,7 +1306,7 @@ class SemiParametricPHFitter(ProportionalHazardMixin, SemiParametricRegressionFi
         utils.check_nans_or_infs(E)
         E = E.astype(bool)
 
-        self._check_values_pre_fitting(X, T, E, W)
+        self._check_values_pre_fitting(X, T, E, W, entries)
 
         return X, T, E, W, entries, original_index, _clusters
 
@@ -1317,7 +1317,7 @@ class SemiParametricPHFitter(ProportionalHazardMixin, SemiParametricRegressionFi
         utils.check_dimensions(X)
         utils.check_complete_separation(X, E, T, self.event_col)
 
-    def _check_values_pre_fitting(self, X, T, E, W):
+    def _check_values_pre_fitting(self, X, T, E, W, entries):
         """
         Some utilities to check for bad data coming in, like NaNs or complete separation.
         """
@@ -1337,6 +1337,9 @@ estimate the variances. See paper "Variance estimation when using inverse probab
                 )
             if (W <= 0).any():
                 raise ValueError("values in weight column %s must be positive." % self.weights_col)
+
+        if self.entry_col:
+            utils.check_entry_times(T, entries)
 
     def _fit_model(
         self,

--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -406,6 +406,10 @@ class KaplanMeierFitter(NonParametricUnivariateFitter):
         return pd.Series(1 - self.predict(times), index=_to_1d_array(times), name=label)
 
     def plot(self, **kwargs):
+        warnings.warn(
+            "The `plot` function is deprecated, and will be removed in future versions. Use `plot_survival_function`",
+            DeprecationWarning,
+        )
         return self.plot_survival_function(**kwargs)
 
     def plot_survival_function(self, **kwargs):

--- a/lifelines/fitters/nelson_aalen_fitter.py
+++ b/lifelines/fitters/nelson_aalen_fitter.py
@@ -14,6 +14,7 @@ from lifelines.utils import (
     check_nans_or_infs,
     CensoringType,
     coalesce,
+    _to_1d_array,
 )
 
 
@@ -242,3 +243,19 @@ class NelsonAalenFitter(UnivariateFitter):
 
     def percentile(self, p):
         raise NotImplementedError()
+
+    def cumulative_hazard_at_times(self, times, label=None) -> pd.Series:
+        """
+        Return a Pandas series of the predicted cumhaz value at specific times
+
+        Parameters
+        -----------
+        times: iterable or float
+
+        Returns
+        --------
+        pd.Series
+
+        """
+        label = coalesce(label, self._label)
+        return pd.Series(self.predict(times), index=_to_1d_array(times), name=label)

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -3,10 +3,7 @@
 import warnings
 from typing import Union, Optional, Iterable
 
-from matplotlib.ticker import MaxNLocator
-from matplotlib import pyplot as plt
-import matplotlib as mpl
-from scipy import stats
+
 import pandas as pd
 import numpy as np
 
@@ -84,6 +81,7 @@ def cdf_plot(model, timeline=None, ax=None, **plot_kwargs):
 
     """
     from lifelines import KaplanMeierFitter
+    from matplotlib import pyplot as plt
 
     if ax is None:
         ax = plt.gca()
@@ -164,6 +162,7 @@ def rmst_plot(model, model2=None, t=np.inf, ax=None, text_position=None, **plot_
 
     """
     from lifelines.utils import restricted_mean_survival_time
+    from matplotlib import pyplot as plt
 
     if ax is None:
         ax = plt.gca()
@@ -256,6 +255,7 @@ def qq_plot(model, ax=None, **plot_kwargs):
     """
     from lifelines.utils import qth_survival_times
     from lifelines import KaplanMeierFitter
+    from matplotlib import pyplot as plt
 
     if ax is None:
         ax = plt.gca()
@@ -421,6 +421,7 @@ def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None,
      Morris TP, Jarvis CI, Cragg W, et al. Proposals on Kaplan–Meier plots in medical research and a survey of stakeholder views: KMunicate. BMJ Open 2019;9:e030215. doi:10.1136/bmjopen-2019-030215
 
     """
+    from matplotlib import pyplot as plt
 
     if ax is None:
         ax = plt.gca()
@@ -560,6 +561,7 @@ def plot_interval_censored_lifetimes(
         df = pd.DataFrame({'lb':[20,15,30, 10, 20, 30], 'ub':[25, 15, np.infty, 20, 20, np.infty]})
         ax = plot_interval_censored_lifetimes(lower_bound=df['lb'], upper_bound=df['ub'])
     """
+    from matplotlib import pyplot as plt
 
     if ax is None:
         ax = plt.gca()
@@ -603,6 +605,8 @@ def plot_interval_censored_lifetimes(
         ax.set_yticks(range(0, N))
         ax.set_yticklabels(lower_bound.index)
     else:
+        from matplotlib.ticker import MaxNLocator
+
         ax.yaxis.set_major_locator(MaxNLocator(integer=True))
 
     ax.set_xlim(0)
@@ -655,6 +659,7 @@ def plot_lifetimes(
         ax = plot_lifetimes(T.loc[:50], event_observed=E.loc[:50])
 
     """
+    from matplotlib import pyplot as plt
 
     if ax is None:
         ax = plt.gca()
@@ -694,6 +699,8 @@ def plot_lifetimes(
         ax.set_yticks(range(0, N))
         ax.set_yticklabels(durations.index)
     else:
+        from matplotlib.ticker import MaxNLocator
+
         ax.yaxis.set_major_locator(MaxNLocator(integer=True))
 
     ax.set_xlim(0)
@@ -728,6 +735,7 @@ def loglogs_plot(cls, loc=None, iloc=None, show_censors=False, censor_styles=Non
     """
     Specifies a plot of the log(-log(SV)) versus log(time) where SV is the estimated survival function.
     """
+    from matplotlib import pyplot as plt
 
     def loglog(s):
         return np.log(-np.log(s))
@@ -903,6 +911,7 @@ def _plot_estimate(
 
 class PlotEstimateConfig:
     def __init__(self, cls, estimate: Union[str, pd.DataFrame], loc, iloc, show_censors, censor_styles, logx, ax, **kwargs):
+        from matplotlib import pyplot as plt
 
         self.censor_styles = coalesce(censor_styles, {})
 

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -2,7 +2,7 @@
 
 import warnings
 from typing import Union, Optional, Iterable
-
+from scipy import stats as stats
 
 import pandas as pd
 import numpy as np
@@ -841,6 +841,8 @@ def _plot_estimate(
     ax:
         a pyplot axis object
     """
+    from matplotlib import pyplot as plt
+
     if ci_force_lines:
         warnings.warn(
             "ci_force_lines is deprecated. Use ci_only_lines instead (no functional difference, only a name change).",

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1807,6 +1807,12 @@ class TestRegressionFitters:
         )
         return regression_models_sans_strata_model
 
+    def test_no_observations(self, rossi, regression_models):
+        rossi["arrest"] == 0
+        for fitter in regression_models:
+            fitter.fit(rossi, "week", "arrest")
+            fitter.print_summary()
+
     def test_compute_central_values_of_raw_training_data(self):
 
         central_values = RegressionFitter()._compute_central_values_of_raw_training_data

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -2475,6 +2475,14 @@ class TestWeibullAFTFitter:
     def aft(self):
         return WeibullAFTFitter()
 
+    def test_interval_censoring_with_formula(self, aft):
+        df = load_diabetes()
+        df["gender"] = df["gender"] == "male"
+        df["E"] = df["left"] == df["right"]
+        df["gender"] = df["gender"].astype(int)
+
+        aft.fit_interval_censoring(df, "left", "right", "E", formula="gender")
+
     def test_fitted_coefs_with_eha_when_left_truncated(self, aft, rossi):
         """
         library(eha)

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -346,6 +346,15 @@ class TestUnivariateFitters:
             SplineFitterTesting,
         ]
 
+    def test_label_is_not_overwritten(self):
+        fitter = WeibullFitter(label="Weibull")
+        fitter.fit([1, 2, 3, 4], event_observed=[1, 1, 1, 1])
+        assert fitter._label == "Weibull"
+
+        fitter = KaplanMeierFitter(label="KM")
+        fitter.fit([1, 2, 3, 4], event_observed=[1, 1, 1, 1])
+        assert fitter._label == "KM"
+
     def test_confidence_interval_has_the_correct_order_so_plotting_doesnt_break(self, sample_lifetimes, univariate_fitters):
         T, E = sample_lifetimes
         for f in univariate_fitters:

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -2927,6 +2927,19 @@ class TestCoxPHFitter:
         cph_pieces.fit(rossi, "week", "arrest", strata="paro", formula="age")
         assert cph_pieces._ll_null_dof < cph_pieces.params_.shape[0]
 
+    def test_late_entries_where_obs_is_equal_to_entry(self, cph):
+
+        df = load_multicenter_aids_cohort_study()
+
+        df.loc[1, "W"] = df.loc[1, "T"]
+        df.loc[1, "D"] = 1
+
+        with pytest.raises(ValueError):
+            cph.fit(df, "T", "D", entry_col="W")
+
+        df.loc[1, "T"] = df.loc[1, "T"] + 0.00001
+        cph.fit(df, "T", "D", entry_col="W")
+
     def test_parametric_strata_score(self, cph_spline, cph_pieces, rossi):
         cph_spline.fit(rossi, "week", "arrest", strata="paro", formula="age")
         cph_spline.score(rossi)

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1511,6 +1511,12 @@ class TestNelsonAalenFitter:
             na = np.insert(na, 0, 0.0)
         return na.reshape(len(na), 1)
 
+    def test_cumulative_hazard_at_times(self, sample_lifetimes):
+        T, _ = sample_lifetimes
+        naf = NelsonAalenFitter(nelson_aalen_smoothing=False)
+        naf.fit(T)
+        naf.cumulative_hazard_at_times([0.5, 0.9, 1.0])
+
     def test_nelson_aalen_no_censorship(self, sample_lifetimes):
         T, _ = sample_lifetimes
         naf = NelsonAalenFitter(nelson_aalen_smoothing=False)

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -2272,7 +2272,7 @@ class TestAFTFitters:
     def test_warning_is_present_if_entry_greater_than_duration(self, rossi, models):
         rossi["start"] = 10
         for fitter in models:
-            with pytest.raises(ValueError, match="entry > duration"):
+            with pytest.raises(ValueError, match="entry >= duration"):
                 fitter.fit(rossi, "week", "arrest", entry_col="start")
 
     def test_weights_col_and_start_col_is_not_included_in_the_output(self, models, rossi):
@@ -2908,12 +2908,16 @@ class TestCoxPHFitter:
         df = load_diabetes()
         df["gender"] = df["gender"] == "male"
         df["gender"] = df["gender"].astype(int)
-
-        cph_spline = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2, penalizer=0.001)
-        cph_spline.fit_interval_censoring(df, "left", "right", formula="gender + 1", show_progress=True)
-        cph_spline.print_summary()
+        df["left"] = df["left"]
+        df["right"] = df["right"]
 
         cph_pieces.fit_interval_censoring(df, "left", "right")
+        cph_pieces.print_summary()
+
+        cph_spline = CoxPHFitter(baseline_estimation_method="spline", n_baseline_knots=2, penalizer=0.01)
+        cph_spline.fit_interval_censoring(
+            df, "left", "right", formula="gender", show_progress=True, initial_point=np.array([-8.68, -0.13, 3.04, 0.52])
+        )
         cph_spline.print_summary()
 
     def test_parametric_models_can_do_left_censoring(self, cph_spline, cph_pieces):

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 import warnings
 
-# pylint: disable=wrong-import-position
-warnings.simplefilter(action="ignore", category=DeprecationWarning)
-
 from io import StringIO, BytesIO as stringio
 from collections.abc import Iterable
 from itertools import combinations

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1115,9 +1115,12 @@ def pearson_correlation(x: np.ndarray, y: np.ndarray):
 
 
 def check_entry_times(T, entries):
-    count_invalid_rows = (entries > T).sum()
+    count_invalid_rows = (entries >= T).sum()
     if count_invalid_rows:
-        raise ValueError("""There exist %d rows where entry > duration.""" % count_invalid_rows)
+        raise ValueError(
+            """There exist %d row(s) where entry >= duration. Recommendation is to add a very small value to duration for these rows."""
+            % count_invalid_rows
+        )
 
 
 def check_complete_separation_close_to_perfect_correlation(df: pd.DataFrame, durations: pd.Series):

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.25.6"
+__version__ = "0.25.7"


### PR DESCRIPTION
##### API Changes
 - Adding `cumulative_hazard_at_times` to NelsonAalenFitter


##### Bug fixes
 - Fixed error in `CoxPHFitter` when entry time == event time.
 - Fixed formulas in AFT interval censoring regression.
 - Fixed `concordance_index_` when no events observed
 - Fixed label being overwritten in ParametricUnivariate models
