### PR TITLE
BUG: Fleming-Harrington weighted log-rank fails when an event occurs at t=0 (#1681)

### DIFF
--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -819,7 +819,11 @@ def multivariate_logrank_test(
             raise ValueError("Must provide keyword argument q for Flemington-Harrington test statistic")
         kwargs["test_name"] = kwargs["test_name"].replace("logrank", "Flemington-Harrington")
         kmf = KaplanMeierFitter().fit(event_durations, event_observed=event_observed)
-        s = kmf.survival_function_.to_numpy().flatten()[:-1]  # Left-continuous Kaplan-Meier survival estimate.
+        # Left-continuous Kaplan-Meier survival estimate S(t-) at each event time. Evaluating at
+        # obs.index and prepending the S=1 baseline keeps w_i aligned to obs whether or not an event
+        # occurs at t=0 (slicing survival_function_[:-1] drops a real weight in the latter case, see #1681).
+        sf = kmf.survival_function_at_times(obs.index).to_numpy()
+        s = np.insert(sf[:-1], 0, 1.0)
         w_i = np.power(s, p) * np.power(1.0 - s, q)
     else:
         raise ValueError("Invalid value for weightings.")

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -156,6 +156,26 @@ def test_peto_weighted_logrank_on_leukemia_dataset():
     assert result.test_name == "Peto_test"
 
 
+def test_fleming_harrington_weighted_logrank_handles_event_at_time_zero():
+    # See #1681: a Fleming-Harrington weighted log-rank test raised
+    # "Unable to coerce to Series" whenever an event time of 0 was present,
+    # because the survival estimate was one element short of the event table.
+    group_1 = np.array([2, 6, 1, 9, 0])
+    group_2 = np.array([3, 5, 4, 11])
+
+    result = stats.logrank_test(group_1, group_2, weightings="fleming-harrington", p=1, q=1)
+
+    assert result.test_name == "Flemington-Harrington_test"
+    assert np.isfinite(result.test_statistic)
+
+    # With p=q=0 every weight is 1, so Fleming-Harrington reduces to the standard log-rank
+    # test. This holds only when the weights stay aligned to the event table in the presence
+    # of an event at t=0, so it pins down the fix for #1681.
+    fh = stats.logrank_test(group_1, group_2, weightings="fleming-harrington", p=0, q=0)
+    plain = stats.logrank_test(group_1, group_2)
+    assert abs(fh.test_statistic - plain.test_statistic) < 10e-9
+
+
 def test_unequal_intensity_event_observed():
     data1 = np.random.exponential(5, size=(2000, 1))
     data2 = np.random.exponential(1, size=(2000, 1))


### PR DESCRIPTION
## Problem

`logrank_test(..., weightings="fleming-harrington")` raises `ValueError: Unable to coerce to Series` whenever the data contains an event at time `0`. Other weightings (`wilcoxon`, `tarone-ware`, `peto`) handle the same data fine. Reported in #1681.

```python
import numpy as np
from lifelines.statistics import logrank_test

g1 = np.array([2, 6, 1, 9, 0])   # note the 0
g2 = np.array([3, 5, 4, 11])

logrank_test(g1, g2, weightings="wilcoxon")                     # works
logrank_test(g1, g2, weightings="fleming-harrington", p=1, q=1) # ValueError
```

## Root cause

The Fleming-Harrington branch builds its weight vector with:

```python
s = kmf.survival_function_.to_numpy().flatten()[:-1]
```

The `[:-1]` assumes the Kaplan-Meier `survival_function_` always carries a synthetic `t=0` baseline row (S=1) in addition to one row per event time, so dropping the last value yields the left-continuous estimate aligned to the event table.

That assumption breaks when `0` is itself an event time: KM no longer adds a separate baseline row (the `t=0` row is now a real event), so `survival_function_` is one row shorter. The `[:-1]` then drops a genuine weight and `w_i` ends up one element short of `obs`, which raises at `obs.mul(w_i, axis=0)`.

## Fix

Evaluate the left-continuous KM survival estimate at the event times and prepend the S=1 baseline explicitly, so `w_i` stays aligned to `obs` regardless of whether an event occurs at `t=0`:

```python
sf = kmf.survival_function_at_times(obs.index).to_numpy()
s = np.insert(sf[:-1], 0, 1.0)
```

This produces weights identical to the previous code when no event occurs at `t=0`, so existing results are unchanged.

## Tests

Added `test_fleming_harrington_weighted_logrank_handles_event_at_time_zero`:

- The reported case (an event at `t=0`) no longer raises and returns a finite statistic.
- `FH(p=0, q=0)` reduces to the standard log-rank test on the zero-time data, which only holds when the weights stay aligned to the event table. This pins the fix.

The test fails on the previous code and passes with the fix. The full `lifelines/tests/test_statistics.py` suite passes (43 tests). There was no prior Fleming-Harrington test, so the change is otherwise unobserved by the suite.
