### PR TITLE
Set upper bound for numpy 1.20.0

### DIFF
--- a/reqs/base-requirements.txt
+++ b/reqs/base-requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.14.0
+numpy>=1.14.0,<1.20.0
 scipy>=1.2.0
 pandas>=0.23.0
 matplotlib>=3.0


### PR DESCRIPTION
pandas version under 1.0.5 is not compatible with numpy version 1.20.0, so I set an upper bound on numpy requirement.
See also [numpy issue #18355](https://github.com/numpy/numpy/issues/18355) and [pandas issue #39520](https://github.com/pandas-dev/pandas/issues/39520#issuecomment-772630011) 


<img width="539" alt="스크린샷 2021-02-11 오후 7 47 56" src="https://user-images.githubusercontent.com/29896892/107627051-0d629b80-6ca2-11eb-8d92-81ed6543ae92.png">
