### PR TITLE
bump to 0.29.0; bump scipy and pandas dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
-#### 0.28.0 - 2023-01-03
+#### 0.29.0 - 2024-06-25
+ - update dependencies (pandas >= 2.1)
+ - update dependencies (scipy >= 1.7)
+
+
+
+#### 0.28.0 - 2024-01-03
  - Fixes bins that are far into the future with using `survival_table_from_events`, see #1587
  - Removed `sklean_adaptor`. It was a terrible hack, and causing more confusion and support debt than I want. This cleans up our API and simplifies the library. ✨ There's no replacement, and I doubt I'll introduce one ✨
  - Fix pandas>=2.0 compatibility.

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -3222,8 +3222,9 @@ class ParametricPiecewiseBaselinePHFitter(ParametricCoxModelFitter, Proportional
             cumulative_hazard = pd.DataFrame()
 
             for stratum, stratified_X in df.groupby(self.strata):
+                print(self.params_)
                 log_lambdas_ = anp.array(
-                    [0] + [self.params_[self._strata_labeler(stratum, i)][0] for i in range(2, self.n_breakpoints + 2)]
+                    [0] + [self.params_.loc[self._strata_labeler(stratum, i)].iloc[0] for i in range(2, self.n_breakpoints + 2)]
                 )
                 lambdas_ = np.exp(log_lambdas_)
 
@@ -3237,7 +3238,9 @@ class ParametricPiecewiseBaselinePHFitter(ParametricCoxModelFitter, Proportional
             return cumulative_hazard
 
         else:
-            log_lambdas_ = np.array([0] + [self.params_[param][0] for param in self._fitted_parameter_names if param != "beta_"])
+            log_lambdas_ = np.array(
+                [0] + [self.params_.loc[param].iloc[0] for param in self._fitted_parameter_names if param != "beta_"]
+            )
             lambdas_ = np.exp(log_lambdas_)
 
             Xs = self.regressors.transform_df(df)

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -3222,7 +3222,6 @@ class ParametricPiecewiseBaselinePHFitter(ParametricCoxModelFitter, Proportional
             cumulative_hazard = pd.DataFrame()
 
             for stratum, stratified_X in df.groupby(self.strata):
-                print(self.params_)
                 log_lambdas_ = anp.array(
                     [0] + [self.params_.loc[self._strata_labeler(stratum, i)].iloc[0] for i in range(2, self.n_breakpoints + 2)]
                 )

--- a/lifelines/fitters/npmle.py
+++ b/lifelines/fitters/npmle.py
@@ -291,7 +291,7 @@ def reconstruct_survival_function(
 
     # First backfill at events between known observations
     # Second fill all events _outside_ known obs with running_sum
-    return full_dataframe.combine_first(df).bfill().fillna(running_sum).clip(lower=0.0)
+    return full_dataframe.combine_first(df).astype(float).bfill().fillna(running_sum).clip(lower=0.0)
 
 
 def npmle_compute_confidence_intervals(left, right, mle_, alpha=0.05, samples=1000):

--- a/lifelines/fitters/piecewise_exponential_regression_fitter.py
+++ b/lifelines/fitters/piecewise_exponential_regression_fitter.py
@@ -66,7 +66,7 @@ class PiecewiseExponentialRegressionFitter(ParametricRegressionFitter):
         coef_penalty = 0
         if self.penalizer > 0:
             for i in range(params_stacked.shape[1]):
-                if not self._cols_to_not_penalize[i]:
+                if not self._cols_to_not_penalize.iloc[i]:
                     coef_penalty = coef_penalty + (params_stacked[:, i]).var()
 
         return neg_ll + self.penalizer * coef_penalty

--- a/lifelines/generate_datasets.py
+++ b/lifelines/generate_datasets.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from scipy import stats
 from scipy.optimize import newton
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 
 random = np.random
 
@@ -308,7 +308,7 @@ def cumulative_integral(fx, x):
     fx: (n,d) numpy array, what you want to integral of
     x: (n,) numpy array, location to integrate over.
     """
-    return cumtrapz(fx.T, x, initial=0).T
+    return cumulative_trapezoid(fx.T, x, initial=0).T
 
 
 def construct_survival_curves(hazard_rates, timelines):

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -490,6 +490,7 @@ class TestUnivariateFitters:
             if not hasattr(fitter, "confidence_interval_cumulative_density_"):
                 continue
             lower, upper = f"{fitter.label}_lower_0.95", f"{fitter.label}_upper_0.95"
+            print(fitter.confidence_interval_cumulative_density_)
             assert np.all(
                 (fitter.confidence_interval_cumulative_density_[upper] - fitter.confidence_interval_cumulative_density_[lower])
                 >= 0
@@ -2008,7 +2009,7 @@ class TestRegressionFitters:
     def test_fit_will_accept_object_dtype_as_event_col(self, regression_models_sans_strata_model, rossi):
         # issue #638
         rossi["arrest"] = rossi["arrest"].astype(object)
-        rossi["arrest"].iloc[0] = None
+        rossi.loc[0, "arrest"] = None
 
         assert rossi["arrest"].dtype == object
         rossi = rossi.dropna()

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -490,7 +490,6 @@ class TestUnivariateFitters:
             if not hasattr(fitter, "confidence_interval_cumulative_density_"):
                 continue
             lower, upper = f"{fitter.label}_lower_0.95", f"{fitter.label}_upper_0.95"
-            print(fitter.confidence_interval_cumulative_density_)
             assert np.all(
                 (fitter.confidence_interval_cumulative_density_[upper] - fitter.confidence_interval_cumulative_density_[lower])
                 >= 0

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -347,7 +347,7 @@ def test_survival_table_from_events_at_risk_column():
         1.0,
     ]
     df = utils.survival_table_from_events(df["T"], df["E"])
-    assert list(df["at_risk"][1:]) == expected  # skip the first event as that is the birth time, 0.
+    assert list(df["at_risk"].loc[1:]) == expected  # skip the first event as that is the birth time, 0.
 
 
 def test_survival_table_to_events_casts_to_float():

--- a/lifelines/version.py
+++ b/lifelines/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"

--- a/reqs/base-requirements.txt
+++ b/reqs/base-requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.14.0,<2.0
-scipy>=1.2.0
-pandas>=1.2.0
+scipy>=1.7.0
+pandas>=2.1
 matplotlib>=3.0
 autograd>=1.5
 autograd-gamma>=0.3

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -16,6 +16,7 @@ dill>=0.3.6
 statsmodels
 flaky
 Jinja2
+joblib
 
 # ex: `py.test` in the docs/ folder. See conftest.py in docs/ first
 sybil

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -15,7 +15,6 @@ black
 dill>=0.3.6
 statsmodels
 flaky
-scikit-learn>=0.22.0
 Jinja2
 
 # ex: `py.test` in the docs/ folder. See conftest.py in docs/ first


### PR DESCRIPTION
This is a "deprecation" and "futureWarning" release, and raises the lower bounds of SciPy and Pandas. 

The Pandas bump is pretty significant, but I figure: it's been out for a year, and if you're the type of person / org who is using scipy 0.14.0, and is interested in numpy 2.0, you're probably on a modern Pandas version. 

For users who don't want such a bump, they still have lifelines 0.28.0. 