### PR TITLE
ENH use scientific number formatting for delta and newton decrement in Cox fitters

### DIFF
--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -443,7 +443,7 @@ https://lifelines.readthedocs.io/en/latest/Examples.html#problems-with-convergen
 
             if show_progress:
                 print(
-                    "\rIteration %d: norm_delta = %.5f, step_size = %.5f, ll = %.5f, newton_decrement = %.5f, seconds_since_start = %.1f"
+                    "\rIteration %d: norm_delta = %.2e, step_size = %.4f, log_lik = %.5f, newton_decrement = %.2e, seconds_since_start = %.1f"
                     % (i, norm_delta, step_size, ll, newton_decrement, time.time() - start_time)
                 )
 

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1564,7 +1564,7 @@ estimate the variances. See paper "Variance estimation when using inverse probab
 
             if show_progress:
                 print(
-                    "\rIteration %d: norm_delta = %.5f, step_size = %.4f, log_lik = %.5f, newton_decrement = %.5f, seconds_since_start = %.1f"
+                    "\rIteration %d: norm_delta = %.2e, step_size = %.4f, log_lik = %.5f, newton_decrement = %.2e, seconds_since_start = %.1f"
                     % (i, norm_delta, step_size, ll_, newton_decrement, time.time() - start)
                 )
 


### PR DESCRIPTION
Hello,
When pushing the solver to convergence, both `delta` and `newton_decrement` go to zero, so the displayed information looks like this when they becomes smaller than 1e-5:
![image](https://github.com/CamDavidsonPilon/lifelines/assets/8993218/d7e26654-6189-412e-9935-e62e7aea164c)

With the proposed change a useful value is printed all along convergence:
![image](https://github.com/CamDavidsonPilon/lifelines/assets/8993218/19a4907d-d280-46fd-8579-fc271dddbb0e)
