### PR TITLE
Fix Aalen-Johansen plotting method when `calculate_variance=False`

### DIFF
--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -137,7 +137,7 @@ class UnivariateFitter(BaseFitter):
         )
         # Fix the confidence interval plot bug from Aalen-Johanson
         # when calculate_variance is True.
-        if not self._calc_var:
+        if not getattr(self._calc_var, None, False):
             kwargs["ci_show"] = False
         return _plot_estimate(self, estimate=self._estimate_name, **kwargs)
 

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -136,8 +136,8 @@ class UnivariateFitter(BaseFitter):
             DeprecationWarning,
         )
         # Fix the confidence interval plot bug from Aalen-Johanson
-        # when calculate_variance is True.
-        if not getattr(self._calc_var, None, False):
+        # when calculate_variance is False.
+        if getattr(self, "_calc_var", None) is False:
             kwargs["ci_show"] = False
         return _plot_estimate(self, estimate=self._estimate_name, **kwargs)
 

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -135,7 +135,7 @@ class UnivariateFitter(BaseFitter):
             "The `plot` function is deprecated, and will be removed in future versions. Use `plot_%s`" % self._estimate_name,
             DeprecationWarning,
         )
-        # Fix the confidence interval plot bug from Aalen-Johanson
+        # Fix the confidence interval plot bug from Aalen-Johansen
         # when calculate_variance is False.
         if getattr(self, "_calc_var", None) is False:
             kwargs["ci_show"] = False

--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -135,6 +135,10 @@ class UnivariateFitter(BaseFitter):
             "The `plot` function is deprecated, and will be removed in future versions. Use `plot_%s`" % self._estimate_name,
             DeprecationWarning,
         )
+        # Fix the confidence interval plot bug from Aalen-Johanson
+        # when calculate_variance is True.
+        if not self._calc_var:
+            kwargs["ci_show"] = False
         return _plot_estimate(self, estimate=self._estimate_name, **kwargs)
 
     def subtract(self, other) -> pd.DataFrame:

--- a/lifelines/fitters/aalen_johansen_fitter.py
+++ b/lifelines/fitters/aalen_johansen_fitter.py
@@ -7,6 +7,7 @@ import warnings
 from lifelines.fitters import NonParametricUnivariateFitter
 from lifelines.utils import _preprocess_inputs, inv_normal_cdf, CensoringType, coalesce
 from lifelines import KaplanMeierFitter
+from lifelines.plotting import _plot_estimate
 
 
 class AalenJohansenFitter(NonParametricUnivariateFitter):
@@ -261,3 +262,47 @@ class AalenJohansenFitter(NonParametricUnivariateFitter):
 
         # Detect duplicated times with different event types
         return (dup_times & (~dup_events)).any()
+
+    def plot_cumulative_density(self, **kwargs):
+        """
+        Plots a pretty figure of the model
+
+        Matplotlib plot arguments can be passed in inside the kwargs, plus
+
+        Parameters
+        -----------
+        show_censors: bool
+            place markers at censorship events. Default: False
+        censor_styles: dict
+            If show_censors, this dictionary will be passed into the plot call.
+        ci_alpha: float
+            the transparency level of the confidence interval. Default: 0.3
+        ci_force_lines: bool
+            force the confidence intervals to be line plots (versus default shaded areas). Default: False
+        ci_show: bool
+            show confidence intervals. Default: True
+        ci_legend: bool
+            if ci_force_lines is True, this is a boolean flag to add the lines' labels to the legend. Default: False
+        at_risk_counts: bool
+            show group sizes at time points. See function ``add_at_risk_counts`` for details. Default: False
+        loc: slice
+            specify a time-based subsection of the curves to plot, ex:
+
+            >>> model.plot(loc=slice(0.,10.))
+
+            will plot the time values between t=0. and t=10.
+        iloc: slice
+            specify a location-based subsection of the curves to plot, ex:
+
+            >>> model.plot(iloc=slice(0,10))
+
+            will plot the first 10 time points.
+
+        Returns
+        -------
+        ax:
+            a pyplot axis object
+        """
+        if not self._calc_var:
+            kwargs["ci_show"] = False
+        _plot_estimate(self, estimate=self._estimate_name, **kwargs)

--- a/lifelines/fitters/aalen_johansen_fitter.py
+++ b/lifelines/fitters/aalen_johansen_fitter.py
@@ -264,10 +264,9 @@ class AalenJohansenFitter(NonParametricUnivariateFitter):
         return (dup_times & (~dup_events)).any()
 
     def plot_cumulative_density(self, **kwargs):
-        """
-        Plots a pretty figure of the model
+        """Plots a pretty figure of the model
 
-        Matplotlib plot arguments can be passed in inside the kwargs, plus
+        Matplotlib plot arguments can be passed in inside the kwargs.
 
         Parameters
         -----------


### PR DESCRIPTION
***What does this PR fix?***

Running `plot()` when setting `calculate_variance=False` for the Aalen-Johansen estimator raises an error:

```python
from lifelines import AalenJohansenFitter

ajf = AalenJohansenFitter(calculate_variance=False)
ajf.fit(
    df["duration"],
    df["event"],
    event_of_interest=2,
)
ajf.plot()
```
<details><summary>Full trace</summary>

```traceback
/Users/vincentmaladiere/INRIA/lifelines/lifelines/fitters/aalen_johansen_fitter.py:111: Warning: Tied event times were detected. The Aalen-Johansen estimator cannot handle tied event times.
                To resolve ties, data is randomly jittered.
  warnings.warn(
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 11
      5 ajf = AalenJohansenFitter(calculate_variance=False)
      6 ajf.fit(
      7     df["duration"],
      8     df["event"],
      9     event_of_interest=1,
     10 )
---> 11 ajf.plot()

File ~/INRIA/lifelines/lifelines/fitters/__init__.py:138, in UnivariateFitter.plot(self, **kwargs)
     95 """
     96 Plots a pretty figure of the model
     97 
   (...)
    132     a pyplot axis object
    133 """
    134 warnings.warn(
    135     "The `plot` function is deprecated, and will be removed in future versions. Use `plot_%s`" % self._estimate_name,
    136     DeprecationWarning,
    137 )
--> 138 return _plot_estimate(self, estimate=self._estimate_name, **kwargs)

File ~/INRIA/lifelines/lifelines/plotting.py:943, in _plot_estimate(cls, estimate, loc, iloc, show_censors, censor_styles, ci_legend, ci_force_lines, ci_only_lines, ci_no_lines, ci_alpha, ci_show, at_risk_counts, logx, ax, **kwargs)
    929         (
    930             dataframe_slicer(plot_estimate_config.confidence_interval_)
    931             .rename(columns=lambda s: ("" if ci_legend else "_") + s)
   (...)
    940             )
    941         )
    942 else:
--> 943     x = dataframe_slicer(plot_estimate_config.confidence_interval_).index.values.astype(float)
    944     lower = dataframe_slicer(plot_estimate_config.confidence_interval_.iloc[:, [0]]).values[:, 0]
    945     upper = dataframe_slicer(plot_estimate_config.confidence_interval_.iloc[:, [1]]).values[:, 0]

File ~/INRIA/lifelines/lifelines/plotting.py:786, in create_dataframe_slicer.<locals>.<lambda>(df)
    783 user_submitted_slice = slice(timeline.min(), timeline.max()) if user_did_not_specify_certain_indexes else coalesce(loc, iloc)
    785 get_method = "iloc" if iloc is not None else "loc"
--> 786 return lambda df: getattr(df, get_method)[user_submitted_slice]

AttributeError: 'NoneType' object has no attribute 'loc'
```

</details>

This is caused by the `plot` method argument `ci_show` being set to True by default. When `ci_show=True`, the `_plot_estimate` function uses `confidence_interval_` as a DataFrame. However, when `calculate_variance=False`, `confidence_interval_` is None and we run into an error.

Besides, `plot` has been deprecated and in our case, the doc suggests using `plot_cumulative_density()` instead. The issue now is that `plot_cumulative_density()` raises a `NotImplementedError`.


***What does this PR implement?***

- When `_calc_var=False`, switch `ci_show` to False in the kwargs of the `plot` method defined in `UnivariateFitter` (the parent class of `AalenJohansenFitter`). One alternative would be to raise a ValueError when `_calc_var=False` and `ci_show=True`, but that would require switching the default value of `ci_show` to False while the method is deprecated, so I would not recommend it.

- Adds the `plot_cumulative_density` method to `AalenJohansenFitter`, using the same logic with `_plot_estimate()`, to remove the `NotImplementedError`.


***Any further comments?***

The CI seems to be broken for a while so I didn't write tests —also, writing tests is challenging due to the rigid structure of the test classes.

This is now working:

```python
from lifelines import AalenJohansenFitter

ajf = AalenJohansenFitter(calculate_variance=False)
ajf.fit(
    df["duration"],
    df["event"],
    event_of_interest=1,
)
ajf.plot()
```

This prints the correct results as well:

```python
import pandas as pd
from lifelines import AalenJohansenFitter

df = pd.read_parquet("data_truck.parquet")
ajf = AalenJohansenFitter(calculate_variance=False)
ajf.fit(
    df["duration"],
    df["event"],
    event_of_interest=1,
)
ajf.plot_cumulative_density()
```

cc @ogrisel who ran into the same errors using the Aalen Johansen estimator.
