### PR TITLE
Adjustment to how durations are calculated for events after cutoff date.

### DIFF
--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -203,8 +203,9 @@ def test_datetimes_to_durations_with_different_frequencies():
 def test_datetimes_to_durations_will_handle_dates_above_fill_date():
     start_date = ["2013-10-08", "2013-10-09", "2013-10-10"]
     end_date = ["2013-10-10", "2013-10-12", "2013-10-15"]
-    T, C = utils.datetimes_to_durations(start_date, end_date, freq="Y", fill_date="2013-10-12")
+    T, C = utils.datetimes_to_durations(start_date, end_date, freq="D", fill_date="2013-10-12")
     npt.assert_almost_equal(C, np.array([1, 1, 0], dtype=bool))
+    npt.assert_almost_equal(T, np.array([2, 3, 2]))
 
 
 def test_datetimes_to_durations_will_handle_dates_above_multi_fill_date():
@@ -218,7 +219,7 @@ def test_datetimes_to_durations_will_handle_dates_above_multi_fill_date():
 
 def test_datetimes_to_durations_will_handle_dates_above_multi_fill_date():
     start_date = ["2013-10-08", "2013-10-09", "2013-10-10"]
-    end_date = ["2013-10-10", None, None]
+    end_date = ["2013-10-10", None, "2013-10-20"]
     last_observation = ["2013-10-10", "2013-10-12", "2013-10-14"]
     T, E = utils.datetimes_to_durations(start_date, end_date, freq="D", fill_date=last_observation)
     npt.assert_almost_equal(E, np.array([1, 0, 0], dtype=bool))

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -679,6 +679,8 @@ def datetimes_to_durations(
     end_times_ = pd.to_datetime(end_times, dayfirst=dayfirst, errors="coerce", format=format)
     deaths_after_cutoff = end_times_ > pd.to_datetime(fill_date_)
     C[deaths_after_cutoff] = False
+    # Avoid duration info leaking from beyond fill date
+    end_times_[deaths_after_cutoff] = pd.to_datetime(fill_date_)
 
     T = (end_times_ - start_times_).values.astype(freq_string).astype(float)
     if (T < 0).sum():


### PR DESCRIPTION
Currently `utils.datetimes_to_durations` calculates durations for censored data in a way that leaks information. For example:

```
import lifelines
start_date = ["2013-10-08", "2013-10-09", "2013-10-10"]
end_date = ["2013-10-10", "2013-10-12", "2013-10-15"]
T, C = lifelines.utils.datetimes_to_durations(start_date, end_date, freq="D", fill_date="2013-10-12")
print(T), print(C);
```
gives:
```
[2. 3. 5.]
[ True  True False]
```
The last item is censored but the duration is calculated based on the provided end date. Consequently, duration calculation makes use of information that would not be available on the cutoff date and results in the the duration being longer than it should be (5 days instead of 2).

This PR attempts to adjust duration calculation for censored items so that information beyond cutoff date would not affect results. Tests have also been updated to reflect this.