### PR TITLE
adding collapsed version of lifetables when only showing a single summary row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Changelog
 
-
 #### 0.25.9 - 2021-02-04
 
 Small bump in dependencies.

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -363,12 +363,14 @@ def remove_ticks(ax, x=False, y=False):
     return ax
 
 
-def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None, rows_to_show=None, ypos=-0.6, ax=None, **kwargs):
+def add_at_risk_counts(
+    *fitters, labels: Optional[Union[Iterable, bool]] = None, rows_to_show=None, ypos=-0.6, xticks=None, ax=None, **kwargs
+):
     """
     Add counts showing how many individuals were at risk, censored, and observed, at each time point in
     survival/hazard plots.
 
-    Tip: you may want to call ``plt.tight_layout()`` afterwards.
+    Tip: you probably want to call ``plt.tight_layout()`` afterwards.
 
     Parameters
     ----------
@@ -382,6 +384,8 @@ def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None,
         a sub-list of ['At risk', 'Censored', 'Events']. Default to show all.
     ypos:
         make more positive to move the table up.
+    xticks: list
+        specify the time periods (as a list) you want to evaluate the counts at.
     ax:
         a matplotlib axes
 
@@ -462,7 +466,6 @@ def add_at_risk_counts(*fitters, labels: Optional[Union[Iterable, bool]] = None,
     min_time, max_time = ax.get_xlim()
     ax2.set_xlim(min_time, max_time)
     # Set ticks to kwarg or visible ticks
-    xticks = kwargs.pop("xticks", None)
     if xticks is None:
         xticks = [xtick for xtick in ax.get_xticks() if min_time <= xtick <= max_time]
     ax2.set_xticks(xticks)

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -154,6 +154,12 @@ class TestPlotting:
 
         kmf_test.plot(ax=ax)
         kmf_con.plot(ax=ax)
+
+        ax.set_ylim([0.0, 1.1])
+        ax.set_xlim([0.0, 100])
+        ax.set_xlabel("Days")
+        ax.set_ylabel("Survival probability")
+
         add_at_risk_counts(kmf_test, kmf_con, ax=ax, rows_to_show=["At risk"], ypos=-0.4)
         self.plt.title("test_kmf_add_at_risk_counts_with_single_row_multi_groups")
         self.plt.tight_layout()

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -136,8 +136,27 @@ class TestPlotting:
         ax = fig.subplots(1, 1)
         kmf.plot(ax=ax)
         add_at_risk_counts(kmf, ax=ax, rows_to_show=["Censored", "At risk"])
-
+        self.plt.tight_layout()
         self.plt.title("test_kmf_add_at_risk_counts_with_specific_rows")
+        self.plt.show(block=block)
+
+    def test_kmf_add_at_risk_counts_with_single_row_multi_groups(self, block, kmf):
+        T = np.random.exponential(10, size=(100))
+        E = np.random.binomial(1, 0.8, size=(100))
+        kmf_test = KaplanMeierFitter().fit(T, E, label="test")
+
+        T = np.random.exponential(15, size=(1000))
+        E = np.random.binomial(1, 0.6, size=(1000))
+        kmf_con = KaplanMeierFitter().fit(T, E, label="con")
+
+        fig = self.plt.figure()
+        ax = fig.subplots(1, 1)
+
+        kmf_test.plot(ax=ax)
+        kmf_con.plot(ax=ax)
+        add_at_risk_counts(kmf_test, kmf_con, ax=ax, rows_to_show=["At risk"], ypos=-0.4)
+        self.plt.tight_layout()
+        self.plt.title("test_kmf_add_at_risk_counts_with_single_row_multi_groups")
         self.plt.show(block=block)
 
     def test_kmf_add_at_risk_counts_with_custom_subplot(self, block, kmf):

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -155,8 +155,8 @@ class TestPlotting:
         kmf_test.plot(ax=ax)
         kmf_con.plot(ax=ax)
         add_at_risk_counts(kmf_test, kmf_con, ax=ax, rows_to_show=["At risk"], ypos=-0.4)
-        self.plt.tight_layout()
         self.plt.title("test_kmf_add_at_risk_counts_with_single_row_multi_groups")
+        self.plt.tight_layout()
         self.plt.show(block=block)
 
     def test_kmf_add_at_risk_counts_with_custom_subplot(self, block, kmf):


### PR DESCRIPTION

### Master
<img width="633" alt="Screen Shot 2021-02-18 at 10 28 52 PM" src="https://user-images.githubusercontent.com/884032/108453609-cf80ec80-7238-11eb-8296-6b7be04715a0.png">

### This branch
<img width="636" alt="Screen Shot 2021-02-18 at 10 28 21 PM" src="https://user-images.githubusercontent.com/884032/108453620-d4de3700-7238-11eb-9c65-764c3dfd7493.png">

