### PR TITLE
bugfix: 'last_iteration' not initialized

### DIFF
--- a/lifelines/fitters/aalen_additive_fitter.py
+++ b/lifelines/fitters/aalen_additive_fitter.py
@@ -223,6 +223,7 @@ class AalenAdditiveFitter(RegressionFitter):
         variance_hazards_ = np.zeros((n_deaths, d))
         v = np.zeros(d)
         start = time.time()
+        last_iteration = 0
 
         W = np.sqrt(weights)
         X = W[:, None] * X


### PR DESCRIPTION
issue #1439 

In: lifelines/fitters/aalen_additive_fitter.py
line: 265
error: UnboundLocalError: local variable 'last_iteration' referenced before assignment.

Proposal: On line 226 add the declaration of the variable (i.e. last_iteration = 0)