### PR TITLE
Added custom knots parameter for Cox Fitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ docs/_build/
 
 # asv builds
 \.asv/
+
+# Pycharm
+\.idea/

--- a/examples/cox_spline_custom_knots.py
+++ b/examples/cox_spline_custom_knots.py
@@ -1,0 +1,13 @@
+from matplotlib import pyplot as plt
+from lifelines import CoxPHFitter
+import numpy as np
+import pandas as pd
+from lifelines.datasets import load_rossi
+
+df = load_rossi()
+
+# Specifying the position of the knots: One week, one month and one year.
+my_knots = [1, 5, 52]
+cph = CoxPHFitter(baseline_estimation_method="spline", knots=my_knots)
+cph.fit(df, 'week', 'arrest', strata=['wexp'])
+cph.print_summary()

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -71,8 +71,13 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         See http://courses.washington.edu/b515/l17.pdf.
 
       n_baseline_knots: int
-        Used when ``baseline_estimation_method="spline"`. Set the number of knots (interior & exterior) in the baseline hazard. Should be atleast 2. Royston et. al, the authors
-        of this model, suggest 4 to start, but any values between 2 and 8 are reasonable.
+        Used when ``baseline_estimation_method="spline"`. Set the number of knots (interior & exterior) in the baseline hazard, which will be placed evenly along the time axis.
+        Should be at least 2. Royston et. al, the authors of this model, suggest 4 to start, but any values between 2 and 8 are reasonable.
+        If you need to customize the timestamps used to calculate the curve, use the ``knots`` parameter instead.
+
+      knots: list, optional
+        When ``baseline_estimation_method="spline"`, this allows customizing the points in the time axis for the baseline hazard curve.
+        To use evenly-spaced points in time, the ``n_baseline_knots`` parameter can be employed instead.
 
       breakpoints: int
         Used when ``baseline_estimation_method="piecewise"`. Set the positions of the baseline hazard breakpoints.

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -133,6 +133,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         strata: Optional[Union[List[str], str]] = None,
         l1_ratio: float = 0.0,
         n_baseline_knots: Optional[int] = None,
+        knots: Optional[List] = None,
         breakpoints: Optional[List] = None,
         **kwargs,
     ) -> None:
@@ -146,7 +147,14 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
         self.strata = strata
         self.l1_ratio = l1_ratio
         self.baseline_estimation_method = baseline_estimation_method
-        self.n_baseline_knots = n_baseline_knots
+        if knots is not None:
+            if n_baseline_knots is not None:
+                raise ValueError("knots and n_baseline_knots are mutually exclusive.")
+            self.knots = knots
+            self.n_baseline_knots = len(knots)
+        else:
+            self.n_baseline_knots = n_baseline_knots
+            self.knots = None
         self.breakpoints = breakpoints
 
     @utils.CensoringType.right_censoring
@@ -710,6 +718,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
             penalizer=self.penalizer,
             l1_ratio=self.l1_ratio,
             n_baseline_knots=self.n_baseline_knots,
+            knots=self.knots,
             alpha=self.alpha,
             label=self._label,
         )
@@ -2950,7 +2959,7 @@ class ParametricSplinePHFitter(ParametricCoxModelFitter, SplineFitterMixin):
     _FAST_MEDIAN_PREDICT = False
     fit_intercept = True
 
-    def __init__(self, strata, strata_values, n_baseline_knots=1, *args, **kwargs):
+    def __init__(self, strata, strata_values, n_baseline_knots=1, knots=None, *args, **kwargs):
         self.strata = strata
         self.strata_values = strata_values
 
@@ -2959,6 +2968,7 @@ class ParametricSplinePHFitter(ParametricCoxModelFitter, SplineFitterMixin):
         ), "n_baseline_knots should be greater than 1. Set in class instantiation"
 
         self.n_baseline_knots = n_baseline_knots
+        self.knots = knots
         super(ParametricSplinePHFitter, self).__init__(*args, **kwargs)
 
     @staticmethod
@@ -2980,6 +2990,8 @@ class ParametricSplinePHFitter(ParametricCoxModelFitter, SplineFitterMixin):
         return
 
     def _pre_fit_model(self, Ts, E, df):
+        if self.knots is not None:
+            return
         if E.sum() > 4:
             self._set_knots(utils.coalesce(*Ts), E)
         else:


### PR DESCRIPTION
I have added a new parameter in CoxPHFitter, named 'knots'. This parameter allows specifying the position of the knots in fitting process, instead of having the library automatically calculating it.

There's also an example file which shows how to use it, by fitting it to one week, a month and a year.

Finally this PR also adds the Pycharm .idea folder to the gitignore file.