### PR TITLE
pandas 3.0 support

### DIFF
--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -1825,11 +1825,11 @@ class ParametricRegressionFitter(RegressionFitter):
 
         self._check_values_pre_fitting(Xs, utils.coalesce(Ts[1], Ts[0]), E, weights, entries)
 
-        _norm_std = Xs.std(0)
+        _norm_std = Xs.std(axis=0)
         _index = Xs.columns
 
         self._cols_to_not_penalize = self._find_cols_to_not_penalize(_norm_std)
-        self._norm_std = Xs.std(0)
+        self._norm_std = Xs.std(axis=0)
         _constant_cols = pd.Series(
             [_norm_std.loc[param_name, variable_name] < 1e-8 for (param_name, variable_name) in _index], index=_index
         )
@@ -3240,7 +3240,7 @@ class ParametericAFTRegressionFitter(ParametricRegressionFitter):
         """
         See https://github.com/CamDavidsonPilon/lifelines/issues/664
         """
-        constant_col = (Xs.std(0) < 1e-8).idxmax()
+        constant_col = (Xs.std(axis=0) < 1e-8).idxmax()
 
         def _transform_ith_param(param):
             if param <= 0:

--- a/lifelines/fitters/aalen_additive_fitter.py
+++ b/lifelines/fitters/aalen_additive_fitter.py
@@ -170,7 +170,7 @@ class AalenAdditiveFitter(RegressionFitter):
         self.event_observed = E.copy()
         self.weights = weights.copy()
 
-        self._norm_std = X.std(0)
+        self._norm_std = X.std(axis=0)
 
         # if we included an intercept, we need to fix not divide by zero.
         if self.fit_intercept:

--- a/lifelines/fitters/cox_time_varying_fitter.py
+++ b/lifelines/fitters/cox_time_varying_fitter.py
@@ -210,8 +210,8 @@ class CoxTimeVaryingFitter(SemiParametricRegressionFitter, ProportionalHazardMix
 
         self._check_values(X, events, start, stop)
 
-        self._norm_mean = X.mean(0)
-        self._norm_std = X.std(0)
+        self._norm_mean = X.mean(axis=0)
+        self._norm_std = X.std(axis=0)
 
         beta_, self.log_likelihood_, self._hessian_ = self._newton_raphson_for_efron_model(
             normalize(X, self._norm_mean, self._norm_std),

--- a/lifelines/fitters/coxph_fitter.py
+++ b/lifelines/fitters/coxph_fitter.py
@@ -1241,8 +1241,8 @@ class SemiParametricPHFitter(ProportionalHazardMixin, SemiParametricRegressionFi
         # TODO: doesn't handle weights, nor strata
         self._central_values = self._compute_central_values_of_raw_training_data(df, self.strata)
 
-        self._norm_mean = X.mean(0)
-        self._norm_std = X.std(0)
+        self._norm_mean = X.mean(axis=0)
+        self._norm_std = X.std(axis=0)
 
         # this is surprisingly faster to do...
         X_norm = pd.DataFrame(
@@ -2518,11 +2518,13 @@ See https://stats.stackexchange.com/q/11109/11867 for more.\n",
 
     def _compute_baseline_hazard(self, partial_hazards: DataFrame, name: Any) -> pd.DataFrame:
         # https://stats.stackexchange.com/questions/46532/cox-baseline-hazard
-        ind_hazards = partial_hazards.copy()
-        ind_hazards["P"] *= ind_hazards["W"]
-        ind_hazards["E"] *= ind_hazards["W"]
+        ind_hazards = partial_hazards.assign(
+            P=partial_hazards["P"] * partial_hazards["W"],
+            E=partial_hazards["E"] * partial_hazards["W"],
+        )
         ind_hazards_summed_over_durations = ind_hazards.groupby("T")[["P", "E"]].sum()
-        ind_hazards_summed_over_durations["P"] = ind_hazards_summed_over_durations["P"].loc[::-1].cumsum()
+        cumP = ind_hazards_summed_over_durations["P"].loc[::-1].cumsum()
+        ind_hazards_summed_over_durations = ind_hazards_summed_over_durations.assign(P=cumP)
         baseline_hazard = pd.DataFrame(
             ind_hazards_summed_over_durations["E"] / ind_hazards_summed_over_durations["P"], columns=[name]
         )

--- a/lifelines/fitters/generalized_gamma_regression_fitter.py
+++ b/lifelines/fitters/generalized_gamma_regression_fitter.py
@@ -112,7 +112,7 @@ class GeneralizedGammaRegressionFitter(ParametricRegressionFitter):
 
     def _create_initial_point(self, Ts, E, entries, weights, Xs):
         # detect constant columns
-        constant_col = (Xs.var(0) < 1e-8).idxmax()
+        constant_col = (Xs.var(axis=0) < 1e-8).idxmax()
 
         uni_model = GeneralizedGammaFitter()
 

--- a/lifelines/plotting.py
+++ b/lifelines/plotting.py
@@ -319,6 +319,9 @@ def qq_plot(model, ax=None, scatter_color="k", **plot_kwargs):
     quantiles[COL_THEO] = dist_object.ppf(q)
     quantiles = quantiles.replace([-np.inf, 0, np.inf], np.nan).dropna()
 
+    if quantiles.empty:
+        return ax
+
     max_, min_ = quantiles[COL_EMP].max(), quantiles[COL_EMP].min()
 
     quantiles.plot.scatter(

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -457,12 +457,11 @@ class TestUnivariateFitters:
     def test_univariate_fitters_ok_if_given_timedelta(self, univariate_fitters):
         t = pd.Series([pd.to_datetime("2015-01-01 12:00"), pd.to_datetime("2015-01-02"), pd.to_datetime("2015-01-02 12:00")])
         T = pd.to_datetime("2015-01-03") - t
+        twelve_hours = pd.to_numeric(T).min()
         for fitter in univariate_fitters:
             f = fitter().fit(T)
-            try:
-                npt.assert_allclose(f.timeline, 1e9 * 12 * 60 * 60 * np.array([0, 1, 2, 3]))
-            except:
-                npt.assert_allclose(f.timeline, 1e9 * 12 * 60 * 60 * np.array([1, 2, 3]))
+            start = 0 if np.isclose(f.timeline[0], 0) else 1
+            npt.assert_allclose(f.timeline, twelve_hours * np.arange(start, start + len(f.timeline)))
 
     def test_univariate_fitters_okay_if_given_boolean_col_with_object_dtype(self, univariate_fitters):
         df = pd.DataFrame({"T": [1, 2, 3, 4, 5], "E": [True, True, True, True, None]})
@@ -5151,9 +5150,12 @@ class TestCoxTimeVaryingFitter:
 
         """
         ctv.fit(dfcv, id_col="id", start_col="start", stop_col="stop", event_col="event")
-        npt.assert_almost_equal(ctv.summary["coef"].values, [1.826757, 0.705963], decimal=4)
-        npt.assert_almost_equal(ctv.summary["se(coef)"].values, [1.229, 1.206], decimal=3)
-        npt.assert_almost_equal(ctv.summary["p"].values, [0.14, 0.56], decimal=2)
+        npt.assert_almost_equal(ctv.summary.loc["group", "coef"], 1.826757, decimal=4)
+        npt.assert_almost_equal(ctv.summary.loc["z", "coef"], 0.705963, decimal=4)
+        npt.assert_almost_equal(ctv.summary.loc["group", "se(coef)"], 1.229, decimal=3)
+        npt.assert_almost_equal(ctv.summary.loc["z", "se(coef)"], 1.206, decimal=3)
+        npt.assert_almost_equal(ctv.summary.loc["group", "p"], 0.14, decimal=2)
+        npt.assert_almost_equal(ctv.summary.loc["z", "p"], 0.56, decimal=2)
 
     def test_that_id_col_is_optional(self, dfcv):
 
@@ -5198,8 +5200,10 @@ class TestCoxTimeVaryingFitter:
             0.19246482703103884,
         ]
         ctv.fit(dfcv, id_col="id", start_col="start", stop_col="stop", event_col="event", weights_col="weights")
-        npt.assert_almost_equal(ctv.summary["coef"].values, [0.313, 0.423], decimal=3)
-        npt.assert_almost_equal(ctv.summary["se(coef)"].values, [1.542, 1.997], decimal=3)
+        npt.assert_almost_equal(ctv.summary.loc["group", "coef"], 0.313, decimal=3)
+        npt.assert_almost_equal(ctv.summary.loc["z", "coef"], 0.423, decimal=3)
+        npt.assert_almost_equal(ctv.summary.loc["group", "se(coef)"], 1.542, decimal=3)
+        npt.assert_almost_equal(ctv.summary.loc["z", "se(coef)"], 1.997, decimal=3)
 
     def test_fitter_will_raise_an_error_if_immediate_death_present(self, ctv):
         df = pd.DataFrame.from_records(
@@ -5243,6 +5247,7 @@ class TestCoxTimeVaryingFitter:
         with pytest.raises(ValueError):
             ctv.fit(df, id_col="id", start_col="start", stop_col="stop", event_col="event")
 
+        df["stop"] = df["stop"].astype(float)
         df.loc[(df["start"] == df["stop"]) & (df["start"] == 0) & df["event"], "stop"] = 0.5
         ctv.fit(df, id_col="id", start_col="start", stop_col="stop", event_col="event")
         assert True

--- a/lifelines/tests/test_plotting.py
+++ b/lifelines/tests/test_plotting.py
@@ -471,10 +471,10 @@ class TestPlotting:
         data1 = np.random.exponential(10, size=200)
         data2 = np.random.exponential(5, size=200)
         kmf.fit(data1, label="test label 1")
-        ax = kmf.plot_survival_function_loglogs()
+        ax = kmf.plot_loglogs()
 
         kmf.fit(data2, label="test label 2")
-        ax = kmf.plot_survival_function_loglogs(ax=ax)
+        ax = kmf.plot_loglogs(ax=ax)
 
         self.plt.title("test_loglogs_plot")
         self.plt.show(block=block)
@@ -564,7 +564,7 @@ class TestPlotting:
         churn_data = churn_data.set_index("customerID")
         churn_data = churn_data.drop(["TotalCharges"], axis=1)
 
-        churn_data = churn_data.applymap(lambda x: "No" if str(x).startswith("No ") else x)
+        churn_data = churn_data.map(lambda x: "No" if str(x).startswith("No ") else x)
         churn_data["Churn"] = churn_data["Churn"] == "Yes"
         strata_cols = ["InternetService"]
 

--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -76,8 +76,8 @@ def test_lstsq_returns_correct_values():
 
 def test_unnormalize():
     df = load_larynx()
-    m = df.mean(0)
-    s = df.std(0)
+    m = df.mean(axis=0)
+    s = df.std(axis=0)
 
     ndf = utils.normalize(df)
 
@@ -87,8 +87,8 @@ def test_unnormalize():
 def test_normalize():
     df = load_larynx()
     n, d = df.shape
-    npt.assert_almost_equal(utils.normalize(df).mean(0).values, np.zeros(d))
-    npt.assert_almost_equal(utils.normalize(df).std(0).values, np.ones(d))
+    npt.assert_almost_equal(utils.normalize(df).mean(axis=0).values, np.zeros(d))
+    npt.assert_almost_equal(utils.normalize(df).std(axis=0).values, np.ones(d))
 
 
 def test_median():

--- a/lifelines/utils/__init__.py
+++ b/lifelines/utils/__init__.py
@@ -676,14 +676,14 @@ def datetimes_to_durations(
     """
     fill_date_ = pd.Series(fill_date).squeeze()
     freq_string = "timedelta64[%s]" % freq
-    start_times = pd.Series(start_times).copy()
-    end_times = pd.Series(end_times).copy()
+    start_times = pd.Series(start_times, dtype=object).copy()
+    end_times = pd.Series(end_times, dtype=object).copy()
 
-    C = ~(pd.isnull(end_times).values | end_times.astype(str).isin(na_values or [""]))
+    C = ~(pd.isnull(end_times).values | end_times.astype(str).isin(na_values or [""]).values)
     end_times[~C] = fill_date_
     start_times_ = pd.to_datetime(start_times, dayfirst=dayfirst, format=format)
     end_times_ = pd.to_datetime(end_times, dayfirst=dayfirst, errors="coerce", format=format)
-    deaths_after_cutoff = end_times_ > pd.to_datetime(fill_date_)
+    deaths_after_cutoff = (end_times_ > pd.to_datetime(fill_date_)).values
     C[deaths_after_cutoff] = False
     # Avoid duration info leaking from beyond fill date
     end_times_[deaths_after_cutoff] = pd.to_datetime(fill_date_)
@@ -691,7 +691,7 @@ def datetimes_to_durations(
     T = (end_times_ - start_times_).values.astype(freq_string).astype(float)
     if (T < 0).sum():
         warnings.warn("Warning: some values of start_times are after end_times.\n", UserWarning)
-    return T, C.values
+    return T, C
 
 
 def coalesce(*args) -> Any:
@@ -792,8 +792,8 @@ def normalize(X, mean=None, std=None):
     X to have mean 0 and std 1.
     """
     if mean is None or std is None:
-        mean = X.mean(0)
-        std = X.std(0)
+        mean = X.mean(axis=0)
+        std = X.std(axis=0)
     return (X - mean) / std
 
 
@@ -1084,7 +1084,7 @@ def check_positivity(array):
 
 
 def _low_var(df):
-    return df.var(0) < 1e-4
+    return df.var(axis=0) < 1e-4
 
 
 def check_low_var(df, prescript="", postscript=""):
@@ -1257,7 +1257,7 @@ def to_episodic_format(df, duration_col, event_col, id_col=None, time_gaps=1) ->
         d_dftv = d
 
     # what dtype can I make it?
-    dtype_dftv = object if (df.dtypes == object).any() else float
+    dtype_dftv = float if all(pd.api.types.is_numeric_dtype(dt) for dt in df.dtypes) else object
 
     # how many rows/cols do I need?
     n_dftv = int(np.ceil(df[stop_col]).sum())

--- a/reqs/base-requirements.txt
+++ b/reqs/base-requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.14.0
 scipy>=1.7.0
-pandas>=2.1,<3.0
+pandas>=2.1
 matplotlib>=3.0
 autograd>=1.5
 autograd-gamma>=0.3


### PR DESCRIPTION
refs https://github.com/CamDavidsonPilon/lifelines/issues/1685.

Lifelines now supports pandas 3.0 while maintaining backward compatibility with pandas 2.1+. The upper bound cap (pandas<3.0) has been removed from base-requirements.txt.

Breaking changes in pandas 3.0 addressed

StringDtype as the default string dtype

pandas 3.0 changed the default dtype for string data from object to StringDtype. This caused datetimes_to_durations to reject Timestamp values being assigned into string-typed Series.
Fixed by explicitly constructing start_times and end_times with dtype=object.

timedelta64 resolution changed from nanoseconds to microseconds

pandas 3.0 changed the default timedelta resolution from timedelta64[ns] to timedelta64[us]. A timedelta unit test was hardcoding the expected timeline values in nanoseconds (1e9 * 12 * 60 * 60), which broke under pandas 3.0. Fixed by deriving the expected unit from the actual timedelta data via pd.to_numeric(T).min(), making the test resolution-agnostic.

Boolean operations between ndarray and Series now return a Series

In pandas 3.0, ndarray | pd.Series returns a Series rather than an ndarray. This caused a type mismatch when building the censoring indicator C in datetimes_to_durations. Fixed byappending .values to isin() results to keep operands as ndarrays throughout.

DataFrame.applymap() removed

applymap was renamed to map in pandas 2.1 and fully removed in 3.0. Updated call site in test_plotting.py.

combine_first() column ordering changed

pandas 3.0 preserves insertion order rather than sorting alphabetically. CoxTimeVaryingFitter inference tests that indexed into .summary["coef"].values by position were fragile to this. Updated to access results by label (.loc["group", "coef"] etc.).

StringDtype index dtype detection in to_episodic_format

The dtype check (df.dtypes == object).any() no longer catches string columns under pandas 3.0. Replaced with pd.api.types.is_numeric_dtype to correctly distinguish numeric from non-numeric columns.

Deprecation warnings addressed (pandas 2.1+)

Positional axis argument to .mean(), .std(), .var()

pandas 2.1 introduced Pandas4Warning for positional axis arguments (e.g. .mean(0)). All occurrences across utils/__init__.py, coxph_fitter.py, cox_time_varying_fitter.py, aalen_additive_fitter.py, fitters/__init__.py, and generalized_gamma_regression_fitter.py have been updated to the keyword form (axis=0).

Copy-on-Write chained assignment

pandas 2.3 introduced FutureWarning: ChainedAssignmentError for in-place mutations on derived DataFrames. The _compute_baseline_hazard method in CoxPHFitter was using *= on columns of a copied DataFrame. Replaced with .assign() to produce new DataFrames rather than mutating views.

Integer column float assignment

pandas 3.0 no longer silently upcasts integer columns on float assignment. Added explicit .astype(float) in the degenerate time interval test before assigning float values to an integer stop column.

Other fixes

- qq_plot now returns early if all quantiles are non-finite (e.g. from a degenerate fit), preventing a crash on an empty DataFrame.
- Timedelta unit test now derives the expected value from the actual timedelta data rather than hardcoding nanosecond units, and uses np.isclose + np.arange instead of a bare except to handle fitters that include or exclude a zero time point.
- Updated plot_survival_function_loglogs → plot_loglogs in test (pre-existing method rename).