### PR TITLE
Add a test to reproduce #1532 and a fix

### DIFF
--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -3115,6 +3115,14 @@ class TestCoxPHFitter:
         cph.fit(rossi, "week", "arrest", formula="age * race")
         cph.predict_survival_function(rossi)
 
+    def test_formulas_handles_categories_at_inference(self, cph):
+        # Create a dummy dataset with some one continuous and one categorical features
+        df = pd.DataFrame({
+            'time': [1, 2, 3, 1, 2, 3], 'event': [0, 1, 1, 1, 0, 0],
+            'cov_cont':[0.1, 0.2, 0.3, 0.1, 0.2, 0.3], 'cov_categ': ['A', 'A', 'B', 'B', 'C', 'C']})
+        cph.fit(df, "time", "event", formula="cov_cont + C(cov_categ)")
+        cph.predict_survival_function(df.iloc[:4])
+
     def test_timeline_argument_can_be_set(self, rossi, cph_spline, cph):
         timeline = np.linspace(0, 100)
         cph.fit(rossi, "week", "arrest", timeline=timeline)

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1908,7 +1908,7 @@ class CovariateParameterMappings:
 
         Xs = {}
         for param_name, transform in self.mappings.items():
-            if isinstance(transform, formulaic.formula.Formula):
+            if isinstance(transform, formulaic.ModelSpec):
                 X = transform.get_model_matrix(df)
             elif isinstance(transform, list):
                 if self.force_intercept:
@@ -1954,6 +1954,6 @@ class CovariateParameterMappings:
         if self.force_intercept:
             formula += "+ 1"
 
-        design_info = formulaic.Formula(formula)
+        design_info = formulaic.ModelSpec.from_spec(formulaic.Formula(formula).get_model_matrix(df))
 
         return design_info


### PR DESCRIPTION
Fixes #1532.

This patch keeps all the categories present in the data at fitting time so that inference can go well even if a cateogory is missing. Note that there may be an easier way to do it but I am not an expert with formulaic.