### PR TITLE
feat: conditional expectation WeibullAFTFitter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
 -   repo: https://github.com/ambv/black
-    rev: 22.8.0
+    rev: 24.10.0
     hooks:
     - id: black
       args: ["--line-length", "130"]

--- a/lifelines/fitters/weibull_aft_fitter.py
+++ b/lifelines/fitters/weibull_aft_fitter.py
@@ -3,7 +3,7 @@ from autograd import numpy as np
 from autograd.builtins import DictBox
 from autograd.numpy.numpy_boxes import ArrayBox
 from typing import Dict, List, Optional, Union
-from scipy.special import gamma
+from scipy.special import gamma, gammaincc
 import pandas as pd
 
 from lifelines.utils import _get_index
@@ -93,7 +93,10 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter, ProportionalHazardMixin):
         super(WeibullAFTFitter, self).__init__(alpha, penalizer, l1_ratio, fit_intercept, model_ancillary)
 
     def _cumulative_hazard(
-        self, params: Union[DictBox, Dict[str, np.array]], T: Union[float, np.array], Xs: DataframeSlicer
+        self,
+        params: Union[DictBox, Dict[str, np.array]],
+        T: Union[float, np.array],
+        Xs: DataframeSlicer,
     ) -> Union[np.array, ArrayBox]:
         lambda_params = params["lambda_"]
         log_lambda_ = Xs["lambda_"] @ lambda_params
@@ -104,13 +107,19 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter, ProportionalHazardMixin):
         return safe_exp(rho_ * (np.log(np.clip(T, 1e-100, np.inf)) - log_lambda_))
 
     def _survival_function(
-        self, params: Union[DictBox, Dict[str, np.array]], T: Union[float, np.array], Xs: DataframeSlicer
+        self,
+        params: Union[DictBox, Dict[str, np.array]],
+        T: Union[float, np.array],
+        Xs: DataframeSlicer,
     ) -> Union[np.array, ArrayBox]:
         ch = self._cumulative_hazard(params, T, Xs)
         return safe_exp(-ch)
 
     def _log_hazard(
-        self, params: Union[DictBox, Dict[str, np.array]], T: Union[float, np.array], Xs: DataframeSlicer
+        self,
+        params: Union[DictBox, Dict[str, np.array]],
+        T: Union[float, np.array],
+        Xs: DataframeSlicer,
     ) -> Union[np.array, ArrayBox]:
         lambda_params = params["lambda_"]
         log_lambda_ = Xs["lambda_"] @ lambda_params
@@ -168,7 +177,12 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter, ProportionalHazardMixin):
             index=_get_index(df),
         )
 
-    def predict_expectation(self, df: pd.DataFrame, ancillary: Optional[pd.DataFrame] = None) -> pd.Series:
+    def predict_expectation(
+        self,
+        df: pd.DataFrame,
+        ancillary: Optional[pd.DataFrame] = None,
+        conditional_after: Optional[np.array] = None,
+    ) -> pd.Series:
         """
         Predict the expectation of lifetimes, :math:`E[T | x]`.
 
@@ -194,4 +208,23 @@ class WeibullAFTFitter(ParametericAFTRegressionFitter, ProportionalHazardMixin):
         predict_median, predict_percentile
         """
         lambda_, rho_ = self._prep_inputs_for_prediction_and_return_scores(df, ancillary)
-        return pd.Series((lambda_ * gamma(1 + 1 / rho_)), index=_get_index(df))
+
+        if conditional_after is None:
+            return pd.Series((lambda_ * gamma(1 + 1 / rho_)), index=_get_index(df))
+
+        cumulative_hazard_at_conditional_after = self._cumulative_hazard(
+            params={name: self.params_.loc[name].values for name in self._fitted_parameter_names},
+            T=conditional_after,
+            Xs=self.regressors.transform_df(df),
+        )
+
+        return pd.Series(
+            (
+                lambda_
+                * np.exp(cumulative_hazard_at_conditional_after)
+                * gamma(1 + 1 / rho_)
+                * gammaincc(1 + 1 / rho_, cumulative_hazard_at_conditional_after)
+            )
+            - conditional_after,
+            index=_get_index(df),
+        )

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from typing import Callable
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
 import numpy.testing as npt
@@ -9,6 +12,7 @@ from lifelines import statistics as stats
 from lifelines import CoxPHFitter, KaplanMeierFitter, WeibullFitter, WeibullAFTFitter
 from lifelines.exceptions import StatisticalWarning
 from lifelines.datasets import load_waltons, load_g3, load_lymphoma, load_dd, load_regression_dataset, load_leukemia
+from lifelines.utils.safe_exp import safe_exp
 
 
 def test_sample_size_necessary_under_cph():
@@ -205,7 +209,6 @@ def test_log_rank_test_on_waltons_dataset_with_case_weights():
     waltonT1 = df.loc[ix]["T"]
     waltonT2 = df.loc[~ix]["T"]
     result = stats.logrank_test(waltonT1, waltonT2)
-    print(result)
 
     dfw = df.groupby(["T", "E", "group"]).size().reset_index().rename(columns={0: "weights"})
     ixw = dfw["group"] == "miR-137"
@@ -594,3 +597,51 @@ def test_weibull_aft_fitter_predict_expectation():
     # Check that using the conditional after argument gives the same result as the unconditional expectation when the conditional after times are all zero
     conditional_expectations = aft.predict_expectation(df, conditional_after=np.zeros(df.shape[0]))
     assert np.isclose(predicted_expectations, conditional_expectations).all()
+
+
+def test_weibull_aft_fitter_predict_expectation_with_conditional_after():
+    aft = WeibullAFTFitter()
+    df = load_regression_dataset()
+    aft.fit(df, duration_col="T", event_col="E")
+
+    def make_fake_prep(rho: float) -> Callable:
+        def fake_prep(X, ancillary_X) -> tuple[np.ndarray, np.ndarray]:
+            output = WeibullAFTFitter._prep_inputs_for_prediction_and_return_scores(aft, X, ancillary_X)
+            return output[0], np.full_like(output[1], rho, dtype=float)
+
+        return fake_prep
+
+    def make_fake_cumulative_hazard(rho: float) -> Callable:
+        def fake_cumulative_hazard(params, T, Xs) -> np.ndarray:
+            lambda_params = params["lambda_"]
+            log_lambda_ = Xs["lambda_"] @ lambda_params
+
+            return safe_exp(rho * (np.log(np.clip(T, 1e-100, np.inf)) - log_lambda_))
+
+        return fake_cumulative_hazard
+
+    conditional_after_times = np.arange(start=1, stop=df.shape[0] + 1, step=1)
+
+    # When the shape parameter equals 1, we are dealing with an exponential distribution.
+    # In that case the conditional and unconditional expectations should be equal, regardless of the conditional_after times.
+    with patch.object(aft, "_cumulative_hazard", make_fake_cumulative_hazard(1.0)):
+        with patch.object(aft, "_prep_inputs_for_prediction_and_return_scores", make_fake_prep(1.0)):
+            unconditional_expectations = aft.predict_expectation(df)
+            conditional_expectations = aft.predict_expectation(df, conditional_after=conditional_after_times)
+            assert np.isclose(unconditional_expectations, conditional_expectations).all()
+
+    # When the shape parameter is greater than 1, the hazard increases over time.
+    # Strictly positive conditional_after times should thus lead to strictly lower conditional expectations.
+    with patch.object(aft, "_cumulative_hazard", make_fake_cumulative_hazard(2.0)):
+        with patch.object(aft, "_prep_inputs_for_prediction_and_return_scores", make_fake_prep(2.0)):
+            unconditional_expectations = aft.predict_expectation(df)
+            conditional_expectations = aft.predict_expectation(df, conditional_after=conditional_after_times)
+            assert (conditional_expectations < unconditional_expectations).all()
+
+    # When the shape parameter is less than 1, the hazard decreases over time.
+    # Strictly positive conditional_after times should thus lead to strictly higher conditional expectations.
+    with patch.object(aft, "_cumulative_hazard", make_fake_cumulative_hazard(0.5)):
+        with patch.object(aft, "_prep_inputs_for_prediction_and_return_scores", make_fake_prep(0.5)):
+            unconditional_expectations = aft.predict_expectation(df)
+            conditional_expectations = aft.predict_expectation(df, conditional_after=conditional_after_times)
+            assert (conditional_expectations > unconditional_expectations).all()

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -6,7 +6,7 @@ import pytest
 
 from pandas.testing import assert_frame_equal
 from lifelines import statistics as stats
-from lifelines import CoxPHFitter, KaplanMeierFitter, WeibullFitter
+from lifelines import CoxPHFitter, KaplanMeierFitter, WeibullFitter, WeibullAFTFitter
 from lifelines.exceptions import StatisticalWarning
 from lifelines.datasets import load_waltons, load_g3, load_lymphoma, load_dd, load_regression_dataset, load_leukemia
 
@@ -579,3 +579,19 @@ def test_statistical_result_has_correct_decimal():
     output = results.to_ascii(decimals=10, test=1)
     numbers = re.findall(r"\d+\.\d{10}\b", output)
     assert len(numbers) >= 3
+
+
+def test_weibull_aft_fitter_predict_expectation():
+
+    aft = WeibullAFTFitter()
+    df = load_regression_dataset()
+    aft.fit(df, duration_col="T", event_col="E")
+
+    predicted_expectations = aft.predict_expectation(df)
+
+    # Check that all expectations are positive
+    assert (predicted_expectations >= 0).all()
+
+    # Check that using the conditional after argument gives the same result as the unconditional expectation when the conditional after times are all zero
+    conditional_expectations = aft.predict_expectation(df, conditional_after=np.zeros(df.shape[0]))
+    assert np.isclose(predicted_expectations, conditional_expectations).all()

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -582,14 +582,13 @@ def test_statistical_result_has_correct_decimal():
 
 
 def test_weibull_aft_fitter_predict_expectation():
-
     aft = WeibullAFTFitter()
     df = load_regression_dataset()
     aft.fit(df, duration_col="T", event_col="E")
 
     predicted_expectations = aft.predict_expectation(df)
 
-    # Check that all expectations are positive
+    # Check that all expectations are nonmegative
     assert (predicted_expectations >= 0).all()
 
     # Check that using the conditional after argument gives the same result as the unconditional expectation when the conditional after times are all zero

--- a/lifelines/tests/test_statistics.py
+++ b/lifelines/tests/test_statistics.py
@@ -588,7 +588,7 @@ def test_weibull_aft_fitter_predict_expectation():
 
     predicted_expectations = aft.predict_expectation(df)
 
-    # Check that all expectations are nonmegative
+    # Check that all expectations are nonnegative
     assert (predicted_expectations >= 0).all()
 
     # Check that using the conditional after argument gives the same result as the unconditional expectation when the conditional after times are all zero


### PR DESCRIPTION
Extends the `WeibullAFTFitter.predict_expectation` method with the `conditional_after` argument.

Resolves #1680 