### PR TITLE
add BIC_ prop

### DIFF
--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -309,6 +309,10 @@ class ParametricUnivariateFitter(UnivariateFitter):
     def AIC_(self) -> float:
         return -2 * self.log_likelihood_ + 2 * self._fitted_parameters_.shape[0]
 
+    @property
+    def BIC_(self) -> float:
+        return -2 * self.log_likelihood_ +  len(self._fitted_parameter_names) * np.log(self.event_observed.shape[0])
+
     def _check_cumulative_hazard_is_monotone_and_positive(self, durations, values):
         class_name = self._class_name
 
@@ -687,6 +691,7 @@ class ParametricUnivariateFitter(UnivariateFitter):
                 ),
             ],
             [("AIC", "{:.{prec}f}".format(self.AIC_, prec=decimals))],
+            [("BIC", "{:.{prec}f}".format(self.BIC_, prec=decimals))],
             justify,
             kwargs,
             decimals,
@@ -2244,6 +2249,7 @@ class ParametricRegressionFitter(RegressionFitter):
         footers.extend(
             [
                 ("AIC", "{:.{prec}f}".format(self.AIC_, prec=decimals)),
+                ("BIC", "{:.{prec}f}".format(self.BIC_, prec=decimals)),
                 (
                     "log-likelihood ratio test",
                     "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals),
@@ -2650,7 +2656,10 @@ class ParametricRegressionFitter(RegressionFitter):
     @property
     def AIC_(self) -> float:
         return -2 * self.log_likelihood_ + 2 * self.params_.shape[0]
-
+    
+    @property
+    def BIC_(self) -> float:
+        return -2 * self.log_likelihood_ +  len(self._fitted_parameter_names) * np.log(self.event_observed.shape[0])
 
 class ParametericAFTRegressionFitter(ParametricRegressionFitter):
 

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -691,7 +691,6 @@ class ParametricUnivariateFitter(UnivariateFitter):
                 ),
             ],
             [("AIC", "{:.{prec}f}".format(self.AIC_, prec=decimals))],
-            [("BIC", "{:.{prec}f}".format(self.BIC_, prec=decimals))],
             justify,
             kwargs,
             decimals,
@@ -2249,7 +2248,6 @@ class ParametricRegressionFitter(RegressionFitter):
         footers.extend(
             [
                 ("AIC", "{:.{prec}f}".format(self.AIC_, prec=decimals)),
-                ("BIC", "{:.{prec}f}".format(self.BIC_, prec=decimals)),
                 (
                     "log-likelihood ratio test",
                     "{:.{prec}f} on {} df".format(sr.test_statistic, sr.degrees_freedom, prec=decimals),

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1760,8 +1760,7 @@ def find_best_parametric_model(
 
     evaluation_lookup = {
         "AIC": lambda model: model.AIC_,
-        "BIC": lambda model: 2 * len(model._fitted_parameter_names)
-        - 2 * model.log_likelihood_ * np.log(model.event_observed.shape[0]),
+        "BIC": lambda model: model.BIC_,
     }
 
     eval_ = evaluation_lookup[scoring_method]


### PR DESCRIPTION
Bayesian Information Criteria (BIC) value is added as model prop: `model.BIC_`

`find_best_parametric_model()` 's `evaluation_lookup` now uses this prop for BIC value.