### PR TITLE
DOC: fixing a typo in conditional_after document

### DIFF
--- a/lifelines/fitters/log_normal_aft_fitter.py
+++ b/lifelines/fitters/log_normal_aft_fitter.py
@@ -135,7 +135,7 @@ class LogNormalAFTFitter(ParametericAFTRegressionFitter):
         p: float, optional (default=0.5)
             the percentile, must be between 0 and 1.
         conditional_after: iterable, optional
-            Must be equal is size to df.shape[0] (denoted `n` above).  An iterable (array, list, series) of possibly non-zero values that represent how long the
+            Must be equal in size to df.shape[0] (denoted `n` above).  An iterable (array, list, series) of possibly non-zero values that represent how long the
             subject has already lived for. Ex: if :math:`T` is the unknown event time, then this represents
             :math:`T | T > s`. This is useful for knowing the *remaining* hazard/survival of censored subjects.
             The new timeline is the remaining duration of the subject, i.e. normalized back to starting at 0.


### PR DESCRIPTION
fixing a typo in conditional_after [documentation](https://lifelines.readthedocs.io/en/latest/fitters/regression/PiecewiseExponentialRegressionFitter.html?highlight=conditional_after#lifelines.fitters.piecewise_exponential_regression_fitter.PiecewiseExponentialRegressionFitter.predict_hazard)
[](url)
<img width="812" alt="image" src="https://user-images.githubusercontent.com/65843206/224853753-f40c6d6e-f854-4110-b62c-799d0ea6acdd.png">
