### PR TITLE
Fix Aalen–Johansen incidence on custom timelines and at the initial event time

### DIFF
--- a/lifelines/fitters/aalen_johansen_fitter.py
+++ b/lifelines/fitters/aalen_johansen_fitter.py
@@ -128,10 +128,12 @@ class AalenJohansenFitter(NonParametricUnivariateFitter):
         self.label_cmprisk = "observed_" + str(event_of_interest)
 
         # Fitting Kaplan-Meier for either event of interest OR competing risk
-        km = KaplanMeierFitter().fit(durations, event_observed=event_observed, timeline=timeline, entry=entry, weights=weights)
+        # The survival factors must be evaluated at every event time. A requested
+        # reporting grid must not remove factors from the incidence calculation.
+        km = KaplanMeierFitter().fit(durations, event_observed=event_observed, entry=entry, weights=weights)
         aj = km.event_table
         aj["overall_survival"] = km.survival_function_
-        aj["lagged_overall_survival"] = aj["overall_survival"].shift()
+        aj["lagged_overall_survival"] = aj["overall_survival"].shift(fill_value=1.0)
 
         # Setting up table for calculations and to return to user
         event_spec = pd.Series(event_observed) == event_of_interest
@@ -144,13 +146,12 @@ class AalenJohansenFitter(NonParametricUnivariateFitter):
 
         # Estimator of Cumulative Incidence (Density) Function
         aj[cmprisk_label] = (aj[self.label_cmprisk] / aj["at_risk"] * aj["lagged_overall_survival"]).cumsum()
-        aj.loc[0, cmprisk_label] = 0  # Setting initial CIF to be zero
         aj = aj.set_index("event_at")
 
         # Setting attributes
         self._estimation_method = "cumulative_density_"
         self._estimate_name = "cumulative_density_"
-        self.timeline = km.timeline
+        self.timeline = km.timeline if timeline is None else np.sort(np.asarray(timeline, dtype=float))
 
         self._label = coalesce(label, self._label, "AJ_estimate")
         self.cumulative_density_ = pd.DataFrame(aj[cmprisk_label])
@@ -164,6 +165,14 @@ class AalenJohansenFitter(NonParametricUnivariateFitter):
             )
         else:
             self.variance_, self.confidence_interval_ = None, None
+
+        # Compute incidence and its variance on the complete event grid first,
+        # then sample the right-continuous estimates at the requested times.
+        if timeline is not None:
+            self.cumulative_density_ = self.cumulative_density_.reindex(self.timeline, method="ffill")
+            if self._calc_var:
+                self.variance_ = self.variance_.reindex(self.timeline, method="ffill")
+                self.confidence_interval_ = self.confidence_interval_.reindex(self.timeline, method="ffill")
 
         self.confidence_interval_cumulative_density_ = self.confidence_interval_
         return self

--- a/lifelines/tests/test_estimation.py
+++ b/lifelines/tests/test_estimation.py
@@ -5641,6 +5641,52 @@ class TestAalenJohansenFitter:
     def kmfitter(self):
         return KaplanMeierFitter()
 
+    @pytest.mark.parametrize("timeline", [[0, 2, 4, 6], [0, 3, 6], [1.5, 4.5, 6.5], [6, 2, 0, 4], [0, 1, 2, 3, 4, 5, 6]])
+    @pytest.mark.parametrize("cause", [1, 2])
+    @pytest.mark.parametrize("calculate_variance", [False, True])
+    def test_reporting_timeline_preserves_incidence(self, timeline, cause, calculate_variance):
+        durations = [1, 2, 3, 4, 5, 6]
+        events = [0, 1, 1, 2, 2, 0]
+        full = AalenJohansenFitter(calculate_variance=calculate_variance).fit(durations, events, cause)
+        sampled = AalenJohansenFitter(calculate_variance=calculate_variance).fit(durations, events, cause, timeline=timeline)
+        grid = np.sort(np.asarray(timeline, dtype=float))
+        # One censor at t=1 leaves five at risk. Each event adds exactly 1/5.
+        expected = sum((grid >= t) * 0.2 for t, event in zip(durations, events) if event == cause)
+        npt.assert_array_equal(sampled.timeline, grid)
+        npt.assert_array_equal(sampled.cumulative_density_.index, grid)
+        npt.assert_allclose(sampled.cumulative_density_.iloc[:, 0], expected)
+        if calculate_variance:
+            assert_series_equal(sampled.variance_, full.variance_.reindex(grid, method="ffill"))
+            assert_frame_equal(sampled.confidence_interval_, full.confidence_interval_.reindex(grid, method="ffill"))
+
+    @pytest.mark.parametrize("cause", [1, 2])
+    def test_reporting_timeline_with_jitter_and_weights(self, cause):
+        durations = [1, 2, 2, 4, 5, 6]
+        events = [0, 1, 2, 1, 2, 0]
+        weights = [2, 1, 3, 2, 4, 1]
+        with pytest.warns(Warning, match="Tied event times"):
+            full = AalenJohansenFitter(seed=12).fit(durations, events, cause, weights=weights)
+        with pytest.warns(Warning, match="Tied event times"):
+            sampled = AalenJohansenFitter(seed=12).fit(durations, events, cause, weights=weights, timeline=[0, 3, 6])
+        npt.assert_allclose(sampled.durations, full.durations)
+        assert_frame_equal(sampled.cumulative_density_, full.cumulative_density_.reindex([0.0, 3.0, 6.0], method="ffill"))
+        assert_series_equal(sampled.variance_, full.variance_.reindex([0.0, 3.0, 6.0], method="ffill"))
+        assert_frame_equal(sampled.confidence_interval_, full.confidence_interval_.reindex([0.0, 3.0, 6.0], method="ffill"))
+
+    @pytest.mark.parametrize("cause", [1, 2])
+    @pytest.mark.parametrize("weights", [None, [3, 2, 1, 2]])
+    def test_incidence_includes_events_at_time_zero(self, cause, weights):
+        durations = [0, 1, 2, 3]
+        events = [1, 2, 1, 0]
+        grid = np.array([0.0, 1.0, 2.0, 3.0])
+        zero = AalenJohansenFitter().fit(durations, events, cause, weights=weights)
+        shifted = AalenJohansenFitter().fit(np.asarray(durations) + 1, events, cause, weights=weights)
+        frequencies = np.ones(4) if weights is None else np.asarray(weights)
+        expected = np.cumsum(frequencies * (np.asarray(events) == cause)) / frequencies.sum()
+        npt.assert_allclose(zero.predict(grid), expected)
+        npt.assert_allclose(zero.predict(grid), shifted.predict(grid + 1))
+        npt.assert_allclose(zero.variance_, shifted.variance_.iloc[1:])
+
     def test_jitter(self, fitter):
         d = pd.Series([1, 1, 1])
         e = fitter._jitter(durations=d, event=pd.Series([1, 1, 1]), jitter_level=0.01)


### PR DESCRIPTION
`AalenJohansenFitter.fit(..., timeline=...)` currently supplies the reporting grid to the intermediate Kaplan–Meier fit, then aligns those sampled survival values to the full event table. Missing event-time values become NaNs, and their incidence increments are skipped. The raw curve contains NaNs and `predict()` can return finite, severely understated estimates. Separately, the first event-table row is always overwritten with CIF=0; this drops an event at the initial time.

Calculate survival, incidence and variance on the complete event grid, then forward-sample the estimates and confidence intervals onto the requested sorted timeline. Initialise lagged survival to 1 and retain any first-time event contribution. The event table stays complete and existing jitter behaviour is preserved.

A six-observation fixture `[1,2,3,4,5,6]`, events `[0,1,1,2,2,0]`, has an exact cause-2 incidence of 0.4 at time 6. Changing only the reporting grid to `[0,2,4,6]` currently loses increments. A separate first-time fixture checks the incidence against weighted event fractions and an equivalent time-shifted dataset.

On the public 35-patient BMT example from Scrucca et al. (https://luca-scr.github.io/R/bmt.csv), using the same fixed jitter seed (12), the original six-month reporting grid returns 0 for both risks at 60 months. The corrected fit returns 0.27533760 for transplant-related mortality and 0.48234443 for relapse, matching a separate scalar risk-set calculation on the identical jittered event times. The original default relapse estimate is 0.45377300; the 1/35 difference is the separately dropped initial event. These are controlled software checks on released example data, not a claim that the original paper used this implementation or reached an incorrect conclusion.

Validation on upstream base `7a8fc34a013ecd79fa405017b89e1697c1cc6e17`: 26 added cases, **20 fail and 6 pass before**; the complete Aalen–Johansen test class with the additions gives **35 passed after**. Coverage includes two causes, full/coarse/off-event/unsorted reporting grids, variance on/off, fixed-seed jitter, case weights, confidence intervals and first-time events. Released lifelines 0.30.3 also reproduces both errors. The full package suite was not run.

Prepared with AI assistance. Maintainer acceptance and independent scientific review are not claimed. The [Cheerful Duck report](https://cheerfulduck.com/research/audits/lifelines-aalen-johansen-event-grid) provides the reproduction scripts, patch, dataset checksum and before/after execution evidence in a downloadable archive.
