### PR TITLE
expose r_precision parameter in Newton raphson solvers, correct typos

### DIFF
--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -457,7 +457,7 @@ https://lifelines.readthedocs.io/en/latest/Examples.html#problems-with-convergen
             elif previous_ll > 0 and abs(ll - previous_ll) / (-previous_ll) < r_precision:
                 # this is what R uses by default with r_precision=1e-9
                 converging, completed = False, True
-            elif newton_decrement < precision:
+            elif newton_decrement < 1e-8:  # precision:
                 converging, completed = False, True
             elif i >= max_steps:
                 # 50 iterations steps with N-R is a lot.

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -328,7 +328,7 @@ class CoxTimeVaryingFitter(SemiParametricRegressionFitter, ProportionalHazardMix
         weights,
         show_progress=False,
         step_size=0.95,
-        precision=10e-6,
+        precision=1e-8,
         r_precision=1e-9,
         max_steps=50,
         initial_point=None,
@@ -457,7 +457,7 @@ https://lifelines.readthedocs.io/en/latest/Examples.html#problems-with-convergen
             elif previous_ll > 0 and abs(ll - previous_ll) / (-previous_ll) < r_precision:
                 # this is what R uses by default with r_precision=1e-9
                 converging, completed = False, True
-            elif newton_decrement < 1e-8:  # precision:
+            elif newton_decrement < precision:
                 converging, completed = False, True
             elif i >= max_steps:
                 # 50 iterations steps with N-R is a lot.

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -153,6 +153,7 @@ class CoxTimeVaryingFitter(SemiParametricRegressionFitter, ProportionalHazardMix
             Override the default values in NR algorithm:
                 step_size: 0.95,
                 precision: 1e-07,
+                r_precision=1e-9,
                 max_steps: 500,
 
         Returns
@@ -346,8 +347,8 @@ class CoxTimeVaryingFitter(SemiParametricRegressionFitter, ProportionalHazardMix
         step_size: float
             > 0 to determine a starting step size in NR algorithm.
         precision: float
-            the convergence halts if the norm of delta between
-                     successive positions is less than epsilon.
+            the algorithm stops if the norm of delta between
+            successive positions is less than ``precision``.
         r_precision: float, optional
             the algorithms stops if the relative decrease in log-likelihood
             between successive iterations goes below ``r_precision``.

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -242,7 +242,7 @@ class CoxPHFitter(RegressionFitter, ProportionalHazardMixin):
             algorithm. Default is the zero vector.
 
         fit_options: dict, optional
-            pass kwargs for the fitting algorithm. For semi-parametric models, this is the Newton-Rhapson method (see method _newton_raphson_for_efron_model for kwargs)
+            pass kwargs for the fitting algorithm. For semi-parametric models, this is the Newton-Raphson method (see method _newton_raphson_for_efron_model for kwargs)
 
         Returns
         -------
@@ -1430,10 +1430,11 @@ estimate the variances. See paper "Variance estimation when using inverse probab
         show_progress: bool = True,
         step_size: float = 0.95,
         precision: float = 1e-07,
+        r_precision: float = 1e-9,
         max_steps: int = 500,
     ):  # pylint: disable=too-many-statements,too-many-branches
         """
-        Newton Rhaphson algorithm for fitting CPH model.
+        Newton Raphson algorithm for fitting CPH model.
 
         Note
         ----
@@ -1450,13 +1451,15 @@ estimate the variances. See paper "Variance estimation when using inverse probab
         step_size: float, optional
             > 0.001 to determine a starting step size in NR algorithm.
         precision: float, optional
-            the convergence halts if the norm of delta between
-            successive positions is less than epsilon.
+            the algorithm stops if the norm of delta between
+            successive positions is less than ``precision``.
+        r_precision: float, optional
+            the algorithms stops if the relative decrease in log-likelihood
+            goes below ``r_precision``.
         show_progress: bool, optional
-            since the fitter is iterative, show convergence
-                 diagnostics.
+            since the fitter is iterative, show convergence diagnostics.
         max_steps: int, optional
-            the maximum number of iterations of the Newton-Rhaphson algorithm.
+            the maximum number of iterations of the Newton-Raphson algorithm.
 
         Returns
         -------
@@ -1571,8 +1574,8 @@ estimate the variances. See paper "Variance estimation when using inverse probab
             # convergence criteria
             if norm_delta < precision:
                 converging, success = False, True
-            elif previous_ll_ != 0 and abs(ll_ - previous_ll_) / (-previous_ll_) < 1e-09:
-                # this is what R uses by default
+            elif previous_ll_ != 0 and abs(ll_ - previous_ll_) / (-previous_ll_) < r_precision:
+                # this is what R uses by default, with r_precision = 1e-9
                 converging, success = False, True
             elif newton_decrement < precision:
                 converging, success = False, True
@@ -1594,6 +1597,7 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
             step_size = step_sizer.update(norm_delta).next()
 
         if show_progress and success:
+            import ipdb; ipdb.set_trace()
             print("Convergence success after %d iterations." % (i))
         elif show_progress and not success:
             print("Convergence failed. See any warning messages.")

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1455,7 +1455,7 @@ estimate the variances. See paper "Variance estimation when using inverse probab
             successive positions is less than ``precision``.
         r_precision: float, optional
             the algorithms stops if the relative decrease in log-likelihood
-            goes below ``r_precision``.
+            between successive iterations goes below ``r_precision``.
         show_progress: bool, optional
             since the fitter is iterative, show convergence diagnostics.
         max_steps: int, optional
@@ -1597,7 +1597,6 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
             step_size = step_sizer.update(norm_delta).next()
 
         if show_progress and success:
-            import ipdb; ipdb.set_trace()
             print("Convergence success after %d iterations." % (i))
         elif show_progress and not success:
             print("Convergence failed. See any warning messages.")
@@ -1606,14 +1605,14 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
         if success and norm_delta > 0.1:
             self._check_values_post_fitting(X, T, E, weights)
             warnings.warn(
-                "Newton-Rhaphson convergence completed successfully but norm(delta) is still high, %.3f. This may imply non-unique solutions to the maximum likelihood. Perhaps there is collinearity or complete separation in the dataset?\n"
+                "Newton-Raphson convergence completed successfully but norm(delta) is still high, %.3f. This may imply non-unique solutions to the maximum likelihood. Perhaps there is collinearity or complete separation in the dataset?\n"
                 % norm_delta,
                 exceptions.ConvergenceWarning,
             )
         elif not success:
             self._check_values_post_fitting(X, T, E, weights)
             warnings.warn(
-                "Newton-Rhaphson failed to converge sufficiently. {0}".format(CONVERGENCE_DOCS), exceptions.ConvergenceWarning
+                "Newton-Raphson failed to converge sufficiently. {0}".format(CONVERGENCE_DOCS), exceptions.ConvergenceWarning
             )
 
         return beta, ll_, hessian


### PR DESCRIPTION
The stopping criterion of the Newton-Raphson method is mostly controlled by the parameter `precision`, but there is also a stopping criterion based on the relative improvement of the log-likelihood that so far used a hardcoded value of 1e-9. This PR exposes this parameter in the two NR solvers, with default value 1e-9 so as not to break existing code.

It also harmonizes stopping criteria between time varying and non time varying Cox Fitter

Finally it corrects the spelling of Raphson in docstrings, warning messages and comments

ping @Badr-Moufad