### PR TITLE
Optimize variance calculation at AalenJohansenFitter with prefix sum approach

### DIFF
--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -1955,3 +1955,54 @@ class CovariateParameterMappings:
         design_info = formulaic.ModelSpec.from_spec(formulaic.Formula(formula).get_model_matrix(df))
 
         return design_info
+    
+class LinearAccumulator:
+    """
+    This class represents a linear function F(x), which can be updated iteratively.
+    """
+    def __init__(self):
+        """
+        Initializes F(x) as 0.
+        """
+        self.const_term: float = 0.0
+        self.linear_term: float = 0.0
+    
+    def add_linear_term(self, a: float, b: float) -> None:
+        """
+        Adds a * (x - b) to F(x).
+        """
+        self.const_term -= a * b
+        self.linear_term += a
+
+    def evaluate(self, x: float) -> float:
+        """
+        Evaluates F(x) at the given value of x.
+        """
+        return self.const_term + self.linear_term * x
+
+class QuadraticAccumulator:
+    """
+    This class represents a quadratic function F(x), which can be updated iteratively.
+    """
+    def __init__(self):
+        """
+        Initializes F(x) as 0.
+        """
+        self.const_term: float = 0.0
+        self.linear_term: float = 0.0
+        self.quadratic_term: float = 0.0
+    
+    def add_quadratic_term(self, a: float, b: float) -> None:
+        """
+        Adds a * (x - b)^2 to F(x).
+        """
+        # a * (x - b)^2 = a * x^2 + (- 2 * a * b) * x + a * b^2
+        self.const_term += a * (b ** 2)
+        self.linear_term -= 2 * a * b
+        self.quadratic_term += a
+
+    def evaluate(self, x: float) -> float:
+        """
+        Evaluates F(x) at the given value of x.
+        """
+        return self.const_term + self.linear_term * x + self.quadratic_term * (x ** 2)


### PR DESCRIPTION
While using the library, I noticed that `AalenJohansenFitter.fit()` is very slow. It appears that the variance calculation, enabled by default, constitutes the primary bottleneck, due to its time complexity $O(N ^ 2)$ where $N$ is the number of events. The method iterates through $O(N)$ rows, spending $O(N)$ time to calculate variance at each step.

According to the codebase and comments, the variance for the $r$-th row equals to the sum of three terms `first_term`, `second_term`, and $\\{(-2) \times$ `third_term` $\\}$, where

- `first_term` $= \sum_{i = 1}^{r} \frac{(F_j(t) - F_j(t_i))^2 \times d}{n \times(n - d)}$
- `second_term` $= \sum_{i = 1}^{r} \frac{S^2(t_i - 1) \times d \times (n - d)}{n^3}$
- `third_term` $= \sum_{i = 1}^{r} \frac{(F_j(t) - F_j(t_i)) \times S(t_i - 1) \times d}{n^2}$

Here, $n$ and $d$ are values that depend on the index $i$.

Each of the three terms can be regarded as a quadratic, constant, and linear function respectively in terms of $F_j(t)$. For example, the `first_term` for the $r$-th row can be represented as $P_r(F_j(t))$, where $P_r(x) = \sum_{i = 1}^{r} \frac{(x - F_j(t_i))^2 \times d}{n \times(n-d)}$.

Since $P_r(x) = P_{r-1}(x) + \frac{(x - F_j(t_r))^2 \times d}{n \times (n-d)}$ for $r = 1, 2, \dots, N$ with $P_0(x) = 0$, we can use a prefix sum algorithm to iteratively update $P_r(x)$ using a data structure that represents a quadratic function and supports:

- Adding a term $\frac{(x - F_j(t_r))^2 \times d}{n \times (n-d)}$, and
- Evaluating $P(x)$ at the given value of $x$.

I will omit details of the data structure implementation here, but the main idea is to store the quadratic, linear, and constant terms of the function.

By applying this method, the performance improved by more than $\text{40x}$ as $N$ approaches $20,000$--no longer requiring a wait of several seconds or even minutes!

<p float="left">
<img width="46%" alt="Screenshot 2025-07-05 at 14 08 56" src="https://github.com/user-attachments/assets/91d47ac8-846e-401b-93b3-1d5f5a9cba53" />
<img width="44%" alt="Screenshot 2025-07-05 at 14 09 12" src="https://github.com/user-attachments/assets/d20afe6c-3428-4880-92db-28417b0d5a1f" />
</P>


We could further optimize performance by using `cumsum()` to evaluate the functions directly and avoid relying on `iterrows()`, but for the sake of maintainability, I chose to continue using `iterrows()`.