### PR TITLE
Fix typos in docstrings and concordance_index error message

### DIFF
--- a/lifelines/fitters/__init__.py
+++ b/lifelines/fitters/__init__.py
@@ -732,7 +732,7 @@ class ParametricUnivariateFitter(UnivariateFitter):
         durations: an array, or pd.Series
           length n, duration subject was observed for
         event_observed: numpy array or pd.Series, optional
-          length n, True if the the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
+          length n, True if the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
         timeline: list, optional
             return the estimate at the values in timeline (positively increasing)
         label: string, optional
@@ -803,7 +803,7 @@ class ParametricUnivariateFitter(UnivariateFitter):
         durations: an array, or pd.Series
           length n, duration subject was observed for
         event_observed: numpy array or pd.Series, optional
-          length n, True if the the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
+          length n, True if the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
         timeline: list, optional
             return the estimate at the values in timeline (positively increasing)
         label: string, optional
@@ -2484,7 +2484,7 @@ class ParametricRegressionFitter(RegressionFitter):
 
         Caution
         --------
-        If the survival function doesn't converge to 0, the the expectation is really infinity and the returned
+        If the survival function doesn't converge to 0, the expectation is really infinity and the returned
         values are meaningless/too large. In that case, using ``predict_median`` or ``predict_percentile`` would be better.
 
         Parameters

--- a/lifelines/fitters/breslow_fleming_harrington_fitter.py
+++ b/lifelines/fitters/breslow_fleming_harrington_fitter.py
@@ -48,7 +48,7 @@ class BreslowFlemingHarringtonFitter(NonParametricUnivariateFitter):
         timeline:
             return the best estimate at the values in timelines (positively increasing)
         event_observed: an array, or pd.Series, of length n
-            True if the the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
+            True if the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
         entry: an array, or pd.Series, of length n
            relative time when a subject entered the study. This is
            useful for left-truncated observations, i.e the birth event was not observed.

--- a/lifelines/fitters/kaplan_meier_fitter.py
+++ b/lifelines/fitters/kaplan_meier_fitter.py
@@ -98,7 +98,7 @@ class KaplanMeierFitter(NonParametricUnivariateFitter):
           durations: an array, list, pd.DataFrame or pd.Series
             length n -- duration (relative to subject's birth) the subject was alive for.
           event_observed: an array, list, pd.DataFrame, or pd.Series, optional
-             True if the the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
+             True if the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
           timeline: an array, list, pd.DataFrame, or pd.Series, optional
             return the best estimate at the values in timelines (positively increasing)
           entry: an array, list, pd.DataFrame, or pd.Series, optional
@@ -164,7 +164,7 @@ class KaplanMeierFitter(NonParametricUnivariateFitter):
           upper_bound: an array, list, pd.DataFrame or pd.Series
             length n -- upper bound of observations
           event_observed: an array, list, pd.DataFrame, or pd.Series, optional
-             True if the the death was observed, False if the event was lost (right-censored). This can be computed from
+             True if the death was observed, False if the event was lost (right-censored). This can be computed from
              the lower_bound and upper_bound, and can be left blank.
           timeline: an array, list, pd.DataFrame, or pd.Series, optional
             return the best estimate at the values in timelines (positively increasing)
@@ -257,7 +257,7 @@ class KaplanMeierFitter(NonParametricUnivariateFitter):
           durations: an array, list, pd.DataFrame or pd.Series
             length n -- duration subject was observed for
           event_observed: an array, list, pd.DataFrame, or pd.Series, optional
-             True if the the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
+             True if the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
           timeline: an array, list, pd.DataFrame, or pd.Series, optional
             return the best estimate at the values in timelines (positively increasing)
           entry: an array, list, pd.DataFrame, or pd.Series, optional
@@ -300,7 +300,7 @@ class KaplanMeierFitter(NonParametricUnivariateFitter):
           durations: an array, list, pd.DataFrame or pd.Series
             length n -- duration subject was observed for
           event_observed: an array, list, pd.DataFrame, or pd.Series, optional
-             True if the the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
+             True if the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
           timeline: an array, list, pd.DataFrame, or pd.Series, optional
             return the best estimate at the values in timelines (positively increasing)
           entry: an array, list, pd.DataFrame, or pd.Series, optional

--- a/lifelines/fitters/nelson_aalen_fitter.py
+++ b/lifelines/fitters/nelson_aalen_fitter.py
@@ -89,7 +89,7 @@ class NelsonAalenFitter(UnivariateFitter):
         timeline: iterable
             return the best estimate at the values in timelines (positively increasing)
         event_observed: an array, or pd.Series, of length n
-            True if the the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
+            True if the death was observed, False if the event was lost (right-censored). Defaults all True if event_observed==None
         entry: an array, or pd.Series, of length n
            relative time when a subject entered the study. This is
            useful for left-truncated observations, i.e the birth event was not observed.

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -979,7 +979,7 @@ class TestWeibullFitter:
         assert wf.summary.loc["lambda_", "coef lower 95%"] < 0.5 < wf.summary.loc["lambda_", "coef upper 95%"]
 
     def test_weibull_with_delayed_entries(self):
-        # note the the independence of entry and final time is really important
+        # note the independence of entry and final time is really important
         # (also called non-informative)
         # for example, the following doesn't work
         # D = np.random.rand(15000) * T

--- a/lifelines/tests/utils/test_concordance.py
+++ b/lifelines/tests/utils/test_concordance.py
@@ -34,10 +34,10 @@ def test_both_concordance_index_with_only_censoring_fails_gracefully():
     actual_times = np.array([1, 2, 3])
     predicted_times = np.array([1, 2, 3])
     obs = np.zeros(3)
-    with pytest.raises(ZeroDivisionError, match="admissable pairs"):
+    with pytest.raises(ZeroDivisionError, match="admissible pairs"):
         fast_cindex(actual_times, predicted_times, obs)
 
-    with pytest.raises(ZeroDivisionError, match="admissable pairs"):
+    with pytest.raises(ZeroDivisionError, match="admissible pairs"):
         slow_cindex(actual_times, predicted_times, obs)
 
 

--- a/lifelines/utils/concordance.py
+++ b/lifelines/utils/concordance.py
@@ -52,10 +52,10 @@ def concordance_index(event_times, predicted_scores, event_observed=None) -> flo
 
     The calculation internally done is
 
-    >>> (pairs_correct + 0.5 * pairs_tied) / admissable_pairs
+    >>> (pairs_correct + 0.5 * pairs_tied) / admissible_pairs
 
     where ``pairs_correct`` is the number of pairs s.t. if ``t_x > t_y``, then ``s_x > s_y``, pairs,
-    ``pairs_tied`` is the number of pairs where ``s_x = s_y``, and ``admissable_pairs`` is all possible pairs. The subtleties
+    ``pairs_tied`` is the number of pairs where ``s_x = s_y``, and ``admissible_pairs`` is all possible pairs. The subtleties
     are in how censored observation are handled (ex: not all pairs can be evaluated due to censoring).
 
 
@@ -96,7 +96,7 @@ def concordance_index(event_times, predicted_scores, event_observed=None) -> flo
 
 def _concordance_ratio(num_correct: int, num_tied: int, num_pairs: int) -> float:
     if num_pairs == 0:
-        raise ZeroDivisionError("No admissable pairs in the dataset.")
+        raise ZeroDivisionError("No admissible pairs in the dataset.")
     return (num_correct + num_tied / 2) / num_pairs
 
 


### PR DESCRIPTION
Fixes a few documentation typos: repeated "the the" in several fitter docstrings, and "admissable" → "admissible" in the concordance_index error message. No behavior changes.