### PR TITLE
Bugfix: Incorrect Decimal Precision in StatisticalResult.print_summary (No Style)

### DIFF
--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -77,7 +77,7 @@ class StatisticalResult:
         kwargs["test_name"] = test_name
         self._kwargs = kwargs
 
-    def _print_specific_style(self, style, decimals=2, **kwargs):
+    def _print_specific_style(self, style, **kwargs):
         """
         Parameters
         -----------
@@ -87,11 +87,11 @@ class StatisticalResult:
 
         """
         if style == "html":
-            return self._html_print(decimals=decimals, **kwargs)
+            return self._html_print(**kwargs)
         elif style == "ascii":
-            return self._ascii_print(decimals=decimals, **kwargs)
+            return self._ascii_print(**kwargs)
         elif style == "latex":
-            return self._latex_print(decimals=decimals, **kwargs)
+            return self._latex_print(**kwargs)
         else:
             raise ValueError("style not available.")
 
@@ -110,6 +110,7 @@ class StatisticalResult:
             multiple outputs.
 
         """
+        self.decimals=decimals
         if style is not None:
             self._print_specific_style(style)
         else:
@@ -120,16 +121,16 @@ class StatisticalResult:
             except ImportError:
                 self._ascii_print()
 
-    def _html_print(self, decimals=2, **kwargs):
-        print(self.to_html(decimals, **kwargs))
+    def _html_print(self, **kwargs):
+        print(self.to_html(**kwargs))
 
-    def _latex_print(self, decimals=2, **kwargs):
-        print(self.to_latex(decimals, **kwargs))
+    def _latex_print(self, **kwargs):
+        print(self.to_latex(**kwargs))
 
-    def _ascii_print(self, decimals=2, **kwargs):
-        print(self.to_ascii(decimals, **kwargs))
+    def _ascii_print(self, **kwargs):
+        print(self.to_ascii(**kwargs))
 
-    def to_html(self, decimals=2, **kwargs):
+    def to_html(self, **kwargs):
         extra_kwargs = dict(list(self._kwargs.items()) + list(kwargs.items()))
         summary_df = self.summary
 
@@ -140,14 +141,14 @@ class StatisticalResult:
         header_df = pd.DataFrame.from_records(headers).set_index(0)
         header_html = header_df.to_html(header=False, notebook=True, index_names=False)
 
-        summary_html = summary_df.to_html(float_format=format_floats(decimals), formatters={**{"p": format_p_value(decimals)}})
+        summary_html = summary_df.to_html(float_format=format_floats(self.decimals), formatters={**{"p": format_p_value(self.decimals)}})
 
         return header_html + summary_html
 
-    def to_latex(self, decimals=2, **kwargs):
+    def to_latex(self, **kwargs):
         # This is using the new Style object in Pandas. Previously df.to_latex was giving a warning.
         s = self.summary.style
-        s = s.format(precision=decimals)
+        s = s.format(precision=self.decimals)
         return s.to_latex()
 
     @property
@@ -172,7 +173,7 @@ class StatisticalResult:
         df["-log2(p)"] = -utils.quiet_log2(df["p"])
         return df
 
-    def to_ascii(self, decimals=2, **kwargs):
+    def to_ascii(self, **kwargs):
         extra_kwargs = dict(list(self._kwargs.items()) + list(kwargs.items()))
         meta_data = self._stringify_meta_data(extra_kwargs)
 
@@ -182,7 +183,7 @@ class StatisticalResult:
         s += "\n" + meta_data + "\n"
         s += "---\n"
         s += df.to_string(
-            float_format=format_floats(decimals), index=self.name is not None, formatters={"p": format_p_value(decimals)}
+            float_format=format_floats(self.decimals), index=self.name is not None, formatters={"p": format_p_value(self.decimals)}
         )
 
         return s


### PR DESCRIPTION
The `print_summary` method in the `lifelines.statistics.StatisticalResult` class was not correctly handling the `decimals` argument when no explicit `style` was provided. This led to the output table displaying the default precision of 2 decimals, even if a different value was specified.

- **Problem:** the value of the 'decimals' argument did not propagate properly in the class. 
- **Solution:** set `self.decimals` so that the value is shared properly by all the methods of the class. 
- **Impact:** this fix ensures that the desired decimal precision is respected in the output table, even when no specific style is chosen.

For example, the issue was reproduced using the provided example with the results of the  `logrank_test` without explicit 'style' argument, resulting in a incorrect table with a precision of 2 decimals (the default) instead of 10:

```python
from lifelines import statistics as stats
from lifelines.datasets import load_rossi

rossi = load_rossi()

results = stats.logrank_test(
    durations_A=rossi.loc[rossi['fin']==0, 'week'],
    durations_B=rossi.loc[rossi['fin']==1,'week'],
    event_observed_A=rossi.loc[rossi['fin']==0, 'arrest'],
    event_observed_B=rossi.loc[rossi['fin']==1,'arrest'],
)

results.print_summary(decimals=10)
```

```html
<div>
<style scoped>
    .dataframe tbody tr th:only-of-type {
        vertical-align: middle;
    }

    .dataframe tbody tr th {
        vertical-align: top;
    }

    .dataframe thead th {
        text-align: right;
    }
</style>
<table border="1" class="dataframe">
  <tbody>
    <tr>
      <th>t_0</th>
      <td>-1</td>
    </tr>
    <tr>
      <th>null_distribution</th>
      <td>chi squared</td>
    </tr>
    <tr>
      <th>degrees_of_freedom</th>
      <td>1</td>
    </tr>
    <tr>
      <th>test_name</th>
      <td>logrank_test</td>
    </tr>
  </tbody>
</table>
</div><table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th></th>
      <th>test_statistic</th>
      <th>p</th>
      <th>-log2(p)</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>0</th>
      <td>3.84</td>
      <td>0.05</td>
      <td>4.32</td>
    </tr>
  </tbody>
</table>
```

This happened only without explicit 'style' was provided, as the following worked well:

```python
results.print_summary(style='html', decimals=5)
```

```html
...
  <tbody>
    <tr>
      <th>0</th>
      <td>3.83757</td>
      <td>0.05012</td>
      <td>4.31858</td>
    </tr>
  </tbody>
```

```python
results.print_summary(style='ascii', decimals=4)
```

```bash
<lifelines.StatisticalResult: logrank_test>
               t_0 = -1
 null_distribution = chi squared
degrees_of_freedom = 1
         test_name = logrank_test

---
 test_statistic      p  -log2(p)
         3.8376 0.0501    4.3186
```

```python
results.print_summary(style='latex', decimals=6)
```

```bash
\begin{tabular}{lrrr}
 & test_statistic & p & -log2(p) \\
0 & 3.837570 & 0.050116 & 4.318582 \\
\end{tabular}
```

With the correction, the call `results.print_summary(decimals=4)` now results in the expected table:

```html
<div>
<style scoped>
    .dataframe tbody tr th:only-of-type {
        vertical-align: middle;
    }

    .dataframe tbody tr th {
        vertical-align: top;
    }

    .dataframe thead th {
        text-align: right;
    }
</style>
<table border="1" class="dataframe">
  <tbody>
    <tr>
      <th>t_0</th>
      <td>-1</td>
    </tr>
    <tr>
      <th>null_distribution</th>
      <td>chi squared</td>
    </tr>
    <tr>
      <th>degrees_of_freedom</th>
      <td>1</td>
    </tr>
    <tr>
      <th>test_name</th>
      <td>logrank_test</td>
    </tr>
  </tbody>
</table>
</div><table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th></th>
      <th>test_statistic</th>
      <th>p</th>
      <th>-log2(p)</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>0</th>
      <td>3.8376</td>
      <td>0.0501</td>
      <td>4.3186</td>
    </tr>
  </tbody>
</table>
```

Other fitters and regression tables (Cox PH, Weibull, etc.) were not affected by this bug and continue to function as expected.