### PR TITLE
Survival function for Cox Time Varying model

### DIFF
--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -295,6 +295,15 @@ class CoxTimeVaryingFitter(SemiParametricRegressionFitter, ProportionalHazardMix
             index=self.params_.index,
         )
 
+    def calculate_survival_function(self, X: pd.DataFrame) -> pd.Series:
+        v = self.predict_partial_hazard(X)
+        col = utils._get_index(v)
+        times_ = X.start.values
+        c_0 = utils.interpolate_at_times(self.baseline_cumulative_hazard_, [times_]).T
+        cumulative_hazard_ = pd.DataFrame(c_0 * v.values, columns=col, index=times_)
+        surv_func = pd.Series(np.exp(-cumulative_hazard_).values.diagonal(), index=times_)
+        return surv_func
+        
     @property
     def summary(self):
         """Summary statistics describing the fit.


### PR DESCRIPTION
I've written a method for getting the survival function until timestep $t$ where $0<t<\tau$. It will not show $S(t)$ for all the way to time of failure $\tau$, as you do not know the covariates at that moment. Adding this function supports with calculation of $\int_0^t S(t)$, needed for determining the optimal replacement time.