### PR TITLE
Use case-weighted survival in Fleming-Harrington tests

### DIFF
--- a/lifelines/statistics.py
+++ b/lifelines/statistics.py
@@ -818,8 +818,9 @@ def multivariate_logrank_test(
         else:
             raise ValueError("Must provide keyword argument q for Flemington-Harrington test statistic")
         kwargs["test_name"] = kwargs["test_name"].replace("logrank", "Flemington-Harrington")
-        kmf = KaplanMeierFitter().fit(event_durations, event_observed=event_observed)
-        s = kmf.survival_function_.to_numpy().flatten()[:-1]  # Left-continuous Kaplan-Meier survival estimate.
+        # Left-continuous pooled survival from the same weighted risk sets as the test.
+        # Shifting on this timeline also handles events at time zero.
+        s = (1.0 - d_i / n_i).cumprod().shift(1, fill_value=1.0).to_numpy()
         w_i = np.power(s, p) * np.power(1.0 - s, q)
     else:
         raise ValueError("Invalid value for weightings.")

--- a/lifelines/tests/test_fleming_harrington_weights.py
+++ b/lifelines/tests/test_fleming_harrington_weights.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+from scipy.stats import chi2
+
+from lifelines.datasets import load_waltons
+from lifelines.statistics import multivariate_logrank_test
+
+
+def _two_group_reference(table, p, q):
+    # Direct risk-set formula, independent of lifelines' survival estimators.
+    time = table["T"].to_numpy()
+    event = table["E"].to_numpy()
+    group = table["group"].to_numpy() == "control"
+    frequency = table["weights"].to_numpy()
+    survival = 1.0
+    observed_minus_expected = 0.0
+    variance = 0.0
+    for t in np.unique(time):
+        at_risk = time >= t
+        died = (time == t) & event.astype(bool)
+        n = frequency[at_risk].sum()
+        n_a = frequency[at_risk & group].sum()
+        deaths = frequency[died].sum()
+        deaths_a = frequency[died & group].sum()
+        weight = survival**p * (1 - survival) ** q
+        observed_minus_expected += weight * (deaths_a - deaths * n_a / n)
+        if n > 1:
+            variance += weight**2 * n_a * (n - n_a) * deaths * (n - deaths) / (n**2 * (n - 1))
+        survival *= 1 - deaths / n
+    statistic = observed_minus_expected**2 / variance
+    return statistic, chi2.sf(statistic, 1)
+
+
+@pytest.mark.parametrize("p,q", [(0, 0), (1, 0), (0, 1), (1, 1), (2, 2), (3, 3), (4, 4)])
+def test_fh_frequency_weights_match_expanded_data_and_risk_set_reference(p, q):
+    data = load_waltons()
+    grouped = data.groupby(["T", "E", "group"]).size().rename("weights").reset_index()
+    expected_stat, expected_p = _two_group_reference(grouped, p, q)
+    expanded = multivariate_logrank_test(data["T"], data["group"], data["E"], weightings="fleming-harrington", p=p, q=q)
+    compressed = multivariate_logrank_test(
+        grouped["T"], grouped["group"], grouped["E"], weights=grouped["weights"], weightings="fleming-harrington", p=p, q=q
+    )
+    for result in [expanded, compressed]:
+        np.testing.assert_allclose(result.test_statistic, expected_stat, rtol=1e-10)
+        np.testing.assert_allclose(result.p_value, expected_p, rtol=1e-10, atol=0)
+
+
+@pytest.mark.parametrize("p,q", [(1, 1), (0, 1)])
+def test_fh_is_invariant_to_time_origin(p, q):
+    time = np.array([2, 6, 1, 9, 0, 3, 5, 4, 11])
+    group = np.array([0] * 5 + [1] * 4)
+    at_zero = multivariate_logrank_test(time, group, weightings="fleming-harrington", p=p, q=q)
+    shifted = multivariate_logrank_test(time + 1, group, weightings="fleming-harrington", p=p, q=q)
+    np.testing.assert_allclose(at_zero.test_statistic, shifted.test_statistic)
+    np.testing.assert_allclose(at_zero.p_value, shifted.p_value)


### PR DESCRIPTION
Fleming–Harrington weighting currently fits its pooled Kaplan–Meier curve without the supplied case weights, although the test's risk sets, event counts and covariance calculation use those weights. This makes the result depend on whether duplicate observations are expanded or represented as frequency counts.

Compute left-continuous pooled survival directly from the same weighted risk sets already used by the test: cumulatively multiply `1 - d_i / n_i`, then shift by one with an initial value of 1. This also avoids the assumption that the KM timeline has an extra origin row before every observed time, resolving the zero-time length mismatch in #1681.

On `load_waltons()`, 163 rows can be compressed losslessly into 39 rows with integer frequency weights. For FH(p=3,q=3), the original expanded representation gives **p=0.0607523**, but the compressed representation gives **p=4.46375e-9**. After this patch, both give **p=0.0607523**. A full grid is recorded rather than only this crossing: (0,0), (1,0), (0,1), (1,1), (2,2), (3,3), (4,4). The (0,0) log-rank control agrees before and after; every nontrivial weighting in this grid disagrees before correction. These are the same observations, not different weighting estimands or new data.

Validation on base `7a8fc34a013ecd79fa405017b89e1697c1cc6e17`: seven cases compare expanded/compressed results against a separate scalar risk-set implementation of the two-group weighted log-rank statistic; two cases test invariance to a shift from a zero time origin. Before: eight fail, one passes. The complete existing statistics test file plus these cases gives **51 passed**. Black 22.8.0 formatting passes. The full package suite was not run. Released 0.30.3 also reproduces the case-weight discrepancy.

Fixes #1681. Prepared with AI assistance. This checks a bundled Drosophila dataset and does not establish an effect on a published conclusion or clinical decision. The [public audit](https://cheerfulduck.com/research/audits/lifelines-fleming-harrington-weights) includes the reproduction scripts, separate patches, environment records and before/after execution logs in a downloadable evidence archive.
