### PR TITLE
fix at_risk table bug, and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Changelog
 
+#### 0.25.11 - 2021-05-26
+
+##### New features
+ - `.BIC_` is now present on fitted models.
+ - `CoxPHFitter` with spline baseline can accept pre-computed knot locations.
+
+
+##### Bug fixes
+ - Fixed an annoying bug where at_risk-table label's were not aligning properly when data spanned large ranges. See merging PR for details.
+ - Fixed a bug in `find_best_parametric_model` where the wrong BIC value was being computed.
+
+
 #### 0.25.11 - 2021-04-06
 
 ##### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 ## Changelog
 
-#### 0.25.11 - 2021-05-26
+#### 0.26.0 - 2021-05-26
 
 ##### New features
  - `.BIC_` is now present on fitted models.
  - `CoxPHFitter` with spline baseline can accept pre-computed knot locations.
-
+ - Left censoring fitting in KaplanMeierFitter is now "expected". That is, `predict` _always_ predicts the survival function (as does every other model), `confidence_interval_` is _always_ the CI for the survival function (as does every other model), and so on. In summary: the API for estimates doesn't change depending on what your censoring your dataset is.
 
 ##### Bug fixes
  - Fixed an annoying bug where at_risk-table label's were not aligning properly when data spanned large ranges. See merging PR for details.
  - Fixed a bug in `find_best_parametric_model` where the wrong BIC value was being computed.
+ - Fixed regression bug when using an array as a penalizer in Cox models.
 
 
 #### 0.25.11 - 2021-04-06

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-0.25.11 - 2021-05-26
---------------------
+0.26.0 - 2021-05-26
+-------------------
 
 New features
 ~~~~~~~~~~~~
@@ -10,6 +10,12 @@ New features
 -  ``.BIC_`` is now present on fitted models.
 -  ``CoxPHFitter`` with spline baseline can accept pre-computed knot
    locations.
+-  Left censoring fitting in KaplanMeierFitter is now “expected”. That
+   is, ``predict`` *always* predicts the survival function (as does
+   every other model), ``confidence_interval_`` is *always* the CI for
+   the survival function (as does every other model), and so on. In
+   summary: the API for estimates doesn’t change depending on what your
+   censoring your dataset is.
 
 Bug fixes
 ~~~~~~~~~
@@ -18,6 +24,8 @@ Bug fixes
    properly when data spanned large ranges. See merging PR for details.
 -  Fixed a bug in ``find_best_parametric_model`` where the wrong BIC
    value was being computed.
+-  Fixed regression bug when using an array as a penalizer in Cox
+   models.
 
 .. _section-1:
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,8 +1,30 @@
 Changelog
 =========
 
+0.25.11 - 2021-05-26
+--------------------
+
+New features
+~~~~~~~~~~~~
+
+-  ``.BIC_`` is now present on fitted models.
+-  ``CoxPHFitter`` with spline baseline can accept pre-computed knot
+   locations.
+
+Bug fixes
+~~~~~~~~~
+
+-  Fixed an annoying bug where at_risk-table label’s were not aligning
+   properly when data spanned large ranges. See merging PR for details.
+-  Fixed a bug in ``find_best_parametric_model`` where the wrong BIC
+   value was being computed.
+
+.. _section-1:
+
 0.25.11 - 2021-04-06
 --------------------
+
+.. _bug-fixes-1:
 
 Bug fixes
 ~~~~~~~~~
@@ -13,10 +35,12 @@ Bug fixes
 -  Bug fix in the elastic-net penalty for Cox models that wasn’t
    weighting the terms correctly.
 
-.. _section-1:
+.. _section-2:
 
 0.25.10 - 2021-03-03
 --------------------
+
+.. _new-features-1:
 
 New features
 ~~~~~~~~~~~~
@@ -24,14 +48,14 @@ New features
 -  Better appearance when using a single row to show in
    ``add_at_risk_table``.
 
-.. _section-2:
+.. _section-3:
 
 0.25.9 - 2021-02-04
 -------------------
 
 Small bump in dependencies.
 
-.. _section-3:
+.. _section-4:
 
 0.25.8 - 2021-01-22
 -------------------
@@ -40,7 +64,7 @@ Important: we dropped Patsy as our formula framework, and adopted
 Formulaic. Will the latter is less mature than Patsy, we feel the core
 capabilities are satisfactory and it provides new opportunities.
 
-.. _new-features-1:
+.. _new-features-2:
 
 New features
 ~~~~~~~~~~~~
@@ -49,7 +73,7 @@ New features
 -  a ``_scipy_callback`` function is available to use in fitting
    algorithms.
 
-.. _section-4:
+.. _section-5:
 
 0.25.7 - 2020-12-09
 -------------------
@@ -59,7 +83,7 @@ API Changes
 
 -  Adding ``cumulative_hazard_at_times`` to NelsonAalenFitter
 
-.. _bug-fixes-1:
+.. _bug-fixes-2:
 
 Bug fixes
 ~~~~~~~~~
@@ -69,12 +93,12 @@ Bug fixes
 -  Fixed ``concordance_index_`` when no events observed
 -  Fixed label being overwritten in ParametricUnivariate models
 
-.. _section-5:
+.. _section-6:
 
 0.25.6 - 2020-10-26
 -------------------
 
-.. _new-features-2:
+.. _new-features-3:
 
 New features
 ~~~~~~~~~~~~
@@ -82,7 +106,7 @@ New features
 -  Parametric Cox models can now handle left and interval censoring
    datasets.
 
-.. _bug-fixes-2:
+.. _bug-fixes-3:
 
 Bug fixes
 ~~~~~~~~~
@@ -94,7 +118,7 @@ Bug fixes
 -  Fix bug in ``KaplanMeierFitter``\ ’s interval censoring where
    max(lower bound) < min(upper bound).
 
-.. _section-6:
+.. _section-7:
 
 0.25.5 - 2020-09-23
 -------------------
@@ -107,7 +131,7 @@ API Changes
 -  ``check_assumptions`` now returns a list of list of axes that can be
    manipulated
 
-.. _bug-fixes-3:
+.. _bug-fixes-4:
 
 Bug fixes
 ~~~~~~~~~
@@ -119,12 +143,12 @@ Bug fixes
    parametric models
 -  ``weights`` wasn’t being applied properly in NPMLE
 
-.. _section-7:
+.. _section-8:
 
 0.25.4 - 2020-08-26
 -------------------
 
-.. _new-features-3:
+.. _new-features-4:
 
 New features
 ~~~~~~~~~~~~
@@ -134,19 +158,19 @@ New features
    ``log_likelihood_ratio_test()`` and ``print_summary()``
 -  Better step-size defaults for Cox model -> more robust convergence.
 
-.. _bug-fixes-4:
+.. _bug-fixes-5:
 
 Bug fixes
 ~~~~~~~~~
 
 -  fix ``check_assumptions`` when using formulas.
 
-.. _section-8:
+.. _section-9:
 
 0.25.3 - 2020-08-24
 -------------------
 
-.. _new-features-4:
+.. _new-features-5:
 
 New features
 ~~~~~~~~~~~~
@@ -163,7 +187,7 @@ API Changes
 -  See note on ``survival_difference_at_fixed_point_in_time_test``
    above.
 
-.. _bug-fixes-5:
+.. _bug-fixes-6:
 
 Bug fixes
 ~~~~~~~~~
@@ -172,12 +196,12 @@ Bug fixes
 -  fix Python error when calling ``plot_covariate_groups``
 -  fix dtype mismatches in ``plot_partial_effects_on_outcome``.
 
-.. _section-9:
+.. _section-10:
 
 0.25.2 - 2020-08-08
 -------------------
 
-.. _new-features-5:
+.. _new-features-6:
 
 New features
 ~~~~~~~~~~~~
@@ -197,7 +221,7 @@ API Changes
    the author.). So add 2 to ``n_baseline_knots`` to recover the
    identical model as previously.
 
-.. _bug-fixes-6:
+.. _bug-fixes-7:
 
 Bug fixes
 ~~~~~~~~~
@@ -206,12 +230,12 @@ Bug fixes
 -  fix some exception imports I missed.
 -  fix log-likelihood p-value in splines ``CoxPHFitter``
 
-.. _section-10:
+.. _section-11:
 
 0.25.1 - 2020-08-01
 -------------------
 
-.. _bug-fixes-7:
+.. _bug-fixes-8:
 
 Bug fixes
 ~~~~~~~~~
@@ -222,12 +246,12 @@ Bug fixes
 -  put ``patsy`` as a proper dependency.
 -  suppress some Pandas 1.1 warnings.
 
-.. _section-11:
+.. _section-12:
 
 0.25.0 - 2020-07-27
 -------------------
 
-.. _new-features-6:
+.. _new-features-7:
 
 New features
 ~~~~~~~~~~~~
@@ -284,7 +308,7 @@ API Changes
    `here <https://lifelines.readthedocs.io/en/latest/Survival%20Regression.html#plotting-the-effect-of-varying-a-covariate>`__.
 -  all exceptions and warnings have moved to ``lifelines.exceptions``
 
-.. _bug-fixes-8:
+.. _bug-fixes-9:
 
 Bug fixes
 ~~~~~~~~~
@@ -300,12 +324,12 @@ Bug fixes
 -  fixed NaN bug in ``survival_table_from_events`` with intervals when
    no events would occur in a interval.
 
-.. _section-12:
+.. _section-13:
 
 0.24.16 - 2020-07-09
 --------------------
 
-.. _new-features-7:
+.. _new-features-8:
 
 New features
 ~~~~~~~~~~~~
@@ -313,19 +337,19 @@ New features
 -  improved algorithm choice for large DataFrames for Cox models. Should
    see a significant performance boost.
 
-.. _bug-fixes-9:
+.. _bug-fixes-10:
 
 Bug fixes
 ~~~~~~~~~
 
 -  fixed ``utils.median_survival_time`` not accepting Pandas Series.
 
-.. _section-13:
+.. _section-14:
 
 0.24.15 - 2020-07-07
 --------------------
 
-.. _bug-fixes-10:
+.. _bug-fixes-11:
 
 Bug fixes
 ~~~~~~~~~
@@ -336,12 +360,12 @@ Bug fixes
 -  fixed bug where using ``conditional_after`` and ``times`` in
    ``CoxPHFitter("spline")`` prediction methods would be ignored.
 
-.. _section-14:
+.. _section-15:
 
 0.24.14 - 2020-07-02
 --------------------
 
-.. _bug-fixes-11:
+.. _bug-fixes-12:
 
 Bug fixes
 ~~~~~~~~~
@@ -353,12 +377,12 @@ Bug fixes
 -  fixed a bug where some columns would not be displayed in
    ``print_summary``
 
-.. _section-15:
+.. _section-16:
 
 0.24.13 - 2020-06-22
 --------------------
 
-.. _bug-fixes-12:
+.. _bug-fixes-13:
 
 Bug fixes
 ~~~~~~~~~
@@ -368,24 +392,24 @@ Bug fixes
 -  fixed a bug where ``CoxPHFitter`` would fail with working with
    ``sklearn_adapter``
 
-.. _section-16:
+.. _section-17:
 
 0.24.12 - 2020-06-20
 --------------------
 
-.. _new-features-8:
+.. _new-features-9:
 
 New features
 ~~~~~~~~~~~~
 
 -  improved convergence of ``GeneralizedGamma(Regression)Fitter``.
 
-.. _section-17:
+.. _section-18:
 
 0.24.11 - 2020-06-17
 --------------------
 
-.. _new-features-9:
+.. _new-features-10:
 
 New features
 ~~~~~~~~~~~~
@@ -408,12 +432,12 @@ API Changes
    penalized by ``penalizer`` - we now penalizing everything except
    intercept terms in linear relationships.
 
-.. _section-18:
+.. _section-19:
 
 0.24.10 - 2020-06-16
 --------------------
 
-.. _new-features-10:
+.. _new-features-11:
 
 New features
 ~~~~~~~~~~~~
@@ -430,7 +454,7 @@ API Changes
 -  Related to above: the fitted spline parameters are now available in
    the ``.summary`` and ``.print_summary`` methods.
 
-.. _bug-fixes-13:
+.. _bug-fixes-14:
 
 Bug fixes
 ~~~~~~~~~
@@ -438,12 +462,12 @@ Bug fixes
 -  fixed a bug in initialization of some interval-censoring models ->
    better convergence.
 
-.. _section-19:
+.. _section-20:
 
 0.24.9 - 2020-06-05
 -------------------
 
-.. _new-features-11:
+.. _new-features-12:
 
 New features
 ~~~~~~~~~~~~
@@ -453,7 +477,7 @@ New features
    ``tarone-ware``, ``peto``, ``fleming-harrington``. Thanks @sean-reed
 -  new interval censored dataset: ``lifelines.datasets.load_mice``
 
-.. _bug-fixes-14:
+.. _bug-fixes-15:
 
 Bug fixes
 ~~~~~~~~~
@@ -461,12 +485,12 @@ Bug fixes
 -  Cleared up some mislabeling in ``plot_loglogs``. Thanks @sean-reed!
 -  tuples are now able to be used as input in univariate models.
 
-.. _section-20:
+.. _section-21:
 
 0.24.8 - 2020-05-17
 -------------------
 
-.. _new-features-12:
+.. _new-features-13:
 
 New features
 ~~~~~~~~~~~~
@@ -475,12 +499,12 @@ New features
    Not all edge cases are fully checked, and some features are missing.
    Try it under ``KaplanMeierFitter.fit_interval_censoring``
 
-.. _section-21:
+.. _section-22:
 
 0.24.7 - 2020-05-17
 -------------------
 
-.. _new-features-13:
+.. _new-features-14:
 
 New features
 ~~~~~~~~~~~~
@@ -496,12 +520,12 @@ New features
 -  some convergence tweaks which should help recent performance
    regressions.
 
-.. _section-22:
+.. _section-23:
 
 0.24.6 - 2020-05-05
 -------------------
 
-.. _new-features-14:
+.. _new-features-15:
 
 New features
 ~~~~~~~~~~~~
@@ -511,7 +535,7 @@ New features
 -  New ``lifelines.plotting.plot_interval_censored_lifetimes`` for
    plotting interval censored data - thanks @sean-reed!
 
-.. _bug-fixes-15:
+.. _bug-fixes-16:
 
 Bug fixes
 ~~~~~~~~~
@@ -519,19 +543,19 @@ Bug fixes
 -  fixed bug where ``cdf_plot`` and ``qq_plot`` were not factoring in
    the weights correctly.
 
-.. _section-23:
+.. _section-24:
 
 0.24.5 - 2020-05-01
 -------------------
 
-.. _new-features-15:
+.. _new-features-16:
 
 New features
 ~~~~~~~~~~~~
 
 -  ``plot_lifetimes`` accepts pandas Series.
 
-.. _bug-fixes-16:
+.. _bug-fixes-17:
 
 Bug fixes
 ~~~~~~~~~
@@ -541,12 +565,12 @@ Bug fixes
 -  Improved ``at_risk_counts`` for subplots.
 -  More data validation checks for ``CoxTimeVaryingFitter``
 
-.. _section-24:
+.. _section-25:
 
 0.24.4 - 2020-04-13
 -------------------
 
-.. _bug-fixes-17:
+.. _bug-fixes-18:
 
 Bug fixes
 ~~~~~~~~~
@@ -555,12 +579,12 @@ Bug fixes
 -  setting a dataframe in ``ancillary_df`` works for interval censoring
 -  ``.score`` works for interval censored models
 
-.. _section-25:
+.. _section-26:
 
 0.24.3 - 2020-03-25
 -------------------
 
-.. _new-features-16:
+.. _new-features-17:
 
 New features
 ~~~~~~~~~~~~
@@ -570,7 +594,7 @@ New features
    the hazard ratio would be at previous times. This is useful because
    the final hazard ratio is some weighted average of these.
 
-.. _bug-fixes-18:
+.. _bug-fixes-19:
 
 Bug fixes
 ~~~~~~~~~
@@ -578,12 +602,12 @@ Bug fixes
 -  Fixed error in HTML printer that was hiding concordance index
    information.
 
-.. _section-26:
+.. _section-27:
 
 0.24.2 - 2020-03-15
 -------------------
 
-.. _bug-fixes-19:
+.. _bug-fixes-20:
 
 Bug fixes
 ~~~~~~~~~
@@ -595,12 +619,12 @@ Bug fixes
 -  Fixed a keyword bug in ``plot_covariate_groups`` for parametric
    models.
 
-.. _section-27:
+.. _section-28:
 
 0.24.1 - 2020-03-05
 -------------------
 
-.. _new-features-17:
+.. _new-features-18:
 
 New features
 ~~~~~~~~~~~~
@@ -608,14 +632,14 @@ New features
 -  Stability improvements for GeneralizedGammaRegressionFitter and
    CoxPHFitter with spline estimation.
 
-.. _bug-fixes-20:
+.. _bug-fixes-21:
 
 Bug fixes
 ~~~~~~~~~
 
 -  Fixed bug with plotting hazards in NelsonAalenFitter.
 
-.. _section-28:
+.. _section-29:
 
 0.24.0 - 2020-02-20
 -------------------
@@ -624,7 +648,7 @@ This version and future versions of lifelines no longer support py35.
 Pandas 1.0 is fully supported, along with previous versions. Minimum
 Scipy has been bumped to 1.2.0.
 
-.. _new-features-18:
+.. _new-features-19:
 
 New features
 ~~~~~~~~~~~~
@@ -676,7 +700,7 @@ API Changes
    to ``scoring_method``.
 -  removed ``_score_`` and ``path`` from Cox model.
 
-.. _bug-fixes-21:
+.. _bug-fixes-22:
 
 Bug fixes
 ~~~~~~~~~
@@ -689,12 +713,12 @@ Bug fixes
 -  Cox models now incorporate any penalizers in their
    ``log_likelihood_``
 
-.. _section-29:
+.. _section-30:
 
 0.23.9 - 2020-01-28
 -------------------
 
-.. _bug-fixes-22:
+.. _bug-fixes-23:
 
 Bug fixes
 ~~~~~~~~~
@@ -705,12 +729,12 @@ Bug fixes
    of ``GeneralizedGammaRegressionFitter`` and any custom regression
    models should update their code as soon as possible.
 
-.. _section-30:
+.. _section-31:
 
 0.23.8 - 2020-01-21
 -------------------
 
-.. _bug-fixes-23:
+.. _bug-fixes-24:
 
 Bug fixes
 ~~~~~~~~~
@@ -721,19 +745,19 @@ Bug fixes
    ``GeneralizedGammaRegressionFitter`` and any custom regression models
    should update their code as soon as possible.
 
-.. _section-31:
+.. _section-32:
 
 0.23.7 - 2020-01-14
 -------------------
 
 Bug fixes for py3.5.
 
-.. _section-32:
+.. _section-33:
 
 0.23.6 - 2020-01-07
 -------------------
 
-.. _new-features-19:
+.. _new-features-20:
 
 New features
 ~~~~~~~~~~~~
@@ -747,12 +771,12 @@ New features
 -  custom parametric regression models can now do left and interval
    censoring.
 
-.. _section-33:
+.. _section-34:
 
 0.23.5 - 2020-01-05
 -------------------
 
-.. _new-features-20:
+.. _new-features-21:
 
 New features
 ~~~~~~~~~~~~
@@ -761,7 +785,7 @@ New features
 -  New lymph node cancer dataset, originally from *H.F. for the German
    Breast Cancer Study Group (GBSG) (1994)*
 
-.. _bug-fixes-24:
+.. _bug-fixes-25:
 
 Bug fixes
 ~~~~~~~~~
@@ -771,26 +795,26 @@ Bug fixes
 -  fixed bug where large exponential numbers in ``print_summary`` were
    not being suppressed correctly.
 
-.. _section-34:
+.. _section-35:
 
 0.23.4 - 2019-12-15
 -------------------
 
 -  Bug fix for PyPI
 
-.. _section-35:
+.. _section-36:
 
 0.23.3 - 2019-12-11
 -------------------
 
-.. _new-features-21:
+.. _new-features-22:
 
 New features
 ~~~~~~~~~~~~
 
 -  ``StatisticalResult.print_summary`` supports html output.
 
-.. _bug-fixes-25:
+.. _bug-fixes-26:
 
 Bug fixes
 ~~~~~~~~~
@@ -798,12 +822,12 @@ Bug fixes
 -  fix import in ``printer.py``
 -  fix html printing with Univariate models.
 
-.. _section-36:
+.. _section-37:
 
 0.23.2 - 2019-12-07
 -------------------
 
-.. _new-features-22:
+.. _new-features-23:
 
 New features
 ~~~~~~~~~~~~
@@ -815,7 +839,7 @@ New features
 -  performance improvements on regression models’ preprocessing. Should
    make datasets with high number of columns more performant.
 
-.. _bug-fixes-26:
+.. _bug-fixes-27:
 
 Bug fixes
 ~~~~~~~~~
@@ -824,12 +848,12 @@ Bug fixes
 -  fixed repr for ``sklearn_adapter`` classes.
 -  fixed ``conditional_after`` in Cox model with strata was used.
 
-.. _section-37:
+.. _section-38:
 
 0.23.1 - 2019-11-27
 -------------------
 
-.. _new-features-23:
+.. _new-features-24:
 
 New features
 ~~~~~~~~~~~~
@@ -839,7 +863,7 @@ New features
 -  performance improvements for ``CoxPHFitter`` - up to 30% performance
    improvements for some datasets.
 
-.. _bug-fixes-27:
+.. _bug-fixes-28:
 
 Bug fixes
 ~~~~~~~~~
@@ -851,12 +875,12 @@ Bug fixes
 -  fixed bug when using ``print_summary`` with left censored models.
 -  lots of minor bug fixes.
 
-.. _section-38:
+.. _section-39:
 
 0.23.0 - 2019-11-17
 -------------------
 
-.. _new-features-24:
+.. _new-features-25:
 
 New features
 ~~~~~~~~~~~~
@@ -865,7 +889,7 @@ New features
    Jupyter notebooks!
 -  silenced some warnings.
 
-.. _bug-fixes-28:
+.. _bug-fixes-29:
 
 Bug fixes
 ~~~~~~~~~
@@ -887,7 +911,7 @@ API Changes
 -  ``left_censorship`` in ``fit`` has been removed in favour of
    ``fit_left_censoring``.
 
-.. _section-39:
+.. _section-40:
 
 0.22.10 - 2019-11-08
 --------------------
@@ -895,7 +919,7 @@ API Changes
 The tests were re-factored to be shipped with the package. Let me know
 if this causes problems.
 
-.. _bug-fixes-29:
+.. _bug-fixes-30:
 
 Bug fixes
 ~~~~~~~~~
@@ -905,12 +929,12 @@ Bug fixes
 -  fixed bug in plot_covariate_groups for AFT models when >1d arrays
    were used for values arg.
 
-.. _section-40:
+.. _section-41:
 
 0.22.9 - 2019-10-30
 -------------------
 
-.. _bug-fixes-30:
+.. _bug-fixes-31:
 
 Bug fixes
 ~~~~~~~~~
@@ -922,12 +946,12 @@ Bug fixes
 -  ``CoxPHFitter`` now displays correct columns values when changing
    alpha param.
 
-.. _section-41:
+.. _section-42:
 
 0.22.8 - 2019-10-06
 -------------------
 
-.. _new-features-25:
+.. _new-features-26:
 
 New features
 ~~~~~~~~~~~~
@@ -937,19 +961,19 @@ New features
 -  ``conditional_after`` now available in ``CoxPHFitter.predict_median``
 -  Suppressed some unimportant warnings.
 
-.. _bug-fixes-31:
+.. _bug-fixes-32:
 
 Bug fixes
 ~~~~~~~~~
 
 -  fixed initial_point being ignored in AFT models.
 
-.. _section-42:
+.. _section-43:
 
 0.22.7 - 2019-09-29
 -------------------
 
-.. _new-features-26:
+.. _new-features-27:
 
 New features
 ~~~~~~~~~~~~
@@ -957,7 +981,7 @@ New features
 -  new ``ApproximationWarning`` to tell you if the package is making an
    potentially mislead approximation.
 
-.. _bug-fixes-32:
+.. _bug-fixes-33:
 
 Bug fixes
 ~~~~~~~~~
@@ -976,19 +1000,19 @@ API Changes
 -  Some previous ``StatisticalWarnings`` have been replaced by
    ``ApproximationWarning``
 
-.. _section-43:
+.. _section-44:
 
 0.22.6 - 2019-09-25
 -------------------
 
-.. _new-features-27:
+.. _new-features-28:
 
 New features
 ~~~~~~~~~~~~
 
 -  ``conditional_after`` works for ``CoxPHFitter`` prediction models 😅
 
-.. _bug-fixes-33:
+.. _bug-fixes-34:
 
 Bug fixes
 ~~~~~~~~~
@@ -1004,12 +1028,12 @@ API Changes
 -  ``utils.dataframe_interpolate_at_times`` renamed to
    ``utils.interpolate_at_times_and_return_pandas``.
 
-.. _section-44:
+.. _section-45:
 
 0.22.5 - 2019-09-20
 -------------------
 
-.. _new-features-28:
+.. _new-features-29:
 
 New features
 ~~~~~~~~~~~~
@@ -1018,7 +1042,7 @@ New features
    weights.
 -  Better support for predicting on Pandas Series
 
-.. _bug-fixes-34:
+.. _bug-fixes-35:
 
 Bug fixes
 ~~~~~~~~~
@@ -1035,12 +1059,12 @@ API Changes
 -  ``_get_initial_value`` in parametric univariate models is renamed
    ``_create_initial_point``
 
-.. _section-45:
+.. _section-46:
 
 0.22.4 - 2019-09-04
 -------------------
 
-.. _new-features-29:
+.. _new-features-30:
 
 New features
 ~~~~~~~~~~~~
@@ -1059,7 +1083,7 @@ API changes
 -  ``KaplanMeierFitter.survival_function_``\ ‘s’ index is no longer
    given the name “timeline”.
 
-.. _bug-fixes-35:
+.. _bug-fixes-36:
 
 Bug fixes
 ~~~~~~~~~
@@ -1067,12 +1091,12 @@ Bug fixes
 -  Fixed issue where ``concordance_index`` would never exit if NaNs in
    dataset.
 
-.. _section-46:
+.. _section-47:
 
 0.22.3 - 2019-08-08
 -------------------
 
-.. _new-features-30:
+.. _new-features-31:
 
 New features
 ~~~~~~~~~~~~
@@ -1096,7 +1120,7 @@ API changes
    gains only in Cox models, and only a small fraction of the API was
    being used.
 
-.. _bug-fixes-36:
+.. _bug-fixes-37:
 
 Bug fixes
 ~~~~~~~~~
@@ -1108,19 +1132,19 @@ Bug fixes
 -  Fixed an error in the ``predict_percentile`` of
    ``LogLogisticAFTFitter``. New tests have been added around this.
 
-.. _section-47:
+.. _section-48:
 
 0.22.2 - 2019-07-25
 -------------------
 
-.. _new-features-31:
+.. _new-features-32:
 
 New features
 ~~~~~~~~~~~~
 
 -  lifelines is now compatible with scipy>=1.3.0
 
-.. _bug-fixes-37:
+.. _bug-fixes-38:
 
 Bug fixes
 ~~~~~~~~~
@@ -1131,12 +1155,12 @@ Bug fixes
    errors when using the library. The correctly numpy has been pinned
    (to 1.14.0+)
 
-.. _section-48:
+.. _section-49:
 
 0.22.1 - 2019-07-14
 -------------------
 
-.. _new-features-32:
+.. _new-features-33:
 
 New features
 ~~~~~~~~~~~~
@@ -1164,7 +1188,7 @@ API changes
    ``.print_summary`` includes confidence intervals for the exponential
    of the value.
 
-.. _bug-fixes-38:
+.. _bug-fixes-39:
 
 Bug fixes
 ~~~~~~~~~
@@ -1174,12 +1198,12 @@ Bug fixes
 -  fixed an overflow bug in ``KaplanMeierFitter`` confidence intervals
 -  improvements in data validation for ``CoxTimeVaryingFitter``
 
-.. _section-49:
+.. _section-50:
 
 0.22.0 - 2019-07-03
 -------------------
 
-.. _new-features-33:
+.. _new-features-34:
 
 New features
 ~~~~~~~~~~~~
@@ -1213,7 +1237,7 @@ API changes
    could set ``fit_intercept`` to False and not have to set
    ``ancillary_df`` - now one must specify a DataFrame.
 
-.. _bug-fixes-39:
+.. _bug-fixes-40:
 
 Bug fixes
 ~~~~~~~~~
@@ -1222,21 +1246,21 @@ Bug fixes
    is now exact instead of an approximation.
 -  fixed a name error bug in ``CoxTimeVaryingFitter.plot``
 
-.. _section-50:
+.. _section-51:
 
 0.21.5 - 2019-06-22
 -------------------
 
 I’m skipping 0.21.4 version because of deployment issues.
 
-.. _new-features-34:
+.. _new-features-35:
 
 New features
 ~~~~~~~~~~~~
 
 -  ``scoring_method`` now a kwarg on ``sklearn_adapter``
 
-.. _bug-fixes-40:
+.. _bug-fixes-41:
 
 Bug fixes
 ~~~~~~~~~
@@ -1246,12 +1270,12 @@ Bug fixes
 -  fixed visual bug that misaligned x-axis ticks and at-risk counts.
    Thanks @christopherahern!
 
-.. _section-51:
+.. _section-52:
 
 0.21.3 - 2019-06-04
 -------------------
 
-.. _new-features-35:
+.. _new-features-36:
 
 New features
 ~~~~~~~~~~~~
@@ -1265,19 +1289,19 @@ New features
 -  ``CoxPHFitter.check_assumptions`` now accepts a ``columns`` parameter
    to specify only checking a subset of columns.
 
-.. _bug-fixes-41:
+.. _bug-fixes-42:
 
 Bug fixes
 ~~~~~~~~~
 
 -  ``covariates_from_event_matrix`` handle nulls better
 
-.. _section-52:
+.. _section-53:
 
 0.21.2 - 2019-05-16
 -------------------
 
-.. _new-features-36:
+.. _new-features-37:
 
 New features
 ~~~~~~~~~~~~
@@ -1301,17 +1325,17 @@ API changes
 -  removing ``_compute_likelihood_ratio_test`` on regression models. Use
    ``log_likelihood_ratio_test`` now.
 
-.. _bug-fixes-42:
+.. _bug-fixes-43:
 
 Bug fixes
 ~~~~~~~~~
 
-.. _section-53:
+.. _section-54:
 
 0.21.1 - 2019-04-26
 -------------------
 
-.. _new-features-37:
+.. _new-features-38:
 
 New features
 ~~~~~~~~~~~~
@@ -1328,19 +1352,19 @@ API changes
 -  output of ``survival_table_from_events`` when collapsing rows to
    intervals now removes the “aggregate” column multi-index.
 
-.. _bug-fixes-43:
+.. _bug-fixes-44:
 
 Bug fixes
 ~~~~~~~~~
 
 -  fixed bug in CoxTimeVaryingFitter when ax is provided, thanks @j-i-l!
 
-.. _section-54:
+.. _section-55:
 
 0.21.0 - 2019-04-12
 -------------------
 
-.. _new-features-38:
+.. _new-features-39:
 
 New features
 ~~~~~~~~~~~~
@@ -1365,7 +1389,7 @@ API changes
 -  ``entries`` property in multivariate parametric models has a new
    Series name: ``entry``
 
-.. _bug-fixes-44:
+.. _bug-fixes-45:
 
 Bug fixes
 ~~~~~~~~~
@@ -1375,12 +1399,12 @@ Bug fixes
 -  Fixed an error that didn’t let users use Numpy arrays in prediction
    for AFT models
 
-.. _section-55:
+.. _section-56:
 
 0.20.5 - 2019-04-08
 -------------------
 
-.. _new-features-39:
+.. _new-features-40:
 
 New features
 ~~~~~~~~~~~~
@@ -1397,7 +1421,7 @@ API changes
 -  in ``AalenJohansenFitter``, the ``variance`` parameter is renamed to
    ``variance_`` to align with the usual lifelines convention.
 
-.. _bug-fixes-45:
+.. _bug-fixes-46:
 
 Bug fixes
 ~~~~~~~~~
@@ -1406,12 +1430,12 @@ Bug fixes
    test when using strata.
 -  Fixed some plotting bugs with ``AalenJohansenFitter``
 
-.. _section-56:
+.. _section-57:
 
 0.20.4 - 2019-03-27
 -------------------
 
-.. _new-features-40:
+.. _new-features-41:
 
 New features
 ~~~~~~~~~~~~
@@ -1430,7 +1454,7 @@ API changes
 -  Pandas is now correctly pinned to >= 0.23.0. This was always the
    case, but not specified in setup.py correctly.
 
-.. _bug-fixes-46:
+.. _bug-fixes-47:
 
 Bug fixes
 ~~~~~~~~~
@@ -1439,12 +1463,12 @@ Bug fixes
 -  ``PiecewiseExponentialFitter`` is available with
    ``from lifelines import *``.
 
-.. _section-57:
+.. _section-58:
 
 0.20.3 - 2019-03-23
 -------------------
 
-.. _new-features-41:
+.. _new-features-42:
 
 New features
 ~~~~~~~~~~~~
@@ -1457,12 +1481,12 @@ New features
    ``plot_survival_function`` and
    ``confidence_interval_survival_function_``.
 
-.. _section-58:
+.. _section-59:
 
 0.20.2 - 2019-03-21
 -------------------
 
-.. _new-features-42:
+.. _new-features-43:
 
 New features
 ~~~~~~~~~~~~
@@ -1486,7 +1510,7 @@ API changes
    @vpolimenov!
 -  The ``C`` column in ``load_lcd`` dataset is renamed to ``E``.
 
-.. _bug-fixes-47:
+.. _bug-fixes-48:
 
 Bug fixes
 ~~~~~~~~~
@@ -1502,7 +1526,7 @@ Bug fixes
    the q parameter was below the truncation limit. This should have been
    ``-np.inf``
 
-.. _section-59:
+.. _section-60:
 
 0.20.1 - 2019-03-16
 -------------------
@@ -1526,7 +1550,7 @@ API changes
    This is no longer the case. A 0 will still be added if there is a
    duration (observed or not) at 0 occurs however.
 
-.. _section-60:
+.. _section-61:
 
 0.20.0 - 2019-03-05
 -------------------
@@ -1535,7 +1559,7 @@ API changes
    recent installs where Py3.
 -  Updated minimum dependencies, specifically Matplotlib and Pandas.
 
-.. _new-features-43:
+.. _new-features-44:
 
 New features
 ~~~~~~~~~~~~
@@ -1555,19 +1579,19 @@ API changes
    transposed now (previous parameters where columns, now parameters are
    rows).
 
-.. _bug-fixes-48:
+.. _bug-fixes-49:
 
 Bug fixes
 ~~~~~~~~~
 
 -  Fixed a bug with plotting and ``check_assumptions``.
 
-.. _section-61:
+.. _section-62:
 
 0.19.5 - 2019-02-26
 -------------------
 
-.. _new-features-44:
+.. _new-features-45:
 
 New features
 ~~~~~~~~~~~~
@@ -1577,24 +1601,24 @@ New features
    features or categorical variables.
 -  Convergence improvements for AFT models.
 
-.. _section-62:
+.. _section-63:
 
 0.19.4 - 2019-02-25
 -------------------
 
-.. _bug-fixes-49:
+.. _bug-fixes-50:
 
 Bug fixes
 ~~~~~~~~~
 
 -  remove some bad print statements in ``CoxPHFitter``.
 
-.. _section-63:
+.. _section-64:
 
 0.19.3 - 2019-02-25
 -------------------
 
-.. _new-features-45:
+.. _new-features-46:
 
 New features
 ~~~~~~~~~~~~
@@ -1606,12 +1630,12 @@ New features
 -  Performance increase to ``print_summary`` in the ``CoxPHFitter`` and
    ``CoxTimeVaryingFitter`` model.
 
-.. _section-64:
+.. _section-65:
 
 0.19.2 - 2019-02-22
 -------------------
 
-.. _new-features-46:
+.. _new-features-47:
 
 New features
 ~~~~~~~~~~~~
@@ -1619,7 +1643,7 @@ New features
 -  ``ParametricUnivariateFitters``, like ``WeibullFitter``, have
    smoothed plots when plotting (vs stepped plots)
 
-.. _bug-fixes-50:
+.. _bug-fixes-51:
 
 Bug fixes
 ~~~~~~~~~
@@ -1629,12 +1653,12 @@ Bug fixes
 -  Univariate fitters are more flexiable and can allow 2-d and
    DataFrames as inputs.
 
-.. _section-65:
+.. _section-66:
 
 0.19.1 - 2019-02-21
 -------------------
 
-.. _new-features-47:
+.. _new-features-48:
 
 New features
 ~~~~~~~~~~~~
@@ -1651,12 +1675,12 @@ API changes
    ``PiecewiseExponential`` to the same as ``ExponentialFitter`` (from
    ``\lambda * t`` to ``t / \lambda``).
 
-.. _section-66:
+.. _section-67:
 
 0.19.0 - 2019-02-20
 -------------------
 
-.. _new-features-48:
+.. _new-features-49:
 
 New features
 ~~~~~~~~~~~~
@@ -1695,7 +1719,7 @@ API changes
    means that the *default* for alpha is set to 0.05 in the latest
    lifelines, instead of 0.95 in previous versions.
 
-.. _bug-fixes-51:
+.. _bug-fixes-52:
 
 Bug Fixes
 ~~~~~~~~~
@@ -1712,7 +1736,7 @@ Bug Fixes
    models. Thanks @airanmehr!
 -  Fixed some Pandas <0.24 bugs.
 
-.. _section-67:
+.. _section-68:
 
 0.18.6 - 2019-02-13
 -------------------
@@ -1722,7 +1746,7 @@ Bug Fixes
    ``rank`` and ``km`` p-values now.
 -  some performance improvements to ``qth_survival_time``.
 
-.. _section-68:
+.. _section-69:
 
 0.18.5 - 2019-02-11
 -------------------
@@ -1743,7 +1767,7 @@ Bug Fixes
    that can be used to turn off variance calculations since this can
    take a long time for large datasets. Thanks @pzivich!
 
-.. _section-69:
+.. _section-70:
 
 0.18.4 - 2019-02-10
 -------------------
@@ -1753,7 +1777,7 @@ Bug Fixes
 -  adding left-truncation support to parametric univarite models with
    the ``entry`` kwarg in ``.fit``
 
-.. _section-70:
+.. _section-71:
 
 0.18.3 - 2019-02-07
 -------------------
@@ -1763,7 +1787,7 @@ Bug Fixes
    warnings are more noticeable.
 -  Improved some warning and error messages.
 
-.. _section-71:
+.. _section-72:
 
 0.18.2 - 2019-02-05
 -------------------
@@ -1779,7 +1803,7 @@ Bug Fixes
    Moved them all (most) to use ``autograd``.
 -  ``LogNormalFitter`` no longer models ``log_sigma``.
 
-.. _section-72:
+.. _section-73:
 
 0.18.1 - 2019-02-02
 -------------------
@@ -1790,7 +1814,7 @@ Bug Fixes
 -  use the ``autograd`` lib to help with gradients.
 -  New ``LogLogisticFitter`` univariate fitter available.
 
-.. _section-73:
+.. _section-74:
 
 0.18.0 - 2019-01-31
 -------------------
@@ -1827,7 +1851,7 @@ Bug Fixes
    ``LinAlgError: Matrix is singular.`` and report back to the user
    advice.
 
-.. _section-74:
+.. _section-75:
 
 0.17.5 - 2019-01-25
 -------------------
@@ -1835,7 +1859,7 @@ Bug Fixes
 -  more bugs in ``plot_covariate_groups`` fixed when using non-numeric
    strata.
 
-.. _section-75:
+.. _section-76:
 
 0.17.4 -2019-01-25
 ------------------
@@ -1847,7 +1871,7 @@ Bug Fixes
 -  ``groups`` is now called ``values`` in
    ``CoxPHFitter.plot_covariate_groups``
 
-.. _section-76:
+.. _section-77:
 
 0.17.3 - 2019-01-24
 -------------------
@@ -1855,7 +1879,7 @@ Bug Fixes
 -  Fix in ``compute_residuals`` when using ``schoenfeld`` and the
    minumum duration has only censored subjects.
 
-.. _section-77:
+.. _section-78:
 
 0.17.2 2019-01-22
 -----------------
@@ -1866,7 +1890,7 @@ Bug Fixes
    ``for`` loop. The downside is the code is more esoteric now. I’ve
    added comments as necessary though 🤞
 
-.. _section-78:
+.. _section-79:
 
 0.17.1 - 2019-01-20
 -------------------
@@ -1883,7 +1907,7 @@ Bug Fixes
 -  Fixes a Pandas performance warning in ``CoxTimeVaryingFitter``.
 -  Performances improvements to ``CoxTimeVaryingFitter``.
 
-.. _section-79:
+.. _section-80:
 
 0.17.0 - 2019-01-11
 -------------------
@@ -1904,7 +1928,7 @@ Bug Fixes
 
 -  some plotting improvemnts to ``plotting.plot_lifetimes``
 
-.. _section-80:
+.. _section-81:
 
 0.16.3 - 2019-01-03
 -------------------
@@ -1912,7 +1936,7 @@ Bug Fixes
 -  More ``CoxPHFitter`` performance improvements. Up to a 40% reduction
    vs 0.16.2 for some datasets.
 
-.. _section-81:
+.. _section-82:
 
 0.16.2 - 2019-01-02
 -------------------
@@ -1923,14 +1947,14 @@ Bug Fixes
    has lots of duplicate times. See
    https://github.com/CamDavidsonPilon/lifelines/issues/591
 
-.. _section-82:
+.. _section-83:
 
 0.16.1 - 2019-01-01
 -------------------
 
 -  Fixed py2 division error in ``concordance`` method.
 
-.. _section-83:
+.. _section-84:
 
 0.16.0 - 2019-01-01
 -------------------
@@ -1966,7 +1990,7 @@ Bug Fixes
    ``lifelines.utils.to_episodic_format``.
 -  ``CoxTimeVaryingFitter`` now accepts ``strata``.
 
-.. _section-84:
+.. _section-85:
 
 0.15.4
 ------
@@ -1974,14 +1998,14 @@ Bug Fixes
 -  bug fix for the Cox model likelihood ratio test when using
    non-trivial weights.
 
-.. _section-85:
+.. _section-86:
 
 0.15.3 - 2018-12-18
 -------------------
 
 -  Only allow matplotlib less than 3.0.
 
-.. _section-86:
+.. _section-87:
 
 0.15.2 - 2018-11-23
 -------------------
@@ -1992,7 +2016,7 @@ Bug Fixes
 -  removed ``entry`` from ``ExponentialFitter`` and ``WeibullFitter`` as
    it was doing nothing.
 
-.. _section-87:
+.. _section-88:
 
 0.15.1 - 2018-11-23
 -------------------
@@ -2001,7 +2025,7 @@ Bug Fixes
 -  Raise NotImplementedError if the ``robust`` flag is used in
    ``CoxTimeVaryingFitter`` - that’s not ready yet.
 
-.. _section-88:
+.. _section-89:
 
 0.15.0 - 2018-11-22
 -------------------
@@ -2072,7 +2096,7 @@ Bug Fixes
    When Estimating Risks in Pharmacoepidemiology” for a nice overview of
    the model.
 
-.. _section-89:
+.. _section-90:
 
 0.14.6 - 2018-07-02
 -------------------
@@ -2080,7 +2104,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test`` (again).
 -  fix bug for when ``event_observed`` column was not boolean.
 
-.. _section-90:
+.. _section-91:
 
 0.14.5 - 2018-06-29
 -------------------
@@ -2088,7 +2112,7 @@ Bug Fixes
 -  fix for n > 2 groups in ``multivariate_logrank_test``
 -  fix weights in KaplanMeierFitter when using a pandas Series.
 
-.. _section-91:
+.. _section-92:
 
 0.14.4 - 2018-06-14
 -------------------
@@ -2105,7 +2129,7 @@ Bug Fixes
 -  New ``delay`` parameter in ``add_covariate_to_timeline``
 -  removed ``two_sided_z_test`` from ``statistics``
 
-.. _section-92:
+.. _section-93:
 
 0.14.3 - 2018-05-24
 -------------------
@@ -2117,7 +2141,7 @@ Bug Fixes
 -  adds a ``column`` argument to ``CoxTimeVaryingFitter`` and
    ``CoxPHFitter`` ``plot`` method to plot only a subset of columns.
 
-.. _section-93:
+.. _section-94:
 
 0.14.2 - 2018-05-18
 -------------------
@@ -2125,7 +2149,7 @@ Bug Fixes
 -  some quality of life improvements for working with
    ``CoxTimeVaryingFitter`` including new ``predict_`` methods.
 
-.. _section-94:
+.. _section-95:
 
 0.14.1 - 2018-04-01
 -------------------
@@ -2143,7 +2167,7 @@ Bug Fixes
    faster completion of ``fit`` for large dataframes, and up to 10%
    faster for small dataframes.
 
-.. _section-95:
+.. _section-96:
 
 0.14.0 - 2018-03-03
 -------------------
@@ -2165,7 +2189,7 @@ Bug Fixes
    of a ``RuntimeWarning``
 -  New checks for complete separation in the dataset for regressions.
 
-.. _section-96:
+.. _section-97:
 
 0.13.0 - 2017-12-22
 -------------------
@@ -2194,7 +2218,7 @@ Bug Fixes
    group the same subjects together and give that observation a weight
    equal to the count. Altogether, this means a much faster regression.
 
-.. _section-97:
+.. _section-98:
 
 0.12.0
 ------
@@ -2211,7 +2235,7 @@ Bug Fixes
 -  Additional functionality to ``utils.survival_table_from_events`` to
    bin the index to make the resulting table more readable.
 
-.. _section-98:
+.. _section-99:
 
 0.11.3
 ------
@@ -2223,7 +2247,7 @@ Bug Fixes
    observation or censorship.
 -  More accurate prediction methods parametrics univariate models.
 
-.. _section-99:
+.. _section-100:
 
 0.11.2
 ------
@@ -2231,14 +2255,14 @@ Bug Fixes
 -  Changing liscense to valilla MIT.
 -  Speed up ``NelsonAalenFitter.fit`` considerably.
 
-.. _section-100:
+.. _section-101:
 
 0.11.1 - 2017-06-22
 -------------------
 
 -  Python3 fix for ``CoxPHFitter.plot``.
 
-.. _section-101:
+.. _section-102:
 
 0.11.0 - 2017-06-21
 -------------------
@@ -2252,14 +2276,14 @@ Bug Fixes
    of a new ``loc`` kwarg. This is to align with Pandas deprecating
    ``ix``
 
-.. _section-102:
+.. _section-103:
 
 0.10.1 - 2017-06-05
 -------------------
 
 -  fix in internal normalization for ``CoxPHFitter`` predict methods.
 
-.. _section-103:
+.. _section-104:
 
 0.10.0
 ------
@@ -2274,7 +2298,7 @@ Bug Fixes
    mimic R’s ``basehaz`` API.
 -  new ``predict_log_partial_hazards`` to ``CoxPHFitter``
 
-.. _section-104:
+.. _section-105:
 
 0.9.4
 -----
@@ -2297,7 +2321,7 @@ Bug Fixes
 -  performance improvements in ``CoxPHFitter`` - should see at least a
    10% speed improvement in ``fit``.
 
-.. _section-105:
+.. _section-106:
 
 0.9.2
 -----
@@ -2306,7 +2330,7 @@ Bug Fixes
 -  throw an error if no admissable pairs in the c-index calculation.
    Previously a NaN was returned.
 
-.. _section-106:
+.. _section-107:
 
 0.9.1
 -----
@@ -2314,7 +2338,7 @@ Bug Fixes
 -  add two summary functions to Weibull and Exponential fitter, solves
    #224
 
-.. _section-107:
+.. _section-108:
 
 0.9.0
 -----
@@ -2330,7 +2354,7 @@ Bug Fixes
 -  Default predict method in ``k_fold_cross_validation`` is now
    ``predict_expectation``
 
-.. _section-108:
+.. _section-109:
 
 0.8.1 - 2015-08-01
 ------------------
@@ -2347,7 +2371,7 @@ Bug Fixes
    -  scaling of smooth hazards in NelsonAalenFitter was off by a factor
       of 0.5.
 
-.. _section-109:
+.. _section-110:
 
 0.8.0
 -----
@@ -2366,7 +2390,7 @@ Bug Fixes
    ``lifelines.statistics. power_under_cph``.
 -  fixed a bug when using KaplanMeierFitter for left-censored data.
 
-.. _section-110:
+.. _section-111:
 
 0.7.1
 -----
@@ -2385,7 +2409,7 @@ Bug Fixes
 -  refactor each fitter into it’s own submodule. For now, the tests are
    still in the same file. This will also *not* break the API.
 
-.. _section-111:
+.. _section-112:
 
 0.7.0 - 2015-03-01
 ------------------
@@ -2404,7 +2428,7 @@ Bug Fixes
    duration remaining until the death event, given survival up until
    time t.
 
-.. _section-112:
+.. _section-113:
 
 0.6.1
 -----
@@ -2416,7 +2440,7 @@ Bug Fixes
    your work is to sum up the survival function (for expected values or
    something similar), it’s more difficult to make a mistake.
 
-.. _section-113:
+.. _section-114:
 
 0.6.0 - 2015-02-04
 ------------------
@@ -2439,7 +2463,7 @@ Bug Fixes
 -  In ``KaplanMeierFitter``, ``epsilon`` has been renamed to
    ``precision``.
 
-.. _section-114:
+.. _section-115:
 
 0.5.1 - 2014-12-24
 ------------------
@@ -2460,7 +2484,7 @@ Bug Fixes
    ``lifelines.plotting.add_at_risk_counts``.
 -  Fix bug Epanechnikov kernel.
 
-.. _section-115:
+.. _section-116:
 
 0.5.0 - 2014-12-07
 ------------------
@@ -2473,7 +2497,7 @@ Bug Fixes
 -  add test for summary()
 -  Alternate metrics can be used for ``k_fold_cross_validation``.
 
-.. _section-116:
+.. _section-117:
 
 0.4.4 - 2014-11-27
 ------------------
@@ -2485,7 +2509,7 @@ Bug Fixes
 -  Fixes bug in 1-d input not returning in CoxPHFitter
 -  Lots of new tests.
 
-.. _section-117:
+.. _section-118:
 
 0.4.3 - 2014-07-23
 ------------------
@@ -2506,7 +2530,7 @@ Bug Fixes
 -  Adds option ``include_likelihood`` to CoxPHFitter fit method to save
    the final log-likelihood value.
 
-.. _section-118:
+.. _section-119:
 
 0.4.2 - 2014-06-19
 ------------------
@@ -2526,7 +2550,7 @@ Bug Fixes
    from failing so often (this a stop-gap)
 -  pep8 everything
 
-.. _section-119:
+.. _section-120:
 
 0.4.1.1
 -------
@@ -2539,7 +2563,7 @@ Bug Fixes
 -  Adding more robust cross validation scheme based on issue #67.
 -  fixing ``regression_dataset`` in ``datasets``.
 
-.. _section-120:
+.. _section-121:
 
 0.4.1 - 2014-06-11
 ------------------
@@ -2558,7 +2582,7 @@ Bug Fixes
 -  Adding a Changelog.
 -  more sanitizing for the statistical tests =)
 
-.. _section-121:
+.. _section-122:
 
 0.4.0 - 2014-06-08
 ------------------

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -347,11 +347,7 @@ class CoxTimeVaryingFitter(SemiParametricRegressionFitter, ProportionalHazardMix
         soft_abs = lambda x, a: 1 / a * (anp.logaddexp(0, -a * x) + anp.logaddexp(0, a * x))
         penalizer = (
             lambda beta, a: n
-            * self.penalizer
-            * (
-                self.l1_ratio * (soft_abs(beta, a)).sum()
-                + 0.5 * (1 - self.l1_ratio) * (beta ** 2).sum()
-            )
+            * (self.penalizer * (self.l1_ratio * (soft_abs(beta, a)) + 0.5 * (1 - self.l1_ratio) * (beta ** 2))).sum()
         )
         d_penalizer = elementwise_grad(penalizer)
         dd_penalizer = elementwise_grad(d_penalizer)

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1461,11 +1461,7 @@ estimate the variances. See paper "Variance estimation when using inverse probab
         soft_abs = lambda x, a: 1 / a * (anp.logaddexp(0, -a * x) + anp.logaddexp(0, a * x))
         elastic_net_penalty = (
             lambda beta, a: n
-            * self.penalizer
-            * (
-                self.l1_ratio * (soft_abs(beta, a)).sum()
-                + 0.5 * (1 - self.l1_ratio) * (beta ** 2).sum()
-            )
+            * (self.penalizer * (self.l1_ratio * (soft_abs(beta, a)) + 0.5 * (1 - self.l1_ratio) * (beta ** 2))).sum()
         )
         d_elastic_net_penalty = elementwise_grad(elastic_net_penalty)
         dd_elastic_net_penalty = elementwise_grad(d_elastic_net_penalty)

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -448,6 +448,11 @@ def add_at_risk_counts(
 
     if rows_to_show is None:
         rows_to_show = ["At risk", "Censored", "Events"]
+    else:
+        assert all(
+            row in ["At risk", "Censored", "Events"] for row in rows_to_show
+        ), 'must be one of ["At risk", "Censored", "Events"]'
+
     n_rows = len(rows_to_show)
 
     # Create another axes where we can put size ticks
@@ -504,8 +509,7 @@ def add_at_risk_counts(
                             lbl += ("\n" if i > 0 else "") + r"%s" % labels[int(i / n_rows)] + "\n"
 
                     l = rows_to_show[i % n_rows]
-                    l = {"At risk": "  At risk", "Censored": "Censored  ", "Events": " Events  "}.get(l)
-                    s = "{}   ".format(l.rjust(10, " ")) + "{{:>{}d}}\n".format(max_length)
+                    s = "{}".format(l.rjust(10, " ")) + (" " * (max_length - len(str(c)) + 3)) + "{{:>{}d}}\n".format(max_length)
 
                     lbl += s.format(c)
 
@@ -526,7 +530,11 @@ def add_at_risk_counts(
                 lbl += rows_to_show[0] + "\n"
 
                 for i, c in enumerate(counts):
-                    s = "{}   ".format(labels[i].rjust(10, " ")) + "{{:>{}d}}\n".format(max_length)
+                    s = (
+                        "{}".format(labels[i].rjust(10, " "))
+                        + (" " * (max_length - len(str(c)) + 3))
+                        + "{{:>{}d}}\n".format(max_length)
+                    )
                     lbl += s.format(c)
 
             else:

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -1351,7 +1351,7 @@ class TestKaplanMeierFitter:
         assert hasattr(kmf, "cumulative_density_")
         assert hasattr(kmf, "plot_cumulative_density")
         assert hasattr(kmf, "confidence_interval_cumulative_density_")
-        assert_frame_equal(kmf.confidence_interval_cumulative_density_, kmf.confidence_interval_)
+        assert_frame_equal(kmf.confidence_interval_survival_function_, kmf.confidence_interval_)
 
     def test_late_entry_with_tied_entry_and_death(self):
         np.random.seed(101)

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -863,3 +863,55 @@ class TestPlotting:
         survival_probability_calibration(cph, rossi.loc[300:], 25)
         self.plt.title("test_survival_probability_calibration_on_out_of_sample_data")
         self.plt.show(block=block)
+
+    def test_at_risk_looks_right_when_scales_are_magnitudes_of_order_larger(self, block):
+
+        T1 = list(map(lambda v: v.right, pd.cut(np.arange(32000), 100, retbins=False)))
+        T2 = list(map(lambda v: v.right, pd.cut(np.arange(9000), 100, retbins=False)))
+        T3 = list(map(lambda v: v.right, pd.cut(np.arange(900), 100, retbins=False)))
+        T4 = list(map(lambda v: v.right, pd.cut(np.arange(90), 100, retbins=False)))
+        T5 = list(map(lambda v: v.right, pd.cut(np.arange(9), 100, retbins=False)))
+
+        kmf1 = KaplanMeierFitter().fit(T1, label="Category A")
+        kmf2 = KaplanMeierFitter().fit(T2, label="Category")
+        kmf3 = KaplanMeierFitter().fit(T3, label="CatB")
+        kmf4 = KaplanMeierFitter().fit(T4, label="Categ")
+        kmf5 = KaplanMeierFitter().fit(T5, label="Categowdary B")
+
+        ax = kmf1.plot()
+        ax = kmf2.plot(ax=ax)
+        ax = kmf3.plot(ax=ax)
+        ax = kmf4.plot(ax=ax)
+        ax = kmf5.plot(ax=ax)
+
+        add_at_risk_counts(kmf1, kmf2, kmf3, kmf5, ax=ax)
+
+        self.plt.title("test_at_risk_looks_right_when_scales_are_magnitudes_of_order_larger")
+        self.plt.tight_layout()
+        self.plt.show(block=block)
+
+    def test_at_risk_looks_right_when_scales_are_magnitudes_of_order_larger_single_attribute(self, block):
+
+        T1 = list(map(lambda v: v.right, pd.cut(np.arange(32000), 100, retbins=False)))
+        T2 = list(map(lambda v: v.right, pd.cut(np.arange(9000), 100, retbins=False)))
+        T3 = list(map(lambda v: v.right, pd.cut(np.arange(900), 100, retbins=False)))
+        T4 = list(map(lambda v: v.right, pd.cut(np.arange(90), 100, retbins=False)))
+        T5 = list(map(lambda v: v.right, pd.cut(np.arange(9), 100, retbins=False)))
+
+        kmf1 = KaplanMeierFitter().fit(T1, label="Category A")
+        kmf2 = KaplanMeierFitter().fit(T2, label="Category")
+        kmf3 = KaplanMeierFitter().fit(T3, label="CatB")
+        kmf4 = KaplanMeierFitter().fit(T4, label="Categ")
+        kmf5 = KaplanMeierFitter().fit(T5, label="Categowdary B")
+
+        ax = kmf1.plot()
+        ax = kmf2.plot(ax=ax)
+        ax = kmf3.plot(ax=ax)
+        ax = kmf4.plot(ax=ax)
+        ax = kmf5.plot(ax=ax)
+
+        add_at_risk_counts(kmf1, kmf2, kmf3, kmf4, kmf5, ax=ax, rows_to_show=["At risk"])
+
+        self.plt.title("test_at_risk_looks_right_when_scales_are_magnitudes_of_order_larger")
+        self.plt.tight_layout()
+        self.plt.show(block=block)

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -1001,6 +1001,16 @@ def test_rmst_works_at_kaplan_meier_edge_case():
     assert abs((utils.restricted_mean_survival_time(kmf, t=4 + 0.1) - (1.0 + 0.8 + 0.6 + 0.4 + 0.2 * 0.1))) < 0.0001
 
 
+def test_rmst_works_at_kaplan_meier_with_left_censoring():
+
+    T = [5]
+    kmf = KaplanMeierFitter().fit_left_censoring(T)
+
+    results = utils.restricted_mean_survival_time(kmf, t=10, return_variance=True)
+    assert abs(results[0] - 5) < 0.0001
+    assert abs(results[1] - 0) < 0.0001
+
+
 def test_rmst_exactely_with_known_solution():
     T = np.random.exponential(2, 100)
     exp = ExponentialFitter().fit(T)

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -316,7 +316,7 @@ def _expected_value_of_survival_squared_up_to_t(
     elif isinstance(model_or_survival_function, lifelines.fitters.UnivariateFitter):
         # lifelines model
         model = model_or_survival_function
-        return 2 * quad(lambda tau: (tau * model.predict(tau)), 0, t)[0]
+        return 2 * quad(lambda tau: (tau * model.predict(tau)), 0, t, epsabs=1.49e-10, epsrel=1e-10)[0]
     else:
         raise ValueError("Can't compute value for object %s" % model_or_survival_function)
 
@@ -1758,10 +1758,7 @@ def find_best_parametric_model(
 
     censoring_type = CensoringType(censoring_type)
 
-    evaluation_lookup = {
-        "AIC": lambda model: model.AIC_,
-        "BIC": lambda model: model.BIC_,
-    }
+    evaluation_lookup = {"AIC": lambda model: model.AIC_, "BIC": lambda model: model.BIC_}
 
     eval_ = evaluation_lookup[scoring_method]
 

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.25.12"
+__version__ = "0.26.0"

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.25.11"
+__version__ = "0.25.12"


### PR DESCRIPTION
#### 0.26.0 - 2021-05-26

##### New features
 - `.BIC_` is now present on fitted models.
 - `CoxPHFitter` with spline baseline can accept pre-computed knot locations.
 - Left censoring fitting in KaplanMeierFitter is now "expected". That is, `predict` _always_ predicts the survival function (as does every other model), `confidence_interval_` is _always_ the CI for the survival function (as does every other model), and so on. In summary: the API for estimates doesn't change depending on what your censoring your dataset is.

##### Bug fixes
 - Fixed an annoying bug where at_risk-table label's were not aligning properly when data spanned large ranges. See merging PR for details.
 - Fixed a bug in `find_best_parametric_model` where the wrong BIC value was being computed.
 - Fixed regression bug when using an array as a penalizer in Cox models.



cc @JoseLlanes @yildizyasin your contributions will be released in this version
