### PR TITLE
Constrain formulaic version to 0.2.x

### DIFF
--- a/reqs/base-requirements.txt
+++ b/reqs/base-requirements.txt
@@ -4,4 +4,4 @@ pandas>=0.23.0
 matplotlib>=3.0
 autograd>=1.3
 autograd-gamma>=0.3
-formulaic
+formulaic>=0.2.2,<0.3


### PR DESCRIPTION
Formulaic has not yet committed to a stable API between major version bumps, and so to prevent future breakage, we constrain the version of formulaic we depend upon to the 0.2.x series. The minimum version we require is version 0.2.2 in order to resolve an issue with pandas indices being incorrectly respected in 0.2.1 .

closes #1215