### PR TITLE
Print with line break

### DIFF
--- a/lifelines/fitters/aalen_additive_fitter.py
+++ b/lifelines/fitters/aalen_additive_fitter.py
@@ -248,7 +248,7 @@ class AalenAdditiveFitter(RegressionFitter):
             X[exits, :] = 0
 
             if show_progress and i % int((n_deaths / 10)) == 0:
-                print("\rIteration %d/%d, seconds_since_start = %.2f" % (i + 1, n_deaths, time.time() - start), end="")
+                print("\rIteration %d/%d, seconds_since_start = %.2f" % (i + 1, n_deaths, time.time() - start))
 
             last_iteration = i + 1
             # terminate early when there are less than (3 * d) subjects left, where d does not include the intercept.

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -435,7 +435,6 @@ https://lifelines.readthedocs.io/en/latest/Examples.html#problems-with-convergen
                 print(
                     "\rIteration %d: norm_delta = %.5f, step_size = %.5f, ll = %.5f, newton_decrement = %.5f, seconds_since_start = %.1f"
                     % (i, norm_delta, step_size, ll, newton_decrement, time.time() - start_time),
-                    end="",
                 )
 
             # convergence criteria

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -434,8 +434,7 @@ https://lifelines.readthedocs.io/en/latest/Examples.html#problems-with-convergen
             if show_progress:
                 print(
                     "\rIteration %d: norm_delta = %.5f, step_size = %.5f, ll = %.5f, newton_decrement = %.5f, seconds_since_start = %.1f"
-                    % (i, norm_delta, step_size, ll, newton_decrement, time.time() - start_time),
-                )
+                    % (i, norm_delta, step_size, ll, newton_decrement, time.time() - start_time))
 
             # convergence criteria
             if norm_delta < precision:


### PR DESCRIPTION
Updated two of the iteration print statements that weren't to use linebreaks. Otherwise, the iterations get overwritten in a notebook and are jammed together in the terminal.