### PR TITLE
Fix row-order dependence in the rank PH diagnostic

### DIFF
--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -858,8 +858,8 @@ def _chisq_test_p_value(U, degrees_freedom) -> float:
 class TimeTransformers:
 
     TIME_TRANSFOMERS = {
-        # using cumsum is kinda hacky (but smart), should be np.argsort but I run into problems later.
-        "rank": lambda t, c, w: np.cumsum(c),
+        # Rank observed event times, averaging ties independently of row or stratum order.
+        "rank": lambda t, c, w: pd.Series(t).where(np.asarray(c, dtype=bool)).rank(method="average"),
         "identity": lambda t, c, w: t,
         "log": lambda t, c, w: np.log(t),
         "km": lambda t, c, w: (1 - KaplanMeierFitter().fit(t, c, weights=w).survival_function_.loc[t, "KM_estimate"]),

--- a/lifelines/tests/test_rank_time_invariance.py
+++ b/lifelines/tests/test_rank_time_invariance.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from lifelines import CoxPHFitter
+from lifelines.datasets import load_lung
+from lifelines.statistics import TimeTransformers, proportional_hazard_test
+
+
+@pytest.mark.parametrize("as_series", [False, True])
+def test_rank_transform_uses_event_times_and_averages_ties(as_series):
+    times = np.array([4.0, 1.0, 2.0, 2.0, 3.0])
+    events = np.array([1, 1, 1, 1, 0], dtype=bool)
+    if as_series:
+        times = pd.Series(times, index=["e", "a", "c", "b", "d"])
+    result = TimeTransformers().get("rank")(times, events, np.ones(5))
+    np.testing.assert_allclose(np.asarray(result)[events], [4.0, 1.0, 2.5, 2.5])
+
+
+def test_rank_transform_preserves_ordered_untied_event_ranks():
+    times = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    events = pd.Series([True, False, True, False, True])
+    result = TimeTransformers().get("rank")(times, events, np.ones(5))
+    np.testing.assert_array_equal(result[events], [1.0, 2.0, 3.0])
+
+
+def test_ph_rank_is_invariant_to_order_within_ties():
+    x = np.linspace(-2.0, 2.0, 400)
+    frame = pd.DataFrame({"T": np.repeat([1.0, 2.0, 3.0, 4.0, 5.0], len(x)), "E": 1, "x": np.tile(x, 5)})
+    results = []
+    for data in [frame, frame.sample(frac=1, random_state=19)]:
+        model = CoxPHFitter().fit(data, "T", "E")
+        assert model.params_["x"] == pytest.approx(0, abs=1e-12)
+        result = proportional_hazard_test(model, data)
+        results.append(result.summary.loc["x", "p"])
+    np.testing.assert_allclose(results, [1.0, 1.0], atol=1e-12)
+
+
+def test_ph_rank_is_invariant_to_stratum_labels():
+    frame = load_lung()[["time", "status", "age", "sex", "ph.ecog"]].dropna()
+    results = []
+    coefficients = []
+    for reverse in [False, True]:
+        data = frame.copy()
+        levels = data.pop("ph.ecog")
+        data["stratum"] = (3 - levels if reverse else levels).astype(str)
+        model = CoxPHFitter().fit(data, "time", "status", strata="stratum", formula="age + sex")
+        coefficients.append(model.params_.values)
+        results.append(proportional_hazard_test(model, data).summary["p"].values)
+    np.testing.assert_allclose(coefficients[0], coefficients[1], atol=1e-12)
+    np.testing.assert_allclose(results[0], results[1], atol=1e-12)


### PR DESCRIPTION
The default PH-test `rank` transform is `np.cumsum(events)`. This ranks positions in the fitted model's stored row order rather than event times. It gives tied events different ranks and, for stratified fits, accumulates through strata sorted by their labels. Consequently, the diagnostic can change without changing the fitted model or survival data.

Rank observed event times directly, assigning average ranks to ties. This preserves the existing event-rank convention for chronologically ordered, untied observations; it does not change the PH-test approximation or attempt to match modern R `cox.zph`.

Reproduction on 2,000 balanced synthetic observations: five event times, each with the same 400 covariate values. The fitted coefficient is exactly 0 and its SE is 0.01931656 in both row orders. Sorting the covariate within tied times gives rank-test **p=3.745e-19**; shuffling the same rows gives **p=0.79865**. `check_assumptions()` consequently flags the sorted representation but not the shuffled one. With the correction, both rank-test p-values are approximately 1. The identity-transform control is approximately 1 throughout.

A separate check uses 227 complete rows from `load_lung()`, fits age and sex with strata defined by ph.ecog, and evaluates all 24 renamings of the four strata. The original age rank-test p-value ranges from **0.08725 to 0.61962**, with unchanged coefficients. The correction gives **0.94072455** across all renamings, within floating-point tolerance. This is a representation-invariance check on released data, not a claim about the original study's conclusions.

Validation on base `7a8fc34a013ecd79fa405017b89e1697c1cc6e17`: five added tests cover unordered/tied times, array/Series inputs, censor exclusion, the untied control, row permutation and stratum relabeling. Before: four fail, one passes. The complete existing statistics test file plus these cases gives **47 passed**. Black 22.8.0 formatting passes. The full package suite was not run. Released 0.30.3 also reproduces the defect.

Related: #997 discusses discrepancies and suspected tie handling; this PR supplies a concrete order-invariance reproduction and a narrowly scoped correction. Prepared with AI assistance. No independent scientific review or changed published conclusion is claimed. The [public audit](https://cheerfulduck.com/research/audits/lifelines-rank-time-order) includes the reproduction scripts, separate patches, environment records and before/after execution logs in a downloadable evidence archive.
