### PR TITLE
Validate inputs in sample_size_necessary_under_cph / power_under_cph

### DIFF
--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -270,7 +270,18 @@ def sample_size_necessary_under_cph(power, ratio_of_participants, p_exp, p_con, 
     --------
     power_under_cph
     """
-
+    if not (0 < power < 1):
+        raise ValueError("power must be between 0 and 1 (exclusive).")
+    if not (0 < alpha < 1):
+        raise ValueError("alpha must be between 0 and 1 (exclusive).")
+    if not (0 <= p_exp <= 1 and 0 <= p_con <= 1):
+        raise ValueError("p_exp and p_con must be probabilities in [0, 1].")
+    if ratio_of_participants <= 0:
+        raise ValueError("ratio_of_participants must be positive.")
+    if postulated_hazard_ratio <= 0:
+        raise ValueError("postulated_hazard_ratio must be positive.")
+    if postulated_hazard_ratio == 1:
+        raise ValueError("postulated_hazard_ratio cannot be 1 - there is no effect to size for.")
     def z(p):
         return stats.norm.ppf(p)
 
@@ -329,6 +340,14 @@ def power_under_cph(n_exp, n_con, p_exp, p_con, postulated_hazard_ratio, alpha=0
     --------
     sample_size_necessary_under_cph
     """
+    if n_exp <= 0 or n_con <= 0:
+        raise ValueError("n_exp and n_con must be positive.")
+    if not (0 <= p_exp <= 1 and 0 <= p_con <= 1):
+        raise ValueError("p_exp and p_con must be probabilities in [0, 1].")
+    if postulated_hazard_ratio <= 0:
+        raise ValueError("postulated_hazard_ratio must be positive.")
+    if not (0 < alpha < 1):
+        raise ValueError("alpha must be between 0 and 1 (exclusive).")
 
     def z(p):
         return stats.norm.ppf(p)

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -9,6 +9,7 @@ from lifelines import statistics as stats
 from lifelines import CoxPHFitter, KaplanMeierFitter, WeibullFitter
 from lifelines.exceptions import StatisticalWarning
 from lifelines.datasets import load_waltons, load_g3, load_lymphoma, load_dd, load_regression_dataset, load_leukemia
+from lifelines.statistics import sample_size_necessary_under_cph, power_under_cph
 
 
 def test_sample_size_necessary_under_cph():
@@ -579,3 +580,23 @@ def test_statistical_result_has_correct_decimal():
     output = results.to_ascii(decimals=10, test=1)
     numbers = re.findall(r"\d+\.\d{10}\b", output)
     assert len(numbers) >= 3
+
+
+
+@pytest.mark.parametrize("kwargs", [
+    dict(power=1.5, ratio_of_participants=1, p_exp=0.25, p_con=0.35, postulated_hazard_ratio=0.7),
+    dict(power=0.8, ratio_of_participants=1, p_exp=0.25, p_con=0.35, postulated_hazard_ratio=1.0),
+    dict(power=0.8, ratio_of_participants=1, p_exp=2.0,  p_con=0.35, postulated_hazard_ratio=0.7),
+])
+def test_sample_size_necessary_under_cph_rejects_invalid_input(kwargs):
+    with pytest.raises(ValueError):
+        sample_size_necessary_under_cph(**kwargs)
+
+
+def test_sample_size_necessary_under_cph_valid_unchanged():
+    assert sample_size_necessary_under_cph(0.8, 1, 0.25, 0.35, 0.7) == (421, 421)
+
+
+def test_power_under_cph_rejects_invalid_input():
+    with pytest.raises(ValueError):
+        power_under_cph(0, 100, 0.25, 0.35, 0.7)


### PR DESCRIPTION
# Summary
`sample_size_necessary_under_cph` and `power_under_cph` in `lifelines.statistics` raised cryptic errors on out-of-range inputs. This adds input validation that raises a clear `ValueError`. No change to valid behavior.

# Reproductions (current master)
```python
sample_size_necessary_under_cph(0.8, 1, 0.25, 0.35, 1.0)  # ZeroDivisionError: float division by zero
sample_size_necessary_under_cph(1.5, 1, 0.25, 0.35, 0.7)  # ValueError: cannot convert float NaN to integer
```
A hazard ratio of 1 (no effect) can't be sized for; out-of-range power/probabilities silently produce NaN.

## Changes
- Range checks on both functions (power, alpha in (0,1); probabilities in [0,1]; positive sizes/ratio; hazard ratio > 0). `postulated_hazard_ratio == 1` is rejected only in `sample_size_necessary_under_cph` — it's still valid for `power_under_cph`.
- Tests covering the invalid inputs and confirming valid output is unchanged: `(0.8, 1, 0.25, 0.35, 0.7) == (421, 421)`.