### PR TITLE
warn when restricted_mean_survival_time(return_variance=True) is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### unreleased
+ - Emit a `UserWarning` when `restricted_mean_survival_time(..., return_variance=True)` is called: the returned value is `Var[min(T, t)]` (variance of the truncated survival RV), not the sampling variance of the RMST estimator, and is unsuitable for confidence intervals or hypothesis testing. Docstring updated to match. (#1682)
+
 #### 0.30.3 - 2026-03-05
  - Revoke the 0.30.2 release and republish as 0.30.3.
  - Require Python >= 3.11 in package metadata.

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -911,7 +911,8 @@ def test_rmst_works_at_kaplan_meier_with_left_censoring():
     T = [5]
     kmf = KaplanMeierFitter().fit_left_censoring(T)
 
-    results = utils.restricted_mean_survival_time(kmf, t=10, return_variance=True)
+    with pytest.warns(UserWarning, match="return_variance=True"):
+        results = utils.restricted_mean_survival_time(kmf, t=10, return_variance=True)
     assert abs(results[0] - 5) < 0.0001
     assert abs(results[1] - 0) < 0.0001
 
@@ -980,8 +981,10 @@ def test_rmst_variance():
     actual_mean = 1 / hazard * (1 - np.exp(-hazard * t))
     actual_var = sq - actual_mean**2
 
-    assert abs(utils.restricted_mean_survival_time(expf, t=t, return_variance=True)[0] - actual_mean) < 0.001
-    assert abs(utils.restricted_mean_survival_time(expf, t=t, return_variance=True)[1] - actual_var) < 0.001
+    with pytest.warns(UserWarning, match="return_variance=True"):
+        rmst_with_var = utils.restricted_mean_survival_time(expf, t=t, return_variance=True)
+    assert abs(rmst_with_var[0] - actual_mean) < 0.001
+    assert abs(rmst_with_var[1] - actual_var) < 0.001
 
 
 def test_find_best_parametric_model():

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -3,6 +3,7 @@
 
 import pytest
 import os
+import warnings
 import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -919,7 +920,27 @@ def test_rmst_works_with_return_variance():
     # issue 1578
     T = [1, 2, 3, 4, 10]
     kmf = KaplanMeierFitter().fit(T)
-    result = utils.restricted_mean_survival_time(kmf.survival_function_, t=10, return_variance=True)
+    with pytest.warns(UserWarning, match="return_variance=True"):
+        result = utils.restricted_mean_survival_time(kmf.survival_function_, t=10, return_variance=True)
+
+
+def test_rmst_return_variance_emits_warning_about_truncated_variance():
+    # issue 1682: return_variance=True returns Var[min(T, t)], not the sampling
+    # variance Var[RMST_hat]. Users were silently constructing wrong CIs and
+    # p-values; emit a UserWarning so the misuse cannot be silent.
+    T = [1, 2, 3, 4, 10]
+    kmf = KaplanMeierFitter().fit(T)
+
+    with pytest.warns(UserWarning, match=r"return_variance=True.*sampling variance"):
+        utils.restricted_mean_survival_time(kmf, t=4, return_variance=True)
+
+    with pytest.warns(UserWarning, match=r"return_variance=True.*sampling variance"):
+        utils.restricted_mean_survival_time(kmf.survival_function_, t=4, return_variance=True)
+
+    # default (return_variance=False) must stay silent
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        utils.restricted_mean_survival_time(kmf, t=4)
 
 
 def test_rmst_exactly_with_known_solution():

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -224,6 +224,14 @@ def restricted_mean_survival_time(
         This can be a univariate model, or a pandas DataFrame. The former will provide a more accurate estimate however.
     t: float
         The upper limit of the integration in the RMST.
+    return_variance: bool, optional
+        If True, return a tuple ``(rmst, v)`` where ``v`` is
+        :math:`\operatorname{Var}[\min(T, t)]`, the variance of the truncated
+        survival random variable. This is **not** the sampling variance
+        :math:`\operatorname{Var}[\widehat{\text{RMST}}]` of the estimator and is
+        therefore unsuitable for constructing confidence intervals or hypothesis
+        tests on RMST. A ``UserWarning`` is emitted when this option is used.
+        See issue `#1682 <https://github.com/CamDavidsonPilon/lifelines/issues/1682>`_.
 
     Example
     --------
@@ -249,6 +257,14 @@ def restricted_mean_survival_time(
 
     mean = _expected_value_of_survival_up_to_t(model_or_survival_function, t)
     if return_variance:
+        warnings.warn(
+            "`return_variance=True` returns Var[min(T, t)], the variance of the truncated "
+            "survival random variable, NOT the sampling variance Var[RMST_hat] of the "
+            "estimator. Do not use this value to construct confidence intervals or perform "
+            "hypothesis tests on RMST. See https://github.com/CamDavidsonPilon/lifelines/issues/1682.",
+            UserWarning,
+            stacklevel=2,
+        )
         sq = _expected_value_of_survival_squared_up_to_t(model_or_survival_function, t)
         return (mean, sq - mean**2)
     else:


### PR DESCRIPTION
refs #1682.

`restricted_mean_survival_time(..., return_variance=True)` returns `Var[min(T, t)]` (variance of the truncated survival RV), not the sampling variance of the RMST estimator. anyone using it for confidence intervals or hypothesis tests silently gets the wrong answer — on the bundled `waltons` miR-137 subset at τ=10 the reported SE is ~6× the survRM2/greenwood reference.

this PR is the smallest fix while #1526 (greenwood-based variance) is in review:
- emits a `UserWarning` when `return_variance=True` is used
- updates the docstring to spell out what is actually returned
- wraps the existing tests that touch `return_variance=True` with `pytest.warns`
- adds a new test covering both the model and `survival_function_` paths, and that the default call stays silent

doesn'''t change the numeric return value or implement greenwood — that belongs in #1526.

tested locally: `pytest -k rmst` → 7 passed.