### PR TITLE
Fix bounds handling in parametric regression fit_options

### DIFF
--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1948,6 +1948,9 @@ class ParametricRegressionFitter(RegressionFitter):
             if _initial_point.shape[0] != Xs.columns.size:
                 raise ValueError("initial_point is not the correct shape.")
 
+            scipy_fit_options = {**self._scipy_fit_options, **fit_options}
+            bounds = scipy_fit_options.pop("bounds", getattr(self, "_bounds", None))
+
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 results = minimize(
@@ -1957,7 +1960,8 @@ class ParametricRegressionFitter(RegressionFitter):
                     method=self._scipy_fit_method,
                     jac=True,
                     args=(Ts, E, weights, entries, utils.DataframeSlicer(Xs)),
-                    options={**{"disp": show_progress}, **self._scipy_fit_options, **fit_options},
+                    bounds=bounds,
+                    options={**{"disp": show_progress}, **scipy_fit_options},
                     callback=self._scipy_fit_callback,
                 )
 

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -2201,6 +2201,15 @@ class TestPiecewiseExponentialRegressionFitter:
         pew = PiecewiseExponentialRegressionFitter(breakpoints=[25, 40]).fit(df, "week", "arrest")
         pew.print_summary()
 
+    def test_fit_options_bounds_are_passed_to_minimize(self):
+        df = pd.DataFrame({"T": [1.0, 2.0, 3.0, 4.0], "E": [1, 1, 0, 1]})
+        model = PiecewiseExponentialRegressionFitter(breakpoints=[2.0])
+        bounds = [(0.0, None)] * len(model._fitted_parameter_names)
+
+        fitted = model.fit(df, "T", "E", fit_options={"bounds": bounds})
+
+        assert fitted.params_.shape[0] == len(model._fitted_parameter_names)
+
     def test_inference(self):
 
         N, d = 80000, 2


### PR DESCRIPTION
Closes #1651.

## Summary

This fixes `ParametricRegressionFitter.fit(..., fit_options={"bounds": ...})` when using SciPy-based optimizers such as SLSQP.

Previously, `fit_options` was forwarded directly into SciPy's `options=` argument. If a caller provided `bounds` in `fit_options`, SciPy received `bounds` twice:
- once via lifelines' dedicated `bounds=` handling
- once inside `options=...`

This caused errors like:

```python
TypeError: _minimize_slsqp() got multiple values for argument 'bounds'

Changes
extract bounds from fit_options before calling scipy.optimize.minimize
pass extracted bounds through the dedicated bounds= argument
leave the remaining entries in fit_options under options=...
add a regression test covering PiecewiseExponentialRegressionFitter.fit(..., fit_options={"bounds": ...})

Verification
Tested locally with:

python -m pytest lifelines/tests/test_estimation.py -k "fit_options_bounds_are_passed_to_minimize or TestPiecewiseExponentialRegressionFitter"

This now passes, and the previous reproduction for #1651 no longer raises the SciPy bounds error.