### PR TITLE
Add throw_on_fail setting to check_assumptions

### DIFF
--- a/lifelines/exceptions.py
+++ b/lifelines/exceptions.py
@@ -5,6 +5,10 @@ class StatError(Exception):
     pass
 
 
+class ProportionalHazardAssumptionError(Exception):
+    pass
+
+
 class ConvergenceError(ValueError):
     # inherits from ValueError for backwards compatibility reasons
     def __init__(self, msg, original_exception=""):

--- a/lifelines/fitters/mixins.py
+++ b/lifelines/fitters/mixins.py
@@ -4,6 +4,7 @@ from textwrap import dedent, fill
 from autograd import numpy as anp
 import numpy as np
 from pandas import DataFrame, Series
+from lifelines.exceptions import ProportionalHazardAssumptionError
 from lifelines.statistics import proportional_hazard_test, TimeTransformers
 from lifelines.utils import format_p_value
 from lifelines.utils.lowess import lowess
@@ -28,6 +29,7 @@ class ProportionalHazardMixin:
         p_value_threshold: float = 0.01,
         plot_n_bootstraps: int = 15,
         columns: Optional[List[str]] = None,
+        raise_on_fail: bool = False,
     ) -> None:
         """
         Use this function to test the proportional hazards assumption. See usage example at
@@ -51,6 +53,8 @@ class ProportionalHazardMixin:
             the function significantly.
         columns: list, optional
             specify a subset of columns to test.
+        raise_on_fail: bool, optional
+            throw a ``ProportionalHazardAssumptionError`` if the test fails. Default: False.
 
         Returns
         --------
@@ -107,7 +111,7 @@ class ProportionalHazardMixin:
 
         for variable in self.params_.index.intersection(columns or self.params_.index):
             minumum_observed_p_value = test_results.summary.loc[variable, "p"].min()
-            
+
             # plot is done (regardless of test result) whenever `show_plots = True`
             if show_plots:
                 axes.append([])
@@ -224,9 +228,8 @@ class ProportionalHazardMixin:
                         ),
                         end="\n\n",
                     )
-#################
+        #################
 
-            
         if advice and counter > 0:
             print(
                 dedent(
@@ -243,6 +246,8 @@ class ProportionalHazardMixin:
 
         if counter == 0:
             print("Proportional hazard assumption looks okay.")
+        elif raise_on_fail:
+            raise ProportionalHazardAssumptionError()
         return axes
 
     @property


### PR DESCRIPTION
## Problem Statement
`cph.check_assumptions` can be tricky to use because it does not return something that can be used to infer the outcome of checking the assumptions (it returns axes [ref](https://github.com/CamDavidsonPilon/lifelines/blob/716b20441768ad399e40ff71baad8fea872c43e5/lifelines/fitters/mixins.py#L246))

## Solution
I added an input parameter `throw_on_fail` where if True, when the check_assumptions fails the function will raise an error so the calling program can take appropriate action (eg discard the model results for that input / output pair).

## Other solutions considered
1. I could write my own helper function using `proportional_hazard_test()` to do a similar check but still return the data in a way where I can detect if the assumption check failed.  I figured it'd be cool to add a fix to the library instead.
2. I could update the function to return the `test_results` table generated by `proportional_hazard_test()` - this might break some expected graphing behavior if used in notebooks.  I think this might be the best result bc it gives the library user the most flexibility, but its a more significant change so I'll await your input.  Adding the `throw_on_fail` I think still makes sense even if the return is adjusted to return test_results if `show_plots==False`.

## Testing
added unit test to verify this functionality.  Ran the test + output below:

```
$ py.test lifelines/tests/test_estimation.py -k test_check_assumptions
======================================================== test session starts =========================================================
platform darwin -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/pearce/workplace/lifelines
plugins: flaky-3.7.0, cov-4.1.0, icdiff-0.8
collected 396 items / 391 deselected / 5 selected                                                                                    

lifelines/tests/test_estimation.py .....                                                                                       [100%]

================================================= 5 passed, 391 deselected in 0.67s ==================================================

```

(This is my first pull request, to lifelines.  I did my best to follow the contributed guide. I appreciate your patience if I missed something.)